### PR TITLE
ci: promote mypy to a blocking zero-error gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
 
   typecheck:
-    name: Mypy (informational)
+    name: Mypy
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/astral-sh/uv:python3.12-bookworm
@@ -45,12 +45,14 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      # NOTE: mypy currently reports ~50 errors across ~14 files. This step is
-      # informational (continue-on-error) so it surfaces type problems without
-      # failing the job's status check on PRs. Burn the existing errors down to
-      # zero, then drop continue-on-error and promote this to a required check.
-      # (continue-on-error MUST be on the step, not the job: a job-level setting
+      # NOTE: mypy is now a zero-error gate. The historical ~50 errors have been
+      # burned down to zero, so this step fails the job's status check whenever a
+      # new type error is introduced. Keep it that way: do not re-add
+      # continue-on-error. (If you ever need to make a step non-blocking again,
+      # continue-on-error MUST go on the step, not the job: a job-level setting
       # still reports the job's conclusion as "failure" on the PR check.)
+      # To make this *required to merge*, a repo admin must also tick "Mypy" as a
+      # required status check in the develop branch-protection settings (same as
+      # the Pytest gate).
       - name: Type-check with Mypy
-        continue-on-error: true
         run: uv run mypy src/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,8 @@ Other per-branch settings nearby in `init.py`: Python version (`branch_python`: 
 - `.github/workflows/lint.yml` runs `black --check` + `ruff check`.
 - `.github/workflows/test.yml` runs `pytest` (with `pytest-cov`) and `mypy src/`. It triggers on pushes to all branches and PRs to all branches (the default branch is `develop`, not `master`).
 - The `Pytest` job is the intended required gate. develop has no branch protection, so the admin must tick `Pytest` as a required status check in the develop branch-protection settings for it to actually block merges.
-- The `Mypy (informational)` job is `continue-on-error: true` because mypy currently emits ~50 errors across ~14 files. Burn those errors down to zero, then drop `continue-on-error` and promote it to a required check.
+- The `Mypy` job is now a zero-error blocking gate. The historical ~50 errors were burned down to zero and `continue-on-error` was dropped from the step, so any new type error fails the job's status check. To make it *required to merge*, the repo admin still has to tick `Mypy` as a required status check in the develop branch-protection settings (same outstanding admin step as `Pytest`).
+- Keep `uv run mypy src/` at zero errors. Two `types-*` stub packages are dev deps for this (`types-requests`, `types-toml`); add the matching `types-*` stub rather than ignoring an untyped third-party import. There are currently no `# type: ignore` comments in `src/` - prefer accurate annotations (e.g. assign a dynamic `json.loads(...)`/`exec_run(...)` result to a typed local, use `str | None` for implicit-Optional defaults) over silencing. Do not loosen `[tool.mypy]` in `pyproject.toml` to make errors disappear.
 - `build.yml` / `release.yml` trigger on `master` (the historical default); they build and publish to PyPI and do not run tests.
 
 ## `rm` command: what removal actually deletes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -245,7 +245,7 @@ uv run black src/ tests/
 # Lint code
 uv run ruff check src/ --fix
 
-# Type check (runs informationally in CI, not yet a required gate)
+# Type check (zero-error gate in CI; keep this clean)
 uv run mypy src/
 ```
 

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -9,7 +9,7 @@ We use four GitHub Actions workflows:
 | Workflow | Triggers | Purpose |
 |----------|----------|---------|
 | **Lint** | All branches, all PRs | Code quality checks (Black, Ruff) |
-| **Test** | All branches, all PRs | Run pytest (required gate) + mypy (informational) |
+| **Test** | All branches, all PRs | Run pytest (required gate) + mypy (zero-error gate) |
 | **Build** | Push to `master` | Build package, verify version consistency |
 | **Release** | Tags `v*.*.*` | Publish to PyPI, create GitHub release |
 
@@ -42,7 +42,7 @@ See [Code Quality Guide](./code-quality.md) for details.
 Runs on every push and PR. Has two jobs:
 
 - **Pytest** - runs the test suite with coverage (`uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing`). This is the intended required gate. Because `develop` has no branch protection, an admin must tick `Pytest` as a required status check in the `develop` branch-protection settings for it to actually block merges.
-- **Mypy (informational)** - runs `uv run mypy src/` with `continue-on-error: true`. mypy currently emits ~50 errors across ~14 files, so this job surfaces type problems without blocking PRs. Burn those errors down to zero, then drop `continue-on-error` and promote it to a required check.
+- **Mypy** - runs `uv run mypy src/` as a zero-error gate. The historical ~50 errors across ~14 files were burned down to zero and `continue-on-error` was dropped from the step, so any new type error fails the job's status check. To make it *required to merge*, an admin must also tick `Mypy` as a required status check in the `develop` branch-protection settings (same outstanding step as `Pytest`).
 
 **Run locally:**
 ```bash

--- a/docs/contributing/code-quality.md
+++ b/docs/contributing/code-quality.md
@@ -9,7 +9,7 @@ We use automated tools to ensure consistent code quality:
 - **Black** - Code formatting
 - **Ruff** - Fast Python linter
 - **pytest** - Testing framework
-- **mypy** - Type checking (runs informationally in CI, not yet a required gate)
+- **mypy** - Type checking (zero-error gate in CI)
 
 ## Quick Reference
 
@@ -377,13 +377,13 @@ ignore = [
 ]
 ```
 
-## Type Checking with mypy (Optional)
+## Type Checking with mypy
 
 ### What is mypy?
 
 mypy is a static type checker for Python that verifies type hints.
 
-**Status:** Runs informationally in CI via the `Mypy` job in `.github/workflows/test.yml` (`continue-on-error: true`), so it surfaces type problems without blocking PRs. It is not yet a required gate - mypy currently emits ~50 errors across ~14 files that need burning down to zero first.
+**Status:** Runs as a zero-error gate in CI via the `Mypy` job in `.github/workflows/test.yml`. The historical ~50 errors across ~14 files were burned down to zero and `continue-on-error` was dropped from the step, so any new type error fails the job. Keep `uv run mypy src/` at zero errors: prefer accurate annotations over `# type: ignore` (there are none in `src/`), add the matching `types-*` stub package for an untyped third-party import rather than ignoring it, and do not loosen `[tool.mypy]` to make errors disappear. To make the check *required to merge*, a repo admin must also tick `Mypy` as a required status check in the `develop` branch-protection settings (same outstanding step as `Pytest`).
 
 ### Basic Usage
 
@@ -553,7 +553,7 @@ jobs:
 - ✅ Black formatting
 - ✅ Ruff linting
 
-The test suite and type checking run in a separate `.github/workflows/test.yml` workflow (`Pytest` as the intended required gate, plus an informational `Mypy` job). See the [CI/CD Workflows guide](./ci-cd.md) for details.
+The test suite and type checking run in a separate `.github/workflows/test.yml` workflow (`Pytest` as the intended required gate, plus a zero-error `Mypy` gate). See the [CI/CD Workflows guide](./ci-cd.md) for details.
 
 ## Common Issues & Solutions
 
@@ -775,7 +775,7 @@ except:  # Too broad
 |------|-------|----------|
 | **Ruff** | ⚡⚡⚡ Very Fast | Linting (10-100x faster than Flake8) |
 | **Black** | ⚡⚡ Fast | Formatting |
-| **mypy** | ⚡ Moderate | Type checking (optional) |
+| **mypy** | ⚡ Moderate | Type checking (zero-error gate) |
 | **pytest** | ⚡ Varies | Testing (depends on test count) |
 
 ### Optimization Tips
@@ -818,7 +818,7 @@ except:  # Too broad
 - [ ] Black formatting check
 - [ ] Ruff linting check
 - [ ] pytest test suite
-- [ ] mypy type checking (informational, not yet required)
+- [ ] mypy type checking (zero-error gate: `uv run mypy src/`)
 
 ## Resources
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -144,7 +144,7 @@ Closes #42
 - [ ] All tests pass: `uv run pytest --cov`
 - [ ] Code formatted: `uv run black src/ tests/`
 - [ ] Linting passes: `uv run ruff check src/ --fix`
-- [ ] No type errors: `uv run mypy src/` (optional)
+- [ ] No type errors: `uv run mypy src/`
 
 **Documentation:**
 - [ ] CHANGELOG.md updated under `[Unreleased]`
@@ -212,7 +212,7 @@ feat: add tab completion support
 
 1. **CI checks run automatically:**
    - Lint workflow (Black, Ruff)
-   - Test workflow (pytest, plus an informational mypy job)
+   - Test workflow (pytest, plus a zero-error mypy gate)
 
 2. **Address CI failures:**
    ```bash

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -296,7 +296,7 @@ Tests run in CI on every push and PR via `.github/workflows/test.yml`:
   run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
 ```
 
-The `Pytest` job is the intended required gate; a second `Mypy` job runs `uv run mypy src/` informationally (`continue-on-error: true`). See the [CI/CD Workflows guide](../contributing/ci-cd.md) for details.
+The `Pytest` job is the intended required gate; a second `Mypy` job runs `uv run mypy src/` as a zero-error gate (it fails on any type error). See the [CI/CD Workflows guide](../contributing/ci-cd.md) for details.
 
 ## Debugging Tests
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dev = [
     "mypy>=1.13.0",
     "pytest>=8.0.0",
     "pytest-cov>=6.0.0",
+    "types-requests>=2.33.0.20260518",
+    "types-toml>=0.10.8.20260518",
 ]
 
 [tool.black]

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -195,7 +195,7 @@ def _exec_in_container(
 def _directory_exists(container, path: str) -> bool:
     """Return True if a directory exists inside the container."""
     exit_code, _ = container.exec_run(["bash", "-lc", f"test -d {shlex.quote(path)}"])
-    return exit_code == 0
+    return bool(exit_code == 0)
 
 
 def _ensure_directory(container, path: str) -> None:
@@ -217,7 +217,7 @@ def _get_pyenv_python_version(container, prefix: str, verbose: bool = False) -> 
             stderr_console.print("[dim]Could not list pyenv versions[/dim]")
         return None
 
-    versions = output.decode("utf-8", errors="replace").split()
+    versions: list[str] = output.decode("utf-8", errors="replace").split()
     for version in versions:
         if version.startswith(prefix + "."):
             if verbose:
@@ -245,7 +245,7 @@ def _install_pyenv_python(container, prefix: str, verbose: bool = False) -> str 
         return None
 
     pattern = re.compile(rf"^\s*({re.escape(prefix)}\.\d+)\s*$", re.MULTILINE)
-    matches = pattern.findall(output.decode("utf-8", errors="replace"))
+    matches: list[str] = pattern.findall(output.decode("utf-8", errors="replace"))
     if not matches:
         if verbose:
             stderr_console.print(f"[dim]No available pyenv version matching {prefix}.x[/dim]")
@@ -282,7 +282,7 @@ def _get_nvm_node_version(container, major: str, verbose: bool = False) -> str |
             stderr_console.print("[dim]Could not list nvm Node.js versions[/dim]")
         return None
 
-    versions = output.decode("utf-8", errors="replace").split()
+    versions: list[str] = output.decode("utf-8", errors="replace").split()
     for version in versions:
         # Entries look like v16.20.2, v22.22.0
         if version.startswith(f"v{major}."):
@@ -375,7 +375,7 @@ def _get_latest_bench_tag(verbose: bool = False) -> str:
 
         semver_re = re.compile(r"^v\d+\.\d+\.\d+$")
         for result in data.get("results", []):
-            tag = result.get("name", "")
+            tag: str = result.get("name", "")
             if semver_re.match(tag):
                 if verbose:
                     stderr_console.print(f"[dim]Resolved latest bench image tag: {tag}[/dim]")

--- a/src/caffeinated_whale_cli/commands/inspect.py
+++ b/src/caffeinated_whale_cli/commands/inspect.py
@@ -117,7 +117,7 @@ def _get_common_site_config(
 
     if exit_code == 0 and output:
         try:
-            config = json.loads(output)
+            config: dict = json.loads(output)
             if verbose:
                 console_err.print(
                     f"[dim]VERBOSE: Found common_site_config with {len(config)} keys[/dim]"
@@ -151,7 +151,7 @@ def _get_site_config(
 
     if exit_code == 0 and output:
         try:
-            config = json.loads(output)
+            config: dict = json.loads(output)
             if verbose:
                 console_err.print(
                     f"[dim]VERBOSE: Found site_config for {site_name} with {len(config)} keys[/dim]"
@@ -194,13 +194,13 @@ def _gather_bench_data(
         # Fetch site-specific config
         site_config = _get_site_config(frappe_container, bench_dir, site, verbose)
 
-        site_data = {"name": site, "installed_apps": installed_apps}
+        site_data: dict = {"name": site, "installed_apps": installed_apps}
         if site_config is not None:
             site_data["site_config"] = site_config
 
         sites_info.append(site_data)
 
-    bench_data = {"path": bench_dir, "sites": sites_info, "available_apps": available_apps}
+    bench_data: dict = {"path": bench_dir, "sites": sites_info, "available_apps": available_apps}
 
     if common_site_config is not None:
         bench_data["common_site_config"] = common_site_config

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -32,7 +32,7 @@ def parse_backup_filename(filename: str) -> dict | None:
     """
     # Remove extensions
     name_without_ext = filename
-    extensions = []
+    extensions: list[str] = []
     while "." in name_without_ext:
         name_without_ext, ext = name_without_ext.rsplit(".", 1)
         extensions.insert(0, ext)
@@ -92,7 +92,7 @@ def scan_backups_for_all_sites(frappe_container, bench_path: str, verbose: bool 
     Returns:
         List of parsed backup file dictionaries (grouped by backup set)
     """
-    backups = []
+    backups: list[dict] = []
 
     # Get all sites in the bench
     sites_path = f"{bench_path}/sites"
@@ -346,7 +346,7 @@ def display_backup_selection_menu(
         Selected backup set dict or None if cancelled
     """
     # Build choices with badges
-    choices = []
+    choices: list[str | questionary.Separator] = []
     backup_map = {}
 
     # Simple text badges
@@ -823,12 +823,14 @@ def restore_receive_mode(
 
         try:
             # Run sendme to download files
-            cmd = [sendme_cmd, "receive", ticket]
+            receive_cmd = [sendme_cmd, "receive", ticket]
 
             if verbose:
-                stderr_console.print(f"[dim]$ {' '.join(cmd)}[/dim]")
+                stderr_console.print(f"[dim]$ {' '.join(receive_cmd)}[/dim]")
 
-            result = subprocess.run(cmd, cwd=temp_dir, capture_output=not verbose, text=True)
+            result = subprocess.run(
+                receive_cmd, cwd=temp_dir, capture_output=not verbose, text=True
+            )
 
             if result.returncode != 0:
                 stderr_console.print(

--- a/src/caffeinated_whale_cli/commands/start.py
+++ b/src/caffeinated_whale_cli/commands/start.py
@@ -85,7 +85,7 @@ def _check_port_conflicts(project_name: str, verbose: bool = False) -> bool:
         conflicting_projects = set(frappe_projects_on_ports.values())
 
         # Group ports by project for better display
-        project_to_ports = {}
+        project_to_ports: dict[str, list] = {}
         for port, proj in frappe_projects_on_ports.items():
             if proj not in project_to_ports:
                 project_to_ports[proj] = []
@@ -154,7 +154,7 @@ def _check_port_conflicts(project_name: str, verbose: bool = False) -> bool:
             )
 
             # Group ports by process
-            process_to_ports = {}
+            process_to_ports: dict[str | None, list] = {}
             for port in remaining_ports_in_use:
                 process = ports_with_processes.get(port, "unknown")
                 if process not in process_to_ports:

--- a/src/caffeinated_whale_cli/commands/update.py
+++ b/src/caffeinated_whale_cli/commands/update.py
@@ -18,7 +18,7 @@ def _stream_command(
     cmd: str,
     workdir: str,
     verbose: bool = False,
-    status_msg: str = None,
+    status_msg: str | None = None,
 ) -> int:
     """Execute command and optionally stream output in real-time."""
     if verbose:
@@ -60,7 +60,8 @@ def _stream_command(
         # Non-verbose mode: just run the command without streaming
         # demux=False ensures we wait for the command to fully complete
         exit_code, _ = container.exec_run(cmd, workdir=workdir, demux=False)
-        return exit_code
+        return_code: int = exit_code
+        return return_code
 
 
 def _run_command_quiet(
@@ -181,7 +182,7 @@ def _get_sites_with_app(
 def _update_project(
     project_name: str,
     apps: list[str],
-    bench_path: str = None,
+    bench_path: str | None = None,
     verbose: bool = False,
     clear_cache: bool = False,
     clear_website_cache: bool = False,

--- a/src/caffeinated_whale_cli/commands/where.py
+++ b/src/caffeinated_whale_cli/commands/where.py
@@ -121,7 +121,7 @@ def _deduplicate_app_results(results: list[dict]) -> list[dict]:
     keep only the installed entries (which have more info like version/branch).
     """
     # First pass: collect all installed apps per project
-    installed_by_project = {}
+    installed_by_project: dict[tuple, list] = {}
     for result in results:
         if result["installed"]:
             key = (result["project"], result["name"])

--- a/src/caffeinated_whale_cli/utils/completion_utils.py
+++ b/src/caffeinated_whale_cli/utils/completion_utils.py
@@ -65,7 +65,7 @@ def _set_cached(key: str, value: list[str]) -> None:
 
 
 def complete_project_names(
-    ctx: typer.Context = None, args: list[str] = None, incomplete: str = ""
+    ctx: typer.Context | None = None, args: list[str] | None = None, incomplete: str = ""
 ) -> list[str]:
     """
     Complete Frappe project names from Docker containers.
@@ -115,7 +115,7 @@ def complete_project_names(
 
 
 def complete_app_names(
-    ctx: typer.Context = None, args: list[str] = None, incomplete: str = ""
+    ctx: typer.Context | None = None, args: list[str] | None = None, incomplete: str = ""
 ) -> list[str]:
     """
     Complete app names for a given project.
@@ -163,7 +163,7 @@ def complete_app_names(
 
 
 def complete_site_names(
-    ctx: typer.Context = None, args: list[str] = None, incomplete: str = ""
+    ctx: typer.Context | None = None, args: list[str] | None = None, incomplete: str = ""
 ) -> list[str]:
     """
     Complete site names for a given project.

--- a/src/caffeinated_whale_cli/utils/config_utils.py
+++ b/src/caffeinated_whale_cli/utils/config_utils.py
@@ -117,9 +117,10 @@ def remove_custom_path(path: str) -> bool:
 def get_auto_inspect_config() -> dict:
     """Get auto-inspect configuration."""
     config = load_config()
-    return config.get(
+    auto_inspect: dict = config.get(
         "auto_inspect", {"enabled": False, "interval": 3600, "startup_enabled": False}
     )
+    return auto_inspect
 
 
 def set_auto_inspect_enabled(enabled: bool):
@@ -162,7 +163,8 @@ def get_show_tips() -> bool:
         True if tips should be shown, False otherwise (default: True)
     """
     config = load_config()
-    return config.get("ui", {}).get("show_tips", True)
+    show_tips: bool = config.get("ui", {}).get("show_tips", True)
+    return show_tips
 
 
 def set_show_tips(enabled: bool):

--- a/src/caffeinated_whale_cli/utils/db_utils.py
+++ b/src/caffeinated_whale_cli/utils/db_utils.py
@@ -319,7 +319,7 @@ def get_all_cached_projects():
     return list(Project.select())
 
 
-def get_common_site_config(project_name: str, bench_path: str = None) -> dict | None:
+def get_common_site_config(project_name: str, bench_path: str | None = None) -> dict | None:
     """
     Get common_site_config for a project/bench.
 
@@ -339,7 +339,8 @@ def get_common_site_config(project_name: str, bench_path: str = None) -> dict | 
             bench = Bench.get((Bench.project == project) & (Bench.path == bench_path))
             try:
                 config_obj = CommonSiteConfig.get(CommonSiteConfig.bench == bench)
-                return json.loads(config_obj.config_json)
+                config: dict = json.loads(config_obj.config_json)
+                return config
             except CommonSiteConfig.DoesNotExist:
                 return None
         else:
@@ -347,7 +348,8 @@ def get_common_site_config(project_name: str, bench_path: str = None) -> dict | 
             for bench in project.benches:
                 try:
                     config_obj = CommonSiteConfig.get(CommonSiteConfig.bench == bench)
-                    return json.loads(config_obj.config_json)
+                    config = json.loads(config_obj.config_json)
+                    return config
                 except CommonSiteConfig.DoesNotExist:
                     continue
             return None
@@ -356,7 +358,9 @@ def get_common_site_config(project_name: str, bench_path: str = None) -> dict | 
         return None
 
 
-def get_site_config(project_name: str, site_name: str, bench_path: str = None) -> dict | None:
+def get_site_config(
+    project_name: str, site_name: str, bench_path: str | None = None
+) -> dict | None:
     """
     Get site_config for a specific site.
 
@@ -392,7 +396,8 @@ def get_site_config(project_name: str, site_name: str, bench_path: str = None) -
         # Get the site config
         try:
             config_obj = SiteConfig.get(SiteConfig.site == site)
-            return json.loads(config_obj.config_json)
+            config: dict = json.loads(config_obj.config_json)
+            return config
         except SiteConfig.DoesNotExist:
             return None
 
@@ -400,7 +405,7 @@ def get_site_config(project_name: str, site_name: str, bench_path: str = None) -
         return None
 
 
-def get_all_site_configs(project_name: str, bench_path: str = None) -> dict[str, dict]:
+def get_all_site_configs(project_name: str, bench_path: str | None = None) -> dict[str, dict]:
     """
     Get all site configs for a project or specific bench.
 
@@ -437,7 +442,7 @@ def get_all_site_configs(project_name: str, bench_path: str = None) -> dict[str,
         return {}
 
 
-def get_default_site(project_name: str, bench_path: str = None) -> str | None:
+def get_default_site(project_name: str, bench_path: str | None = None) -> str | None:
     """
     Get the default site for a project from the common_site_config.
 

--- a/src/caffeinated_whale_cli/utils/docker_utils.py
+++ b/src/caffeinated_whale_cli/utils/docker_utils.py
@@ -64,7 +64,7 @@ def get_project_containers(
         client = docker.from_env()
         client.ping()
 
-        containers = client.containers.list(
+        containers: list = client.containers.list(
             all=True, filters={"label": f"com.docker.compose.project={project_name}"}
         )
         return containers

--- a/src/caffeinated_whale_cli/utils/port_utils.py
+++ b/src/caffeinated_whale_cli/utils/port_utils.py
@@ -106,7 +106,9 @@ def get_project_ports(project_name: str) -> list[int]:
     return sorted(list(ports))
 
 
-def find_project_using_ports(ports: int | list[int], exclude_project: str = None) -> dict[int, str]:
+def find_project_using_ports(
+    ports: int | list[int], exclude_project: str | None = None
+) -> dict[int, str]:
     """
     Find which Frappe projects are using specific ports.
 
@@ -233,7 +235,7 @@ def get_ports_in_use_with_processes(
     # Normalize input to list
     port_list = [ports] if isinstance(ports, int) else ports
 
-    results = {}
+    results: dict[int, str | None] = {}
     system = platform.system()
 
     for port in port_list:

--- a/src/caffeinated_whale_cli/utils/startup.py
+++ b/src/caffeinated_whale_cli/utils/startup.py
@@ -30,9 +30,9 @@ def get_cwcli_path() -> str:
     # Fallback: use the Python executable path to construct cwcli path
     # This works when running from a virtual environment
     python_dir = Path(sys.executable).parent
-    cwcli_path = python_dir / "cwcli"
-    if cwcli_path.exists():
-        return str(cwcli_path)
+    cwcli_candidate = python_dir / "cwcli"
+    if cwcli_candidate.exists():
+        return str(cwcli_candidate)
 
     # Last resort: just return "cwcli" and hope it's in PATH
     return "cwcli"

--- a/src/caffeinated_whale_cli/utils/tips.py
+++ b/src/caffeinated_whale_cli/utils/tips.py
@@ -98,6 +98,7 @@ class TipRotator:
         """
         if self._shuffled_tips is None:
             self.shuffle_tips()
+        assert self._shuffled_tips is not None  # shuffle_tips() always populates it
 
         tip = self._shuffled_tips[self.current_index]
         self.current_index = (self.current_index + 1) % len(self._shuffled_tips)

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-requests" },
+    { name = "types-toml" },
 ]
 
 [package.metadata]
@@ -71,6 +73,8 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
     { name = "toml", specifier = ">=0.10.2" },
     { name = "typer", specifier = ">=0.16.0" },
+    { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260518" },
+    { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20260518" },
 ]
 provides-extras = ["dev"]
 
@@ -642,6 +646,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
+]
+
+[[package]]
+name = "types-toml"
+version = "0.10.8.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/11/6ece999e91f2ccb848ab4420f3f4816e78ac0541f739e6864affdaaa5737/types_toml-0.10.8.20260518.tar.gz", hash = "sha256:80e10facd24fdeda9d5c672187d72be3ac284843788d67f5aae59e3e016db6fe", size = 9419, upload-time = "2026-05-18T06:02:16.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/91/25/489751806bf5c95e4007f8e17409199c54d31e49ffbea07c5729b1286c8e/types_toml-0.10.8.20260518-py3-none-any.whl", hash = "sha256:0e564ab05f6fde62a315b3b5a9b6624fda569399795d30a37e64705a70459303", size = 9669, upload-time = "2026-05-18T06:02:15.86Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Intent

Drive cwcli's mypy type errors to zero, then promote mypy from an informational CI step to a real blocking quality gate.

Part 1 (typing pass): the project had ~50 mypy errors across 14 files. Fix them PROPERLY with real type correctness, NOT by silencing or loosening config. Decisions/approaches taken: replace implicit-Optional defaults (str = None) with str | None; assign dynamic results from json.loads()/container.exec_run()/dict.get() to typed locals so functions stop returning Any; annotate empty containers that need inference (dict/list); annotate restore's choices list as list[str | questionary.Separator]; rename the sendme 'cmd' list to 'receive_cmd' because it collided in the same function scope with a later 'cmd' restore string (a real name-reuse, not a behavior change). For the two untyped third-party imports (requests, toml) I added the proper types-requests and types-toml stub dev deps rather than ignoring the imports. There are ZERO '# type: ignore' comments and NO loosening of [tool.mypy] config. No runtime behavior changed anywhere - this is purely a typing pass; logic, control flow, and outputs are identical.

Part 2 (CI gate): in .github/workflows/test.yml I dropped continue-on-error from the 'Type-check with Mypy' step so the job now fails on type errors, renamed the job from 'Mypy (informational)' to 'Mypy', and updated the NOTE comment (keeping the accurate caveat that continue-on-error belongs on the step, not the job). Making the check required-to-merge additionally needs a repo admin to tick 'Mypy' as a required status check in develop branch protection - that is an out-of-PR GitHub settings action, documented in AGENTS.md alongside the same note for Pytest.

Validation done before committing: uv run mypy src/ is clean (0 errors), black/ruff pass, pytest is 101 passed. AGENTS.md CI-gates section updated (CLAUDE.md is a symlink to it). Commits follow conventional commits: refactor(typing) for the burn-down, ci(mypy) for the gate flip.

## What Changed

- Drove `mypy src/` from ~50 errors across 14 files to zero with real annotations (no `# type: ignore`, no loosening of `[tool.mypy]`): replaced implicit-Optional defaults with `str | None`, assigned dynamic `json.loads()`/`exec_run()`/`dict.get()` results to typed locals so functions stop returning `Any`, annotated empty containers and `restore`'s `list[str | questionary.Separator]` choices, and renamed `sendme`'s `cmd` list to `receive_cmd` to avoid a same-scope name collision.
- Added `types-requests` and `types-toml` stub dev deps (and `uv.lock` entries) to properly type the third-party `requests` and `toml` imports.
- Flipped `.github/workflows/test.yml` from informational to enforcing: dropped `continue-on-error` from the mypy step and renamed the job from `Mypy (informational)` to `Mypy`, so type errors now fail the check.
- Synced contributor docs (`AGENTS.md`, `CONTRIBUTING.md`, `docs/`) to describe the zero-error blocking gate, including the outstanding admin step of marking `Mypy` a required status check in develop branch protection.

## Risk Assessment

✅ Low: Pure typing/CI-gate pass: every edit is an annotation, an implicit-Optional fix, an equivalent typed-local assignment, a scope-safe variable rename, an always-true defensive assert, or the intended drop of continue-on-error - none of which alter runtime behavior, control flow, or output.

## Testing

Ran the project test suite (`uv run pytest -q`, 101 passed) to confirm the typing-only diff changed no runtime behavior, then exercised the change's actual product surface - the mypy gate - directly: `uv run mypy src/` is clean (0 errors, exit 0, 34 files), with zero `# type: ignore` in src/ and the `[tool.mypy]` config unchanged from base, validating the intent's "fix properly, don't silence or loosen" claim. To prove the CI gate now blocks (continue-on-error was dropped), I transiently reintroduced one of the PR's exact implicit-Optional fixes and showed `uv run mypy src/` then fails with exit 1, reverting to a clean tree afterward. This is a CLI/CI tooling change with no UI surface, so evidence is CLI transcripts rather than visual artifacts. Everything passed; no issues found.

<details>
<summary>Evidence: mypy gate clean + no-silencing + pytest (consolidated transcript)</summary>

<code>$ uv run mypy src/&#10;Success: no issues found in 34 source files&#10;exit code: 0&#10;&#10;grep -rn &#39;type:\s*ignore&#39; src/ -&gt; (none)&#10;&#10;$ uv run pytest -q&#10;= 101 passed in 3.36s =</code>

```text
# cwcli mypy zero-error gate - validation evidence
# target commit: 02192bf8e2a66936a1346e92ed52114b77ad95ae

## Part 1: gate command is clean at the target commit (product surface)
$ uv run mypy src/
Success: no issues found in 34 source files
exit code: 0

## No silencing: zero '# type: ignore' in src/
$ grep -rn 'type:\s*ignore' src/  ->  (no matches)
(none)

## Test suite: no runtime behavior change
$ uv run pytest -q
tests/test_rm_truth.py ..................                                [ 76%]
tests/test_tips.py ........................                              [100%]

============================= 101 passed in 3.36s ==============================
```
</details>
<details>
<summary>Evidence: gate blocks on a type error (exit 1 fails the CI step)</summary>

<code>$ uv run mypy src/ (with an implicit-Optional regression injected)&#10;src/caffeinated_whale_cli/commands/update.py:21: error: Incompatible default for argument &#34;status_msg&#34; (default has type &#34;None&#34;, argument has type &#34;str&#34;) [assignment]&#10;Found 1 error in 1 file (checked 34 source files)&#10;exit code: 1 &lt;-- non-zero =&gt; CI &#39;Type-check with Mypy&#39; step fails the job&#39;s status check</code>

```text
# Part 2: the gate now BLOCKS on a type error
# (workflow .github/workflows/test.yml dropped continue-on-error from the mypy step)

Regressed one of the PR's fixes back to an implicit-Optional default, then ran the exact gate command:
$ uv run mypy src/
src/caffeinated_whale_cli/commands/update.py:21: error: Incompatible default for argument "status_msg" (default has type "None", argument has type "str")  [assignment]
src/caffeinated_whale_cli/commands/update.py:21: note: PEP 484 prohibits implicit Optional. Accordingly, mypy has changed its default to no_implicit_optional=True
src/caffeinated_whale_cli/commands/update.py:21: note: Use https://github.com/hauntsaninja/no_implicit_optional to automatically upgrade your codebase
Found 1 error in 1 file (checked 34 source files)
exit code: 1  <-- non-zero => CI 'Type-check with Mypy' step fails the job's status check
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv sync --frozen --all-extras` - lockfile/pyproject consistent; installs types-requests + types-toml stubs</code>
- <code>`uv run pytest -q` - 101 passed (no runtime behavior change from the typing pass)</code>
- <code>`uv run mypy src/` - Success, 0 errors, exit 0 (Part 1 product surface / the CI gate command)</code>
- <code>`grep -rn &#39;type:\s*ignore&#39; src/` - no matches (fixed properly, not silenced)</code>
- <code>compared `[tool.mypy]` in pyproject.toml between base 697ed3c and target - byte-identical (config not loosened)</code>
- <code>Gate-blocks demo: transiently regressed `status_msg: str | None = None` -&gt; `str = None` in update.py, ran `uv run mypy src/` (exit 1, reports the type error), then `git checkout` to restore a clean tree</code>
- <code>inspected `.github/workflows/test.yml` diff - confirmed `continue-on-error` removed from the mypy step and job renamed to `Mypy`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by making type-checking fail on new errors, helping prevent broken changes from being merged.
* **Documentation**
  * Updated contributor and testing guides to reflect the stricter type-checking requirement.
  * Clarified how to keep type checks passing and where to add missing type stubs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->