### PR TITLE
feat: bench list apps command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+# <!-- ## [Unreleased] -->
+## [Unreleased]
+
+### Added
+
+- Global `--bench`/`-b` option for targeting a bench alias across commands (no project name needed when alias is unique)
+- `list-apps` command: new subcommand to display apps for a bench alias
+
+### Changed
+
+- Default `list-apps` output is now a table of App | Version | Branch | Sites
+- Added `--quiet`/`-q` flag to `list-apps` for name-only output suitable for scripting
+- Persist interactive aliases immediately to cache in `inspect --interactive`
+- Renamed `AvailableApp` table to `available_apps`; renamed join model to `installed_apps` for clarity
+- Introduced `InstalledAppDetail` (`installed_apps` table) to store per-site app version and branch
 
 ## [0.3.2] - 2025-08-03
 

--- a/src/caffeinated_whale_cli/commands/apps.py
+++ b/src/caffeinated_whale_cli/commands/apps.py
@@ -1,0 +1,95 @@
+import typer
+from ..utils.db_utils import get_cached_project_data, get_bench_by_alias
+
+app = typer.Typer(name="apps", help="Commands for working with bench aliases and apps")
+
+
+from typing import Optional
+from rich.console import Console
+from rich.table import Table
+
+@app.command("list-apps")
+def list_apps(
+    ctx: typer.Context,
+    project_name: Optional[str] = typer.Argument(
+        None,
+        help="The Docker Compose project to query (optional if alias is unique).",
+    ),
+    quiet: bool = typer.Option(
+        False,
+        "--quiet",
+        "-q",
+        help="Just output app names, one per line.",
+        rich_help_panel="Output Formatting",
+    ),
+) -> None:
+    """
+    List available apps for the specified bench alias (project optional when alias is unique).
+    By default outputs a table of app, version, branch, and sites.
+    """
+    console = Console()
+    bench_alias = ctx.obj.get("bench")
+    if not bench_alias:
+        typer.echo("Error: --bench <alias> is required to list apps.", err=True)
+        raise typer.Exit(code=1)
+
+    if project_name:
+        cache = get_cached_project_data(project_name)
+        if not cache:
+            typer.echo(
+                f"No cached data for project '{project_name}'. Run 'cwcli inspect {project_name}' first.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        benches = [b for b in cache["bench_instances"] if b.get("alias") == bench_alias]
+        if not benches:
+            typer.echo(
+                f"No bench with alias '{bench_alias}' found in project '{project_name}'.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        bench = benches[0]
+    else:
+        # Global lookup by alias
+        data = get_bench_by_alias(bench_alias)
+        if not data:
+            typer.echo(f"No bench with alias '{bench_alias}' found in cache.", err=True)
+            raise typer.Exit(code=1)
+
+        project_name = data["project_name"]
+        bench = data["bench"]
+
+    # Collect detailed info from cached site/app entries
+    apps_info: dict = {}
+    for site_data in bench.get("sites", []):
+        site_name = site_data.get("name")
+        for app_entry in site_data.get("installed_apps", []):
+            parts = app_entry.split(maxsplit=2)
+            if len(parts) == 3:
+                name, version, branch = parts
+            else:
+                name = parts[0]
+                version = parts[1] if len(parts) > 1 else ""
+                branch = parts[2] if len(parts) > 2 else ""
+            info = apps_info.setdefault(name, {"version": version, "branch": branch, "sites": set()})
+            info["sites"].add(site_name)
+
+    if quiet:
+        for name in sorted(apps_info):
+            typer.echo(name)
+        return
+
+    # Render table
+    table = Table(title=f"Apps for bench '{bench_alias}'")
+    table.add_column("App", style="cyan", no_wrap=True)
+    table.add_column("Version", style="green")
+    table.add_column("Branch", style="magenta")
+    table.add_column("Sites", style="yellow")
+
+    for name in sorted(apps_info):
+        info = apps_info[name]
+        sites_str = ", ".join(sorted(info["sites"]))
+        table.add_row(name, info["version"], info["branch"], sites_str)
+    console.print(table)

--- a/src/caffeinated_whale_cli/main.py
+++ b/src/caffeinated_whale_cli/main.py
@@ -1,4 +1,5 @@
 import typer
+from typing import Optional
 import importlib.metadata
 
 from .commands import list as list_cmd
@@ -24,11 +25,25 @@ def version_callback(value: bool):
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(
-        None, "--version", callback=version_callback, is_eager=True, help="Show the application's version and exit."
-    )
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show the application's version and exit.",
+    ),
+    bench: Optional[str] = typer.Option(
+        None,
+        "--bench",
+        "-b",
+        help="Only operate on the specified bench alias",
+        rich_help_panel="Global Options",
+    ),
 ):
-    pass
+    # Initialize context object and store global bench filter
+    ctx.ensure_object(dict)
+    ctx.obj["bench"] = bench
 
 app.command("inspect")(inspect_cmd_func)
 
@@ -36,6 +51,9 @@ app.add_typer(list_cmd.app, name="ls")
 app.add_typer(start_cmd.app, name="start")
 app.add_typer(stop_cmd.app, name="stop")
 app.add_typer(config_cmd.app, name="config")
+# Register apps subcommands for bench alias operations
+from .commands.apps import list_apps as _list_apps_cmd
+app.command("list-apps")(_list_apps_cmd)
 
 def cli():
     """


### PR DESCRIPTION
## [Unreleased]

### Added

- Global `--bench`/`-b` option for targeting a bench alias across commands (no project name needed when alias is unique)
- `list-apps` command: new subcommand to display apps for a bench alias

### Changed

- Default `list-apps` output is now a table of App | Version | Branch | Sites
- Added `--quiet`/`-q` flag to `list-apps` for name-only output suitable for scripting
- Persist interactive aliases immediately to cache in `inspect --interactive`
- Renamed `AvailableApp` table to `available_apps`; renamed join model to `installed_apps` for clarity
- Introduced `InstalledAppDetail` (`installed_apps` table) to store per-site app version and branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global `--bench` (`-b`) option to target a bench alias across commands.
  * Introduced a `list-apps` command to display apps for a specified bench alias.
  * `list-apps` now displays output in a table format with app name, version, branch, and sites.
  * Added a `--quiet` (`-q`) flag to `list-apps` for name-only output suitable for scripting.

* **Improvements**
  * Interactive aliases are now immediately persisted to cache when using interactive inspection.
  * Enhanced database structure for clearer app and site information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->