### PR TITLE
fix(init): use --no-mariadb-socket for Frappe version-14

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Project agent memory
+
+This file is the project's committed home for project-intrinsic agent knowledge: build, test, release, architecture, and sharp-edge notes that should travel with the code.
+
+- Add durable project-specific notes here as they are discovered through real work.
+
+## `init` command: Frappe/bench version gating
+
+`bench new-site` MariaDB flag depends on the Frappe branch (see `_select_mariadb_flag` in `src/caffeinated_whale_cli/commands/init.py`):
+
+- `version-13` and `version-14` -> `--no-mariadb-socket`
+- `version-15`+ -> `--mariadb-user-host-login-scope=%` (this flag only exists in bench/Frappe 15+; passing it to bench 14 makes `bench new-site` fail)
+
+Other per-branch settings nearby in `init.py`: Python version (`branch_python`: 15->3.12, 14->3.10, 13->3.9), Node major (`branch_node`: 14->16, 13->14), and `setuptools<82` is pinned only for `version-13`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ cwcli init [OPTIONS] [PROJECT_NAME]
 Missing Python or Node.js versions are automatically installed inside the container.
 `version-13` also pins `setuptools<82` in the bench virtualenv after init.
 
+Site creation picks the MariaDB flag per branch: `version-13` and `version-14` use `--no-mariadb-socket`,
+while `version-15` and newer use `--mariadb-user-host-login-scope=%` (a flag that only exists in bench/Frappe 15+).
+
 **Examples:**
 
 ```bash

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -323,6 +323,17 @@ def _build_cd_command(path: str, command: str) -> str:
     return f"cd {shlex.quote(path)} && {command}"
 
 
+def _select_mariadb_flag(frappe_branch: str) -> str:
+    """Select the ``bench new-site`` MariaDB flag for the given Frappe branch.
+
+    ``--mariadb-user-host-login-scope`` only exists in bench/Frappe 15+, so
+    versions 13 and 14 must fall back to ``--no-mariadb-socket``.
+    """
+    if frappe_branch in ("version-13", "version-14"):
+        return "--no-mariadb-socket"
+    return "--mariadb-user-host-login-scope=%"
+
+
 def _run_host_command(
     cmd: list[str],
     cwd: str | None = None,
@@ -717,12 +728,20 @@ def init(
                         f"[dim]Using Node.js {node_version} for {frappe_branch}[/dim]"
                     )
                 if verbose:
-                    stderr_console.print(f"[dim]Installing yarn globally for Node.js {node_version}...[/dim]")
+                    stderr_console.print(
+                        f"[dim]Installing yarn globally for Node.js {node_version}...[/dim]"
+                    )
                 yarn_exit_code, _ = frappe_container.exec_run(
-                    ["bash", "-lc", f"source ~/.nvm/nvm.sh && nvm use {node_version} && npm install -g yarn"]
+                    [
+                        "bash",
+                        "-lc",
+                        f"source ~/.nvm/nvm.sh && nvm use {node_version} && npm install -g yarn",
+                    ]
                 )
                 if yarn_exit_code != 0:
-                    stderr_console.print("[yellow]Warning: Failed to install yarn globally.[/yellow]")
+                    stderr_console.print(
+                        "[yellow]Warning: Failed to install yarn globally.[/yellow]"
+                    )
                 elif verbose:
                     stderr_console.print("[dim]yarn installed successfully.[/dim]")
 
@@ -769,9 +788,7 @@ def init(
 
     # Pin setuptools<82 for version-13 to retain pkg_resources
     if frappe_branch == "version-13":
-        pin_cmd = _build_cd_command(
-            bench_full_path, "./env/bin/pip install 'setuptools<82'"
-        )
+        pin_cmd = _build_cd_command(bench_full_path, "./env/bin/pip install 'setuptools<82'")
         if verbose:
             stderr_console.print("[dim]Pinning setuptools<82 for version-13...[/dim]")
         pin_exit_code, pin_output = frappe_container.exec_run(["bash", "-lc", pin_cmd])
@@ -811,9 +828,7 @@ def init(
 
     # Create site if it doesn't exist
     if not site_exists:
-        mariadb_flag = (
-            "--no-mariadb-socket" if frappe_branch == "version-13" else "--mariadb-user-host-login-scope=%"
-        )
+        mariadb_flag = _select_mariadb_flag(frappe_branch)
         new_site_cmd = _build_cd_command(
             bench_full_path,
             " ".join(

--- a/tests/test_init_mariadb_flag.py
+++ b/tests/test_init_mariadb_flag.py
@@ -1,0 +1,26 @@
+"""Tests for ``bench new-site`` MariaDB flag selection per Frappe branch.
+
+The ``--mariadb-user-host-login-scope`` flag only exists in bench/Frappe 15+,
+so versions 13 and 14 must fall back to ``--no-mariadb-socket``. Passing the
+newer flag to bench 14 makes ``bench new-site`` fail.
+"""
+
+import pytest
+
+from caffeinated_whale_cli.commands.init import _select_mariadb_flag
+
+
+class TestSelectMariadbFlag:
+    """Test cases for ``_select_mariadb_flag``."""
+
+    def test_version_13_uses_no_mariadb_socket(self):
+        assert _select_mariadb_flag("version-13") == "--no-mariadb-socket"
+
+    def test_version_14_uses_no_mariadb_socket(self):
+        # Regression: bench 14 does not understand
+        # --mariadb-user-host-login-scope, so it must use --no-mariadb-socket.
+        assert _select_mariadb_flag("version-14") == "--no-mariadb-socket"
+
+    @pytest.mark.parametrize("branch", ["version-15", "develop"])
+    def test_version_15_plus_uses_host_login_scope(self, branch):
+        assert _select_mariadb_flag(branch) == "--mariadb-user-host-login-scope=%"


### PR DESCRIPTION
## Intent

Fix a version-gating bug in cwcli's init command: 'cwcli init --frappe-branch version-14' failed because it passed --mariadb-user-host-login-scope=% to 'bench new-site', but that flag only exists in bench/Frappe 15+, so bench 14 cannot parse it. The fix makes both version-13 and version-14 use --no-mariadb-socket, while version-15+ keeps --mariadb-user-host-login-scope=%. The flag selection was extracted from an inline conditional into a new testable helper _select_mariadb_flag(frappe_branch) in src/caffeinated_whale_cli/commands/init.py, placed near the other per-branch version gating (branch_python, branch_node, the version-13 setuptools pin). A regression test (tests/test_init_mariadb_flag.py) was added that locks in 13->socket, 14->socket, 15+/develop->host-login-scope; it was confirmed to fail against the original logic before the fix. Black reformatting (per the documented 'black src/ tests/' workflow) also tidied a few pre-existing over-length lines in init.py that were unrelated to the logic change. AGENTS.md/CLAUDE.md were created (via the project's fm-ensure script) to document the per-branch version-gating rules. Commit message uses Conventional Commits 'fix:' and does not add an agent co-author per the user's global instructions.

## What Changed

- Extracted the `bench new-site` MariaDB flag selection from an inline conditional into a new testable helper `_select_mariadb_flag(frappe_branch)` in `init.py`, placed alongside the other per-branch version gating; `version-13` and `version-14` now both resolve to `--no-mariadb-socket`, while `version-15`+/`develop` keep `--mariadb-user-host-login-scope=%` (which only exists in bench/Frappe 15+).
- Added `tests/test_init_mariadb_flag.py` locking in 13->socket, 14->socket, and 15+/develop->host-login-scope (confirmed to fail against the pre-fix logic); the full suite passes at 73.
- Documented the per-branch MariaDB flag gating rules in `README.md`, `CLAUDE.md`, and a new `AGENTS.md`.

## Risk Assessment

✅ Low: A well-bounded, behavior-preserving refactor that extracts a testable helper and adds version-14 to the existing socket-flag branch, consistent with surrounding per-branch gating and covered by a regression test.

## Testing

Ran the new regression test and the full 73-test suite (all green), confirmed the original inline logic mis-selected the flag for version-14 (the reported bug), and produced a CLI transcript showing the actual `bench new-site` command cwcli init now builds per branch: version-13 and version-14 both emit `--no-mariadb-socket` while version-15/develop emit `--mariadb-user-host-login-scope=%`, directly demonstrating the intended end-user behavior. No visual artifact applies since this is a CLI/command-construction change; the command transcript is the closest end-user-facing surface. Transient `.venv`/`__pycache__` created during testing were removed, leaving the worktree clean.

<details>
<summary>Evidence: Per-branch bench new-site command transcript (post-fix)</summary>

<code># cwcli init --frappe-branch version-14&#10;flag -&gt; --no-mariadb-socket&#10;cd /home/frappe/frappe-bench &amp;&amp; bench new-site --db-root-password secret --admin-password admin --no-mariadb-socket dev.localhost --verbose&#10;&#10;# cwcli init --frappe-branch version-15&#10;flag -&gt; --mariadb-user-host-login-scope=%&#10;cd ... &amp;&amp; bench new-site ... --mariadb-user-host-login-scope=% dev.localhost --verbose</code>

```text
Effective `bench new-site` command per --frappe-branch (post-fix):

# cwcli init --frappe-branch version-13
  flag -> --no-mariadb-socket
  cd /home/frappe/frappe-bench && bench new-site --db-root-password secret --admin-password admin --no-mariadb-socket dev.localhost --verbose

# cwcli init --frappe-branch version-14
  flag -> --no-mariadb-socket
  cd /home/frappe/frappe-bench && bench new-site --db-root-password secret --admin-password admin --no-mariadb-socket dev.localhost --verbose

# cwcli init --frappe-branch version-15
  flag -> --mariadb-user-host-login-scope=%
  cd /home/frappe/frappe-bench && bench new-site --db-root-password secret --admin-password admin --mariadb-user-host-login-scope=% dev.localhost --verbose

# cwcli init --frappe-branch develop
  flag -> --mariadb-user-host-login-scope=%
  cd /home/frappe/frappe-bench && bench new-site --db-root-password secret --admin-password admin --mariadb-user-host-login-scope=% dev.localhost --verbose
```
</details>
<details>
<summary>Evidence: Pre-fix vs post-fix flag selection (bug reproduction)</summary>

```text
OLD logic: version-14 -> --mariadb-user-host-login-scope=% (broken on bench 14)
NEW logic: version-14 -> --no-mariadb-socket (fixed)
```
</details>
<details>
<summary>Evidence: Evidence generator script</summary>

```text
"""Build the exact `bench new-site` command cwcli init would run, per Frappe branch,
using the real shipped helpers from the source module."""
import shlex
from caffeinated_whale_cli.commands.init import _select_mariadb_flag, _build_cd_command

bench_full_path = "/home/frappe/frappe-bench"
db_root_password = "secret"
admin_password = "admin"
site_name = "dev.localhost"

print("Effective `bench new-site` command per --frappe-branch (post-fix):\n")
for branch in ["version-13", "version-14", "version-15", "develop"]:
    flag = _select_mariadb_flag(branch)
    cmd = _build_cd_command(
        bench_full_path,
        " ".join([
            "bench", "new-site",
            "--db-root-password", shlex.quote(db_root_password),
            "--admin-password", shlex.quote(admin_password),
            flag,
            shlex.quote(site_name),
            "--verbose",
        ]),
    )
    print(f"# cwcli init --frappe-branch {branch}")
    print(f"  flag -> {flag}")
    print(f"  {cmd}\n")
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run --extra dev python -m pytest tests/test_init_mariadb_flag.py -v` — all 4 cases pass (13-&gt;socket, 14-&gt;socket, 15/develop-&gt;host-login-scope)</code>
- <code>`uv run --extra dev python -m pytest tests/ -q` — full suite, 73 passed</code>
- <code>Reproduced the pre-fix bug by simulating the original inline conditional: version-14 incorrectly resolved to `--mariadb-user-host-login-scope=%`, confirming the regression the test locks down</code>
- <code>End-to-end: ran `gen_commands.py` using the shipped `_select_mariadb_flag` + `_build_cd_command` to render the exact `bench new-site` command cwcli init issues for version-13/14/15/develop</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Site setup now automatically selects the MariaDB option that matches the chosen Frappe version, reducing setup errors on older releases.
  * Improved the setup output around Yarn installation to make the process clearer when warnings occur.

* **Documentation**
  * Updated setup docs to reflect version-specific MariaDB configuration behavior.

* **Tests**
  * Added coverage for MariaDB flag selection across supported version branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->