### PR TITLE
fix(init): continue site setup when declining to reuse an existing bench

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,17 @@ This file is the project's committed home for project-intrinsic agent knowledge:
 
 Other per-branch settings nearby in `init.py`: Python version (`branch_python`: 15->3.12, 14->3.10, 13->3.9), Node major (`branch_node`: 14->16, 13->14), and `setuptools<82` is pinned only for `version-13`.
 
+### `init` existing-bench flow: decline must continue, not dead-end
+
+The devcontainer image ships a `/workspace/frappe-bench`, so a fresh `cwcli init` usually finds an already-existing bench at the default `bench_parent/bench_name`.
+`_resolve_bench_target(frappe_container, bench_parent_path, bench_name)` in `init.py` owns this branch and returns `(bench_name, bench_full_path, bench_exists)`.
+When the bench exists it asks "Reuse the existing bench ...?": Yes reuses it (returns `bench_exists=True` so `bench init` is skipped); No now prompts for a different bench name and loops, so site setup continues on a fresh bench (returns `bench_exists=False`).
+A blank replacement name or a cancelled prompt (`.ask()` returns `None`) exits cleanly with code 0 and "No changes made.".
+This replaced the old behavior where declining reuse just `raise typer.Exit(0)` and aborted the whole command (issue #20).
+The resolver runs after the setup spinner has exited, so its prompts own the terminal; keep it out of any `console.status`/`TipSpinner` block.
+`inputs.bench_name` is reassigned from the resolver's return (so `bench init` and the site paths use the chosen name), which is valid because `InitInputs` is a plain mutable `@dataclass`.
+Regression coverage is in `tests/test_init_reuse_bench.py`.
+
 ## CI quality gates
 
 - `.github/workflows/lint.yml` runs `black --check` + `ruff check`.

--- a/README.md
+++ b/README.md
@@ -175,11 +175,24 @@ Example: cwcli init my-project --port 10000
 
 **Reusing Existing Bench:**
 
-If a bench already exists at the specified path:
+If a bench already exists at the specified path (the devcontainer image ships a default `/workspace/frappe-bench`, so a fresh `init` usually hits this):
 
 ```
 Bench 'frappe-bench' already exists at /workspace/frappe-bench.
-? Reuse the existing bench and continue with site setup? (Y/n)
+? Reuse the existing bench 'frappe-bench' and continue with site setup? (Y/n)
+```
+
+Answer `Y` to reuse it as-is (bench initialization is skipped and site setup continues on the existing bench).
+Answer `n` to set up a fresh bench instead; you're prompted for a different bench name and site setup continues there:
+
+```
+? Enter a different bench name to create (leave blank to cancel): my-bench
+```
+
+Leaving the name blank (or cancelling either prompt) makes no changes and exits cleanly:
+
+```
+No changes made.
 ```
 
 ---

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -209,6 +209,58 @@ def _ensure_directory(container, path: str) -> None:
         raise typer.Exit(code=1)
 
 
+def _resolve_bench_target(
+    frappe_container,
+    bench_parent_path: str,
+    bench_name: str,
+) -> tuple[str, str, bool]:
+    """Resolve which bench to set up inside the container.
+
+    Returns ``(bench_name, bench_full_path, bench_exists)``.
+
+    When the chosen bench already exists, the user is asked whether to reuse it.
+    Declining no longer aborts the command: the user is prompted for a different
+    bench name so site setup can continue on a fresh bench (issue #20). A blank
+    name or a cancelled prompt exits cleanly without making changes.
+    ``bench_exists`` is True when an existing bench will be reused (so
+    ``bench init`` is skipped) and False when a fresh bench must be initialized.
+    """
+    bench_full_path = f"{bench_parent_path}/{bench_name}"
+    add_path(bench_full_path)
+    bench_exists = _directory_exists(frappe_container, bench_full_path)
+
+    while bench_exists:
+        console.print(f"[yellow]Bench '{bench_name}' already exists at {bench_full_path}.[/yellow]")
+        reuse = questionary.confirm(
+            f"Reuse the existing bench '{bench_name}' and continue with site setup?",
+            default=True,
+            auto_enter=False,
+        ).ask()
+        if reuse is None:
+            # Prompt cancelled (e.g. Ctrl-C).
+            console.print("[yellow]No changes made.[/yellow]")
+            raise typer.Exit(code=0)
+        if reuse:
+            break
+
+        # The user declined to reuse the existing bench. Let them name a
+        # different bench and continue setup instead of dead-ending.
+        new_name = questionary.text(
+            "Enter a different bench name to create (leave blank to cancel):",
+            default="",
+        ).ask()
+        if not new_name or not new_name.strip():
+            console.print("[yellow]No changes made.[/yellow]")
+            raise typer.Exit(code=0)
+
+        bench_name = _validate_slug(new_name, "Bench name")
+        bench_full_path = f"{bench_parent_path}/{bench_name}"
+        add_path(bench_full_path)
+        bench_exists = _directory_exists(frappe_container, bench_full_path)
+
+    return bench_name, bench_full_path, bench_exists
+
+
 def _get_pyenv_python_version(container, prefix: str, verbose: bool = False) -> str | None:
     """Find a pyenv Python version matching the given prefix (e.g. '3.12') inside the container."""
     exit_code, output = container.exec_run(["bash", "-lc", "ls ~/.pyenv/versions"])
@@ -663,30 +715,17 @@ def init(
 
     # Prepare bench paths inside the container
     bench_parent_path = bench_parent.rstrip("/") or "/workspace"
-    bench_full_path = f"{bench_parent_path}/{inputs.bench_name}"
-
-    # Add path to config for open to work
-    add_path(bench_full_path)
 
     # Create parent directory inside the container
     _ensure_directory(frappe_container, bench_parent_path)
 
-    # Bench initialization
-    bench_exists = _directory_exists(frappe_container, bench_full_path)
-
-    # Exit spinner before interactive prompt
-    if bench_exists:
-        console.print(
-            f"[yellow]Bench '{inputs.bench_name}' already exists at {bench_full_path}.[/yellow]"
-        )
-        reuse = questionary.confirm(
-            "Reuse the existing bench and continue with site setup?",
-            default=True,
-            auto_enter=False,
-        ).ask()
-        if not reuse:
-            console.print("[yellow]No changes made.[/yellow]")
-            raise typer.Exit(code=0)
+    # Resolve which bench to set up (the spinner has already exited, so the
+    # prompts below own the terminal). If the bench already exists, the user is
+    # asked whether to reuse it; declining lets them pick a different bench name
+    # and continue site setup instead of aborting (issue #20).
+    inputs.bench_name, bench_full_path, bench_exists = _resolve_bench_target(
+        frappe_container, bench_parent_path, inputs.bench_name
+    )
 
     # Initialize bench if it doesn't exist
     if not bench_exists:

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -209,6 +209,27 @@ def _ensure_directory(container, path: str) -> None:
         raise typer.Exit(code=1)
 
 
+def _bench_name_validation(value: str) -> bool | str:
+    """Validate a replacement bench name typed at the reuse-decline prompt.
+
+    Returns ``True`` when valid, or an error string so questionary re-prompts in
+    place. A blank value is treated as valid so the caller's cancel path can
+    handle it (leaving the prompt blank cancels). The non-blank rules match
+    :func:`_validate_slug`.
+    """
+    cleaned = value.strip()
+    if not cleaned:
+        return True
+
+    lowered = cleaned.lower()
+    allowed = "abcdefghijklmnopqrstuvwxyz0123456789-_"
+    if not all(char in allowed for char in lowered):
+        return "Bench name must contain only lowercase letters, numbers, dashes, or underscores."
+    if lowered[0] in "-_" or lowered[-1] in "-_":
+        return "Bench name cannot start or end with '-' or '_'."
+    return True
+
+
 def _resolve_bench_target(
     frappe_container,
     bench_parent_path: str,
@@ -226,7 +247,6 @@ def _resolve_bench_target(
     ``bench init`` is skipped) and False when a fresh bench must be initialized.
     """
     bench_full_path = f"{bench_parent_path}/{bench_name}"
-    add_path(bench_full_path)
     bench_exists = _directory_exists(frappe_container, bench_full_path)
 
     while bench_exists:
@@ -248,16 +268,17 @@ def _resolve_bench_target(
         new_name = questionary.text(
             "Enter a different bench name to create (leave blank to cancel):",
             default="",
+            validate=_bench_name_validation,
         ).ask()
         if not new_name or not new_name.strip():
             console.print("[yellow]No changes made.[/yellow]")
             raise typer.Exit(code=0)
 
-        bench_name = _validate_slug(new_name, "Bench name")
+        bench_name = new_name.strip().lower()
         bench_full_path = f"{bench_parent_path}/{bench_name}"
-        add_path(bench_full_path)
         bench_exists = _directory_exists(frappe_container, bench_full_path)
 
+    add_path(bench_full_path)
     return bench_name, bench_full_path, bench_exists
 
 

--- a/tests/test_init_reuse_bench.py
+++ b/tests/test_init_reuse_bench.py
@@ -11,7 +11,7 @@ import pytest
 import typer
 
 from caffeinated_whale_cli.commands import init as init_mod
-from caffeinated_whale_cli.commands.init import _resolve_bench_target
+from caffeinated_whale_cli.commands.init import _bench_name_validation, _resolve_bench_target
 
 
 @pytest.fixture
@@ -43,6 +43,7 @@ class TestResolveBenchTarget:
         assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", False)
         questionary_mock.confirm.assert_not_called()
         questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_called_once_with("/workspace/frappe-bench")
 
     def test_existing_bench_reused_when_confirmed(self, patched):
         questionary_mock, directory_exists_mock = patched
@@ -53,6 +54,7 @@ class TestResolveBenchTarget:
 
         assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", True)
         questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_called_once_with("/workspace/frappe-bench")
 
     def test_declining_reuse_continues_with_new_bench_name(self, patched):
         # Regression for issue #20: declining must NOT abort. The user supplies a
@@ -66,6 +68,8 @@ class TestResolveBenchTarget:
         name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
 
         assert (name, path, exists) == ("primis-bench", "/workspace/primis-bench", False)
+        # Only the finally-resolved bench is persisted, not the declined one.
+        init_mod.add_path.assert_called_once_with("/workspace/primis-bench")
 
     def test_declining_then_naming_another_existing_bench_can_reuse_it(self, patched):
         questionary_mock, directory_exists_mock = patched
@@ -88,6 +92,8 @@ class TestResolveBenchTarget:
         with pytest.raises(typer.Exit) as excinfo:
             _resolve_bench_target(_container(), "/workspace", "frappe-bench")
         assert excinfo.value.exit_code == 0
+        # Cancelling must not persist any path to the custom search paths.
+        init_mod.add_path.assert_not_called()
 
     def test_cancelled_confirm_prompt_exits_cleanly(self, patched):
         questionary_mock, directory_exists_mock = patched
@@ -98,3 +104,39 @@ class TestResolveBenchTarget:
         with pytest.raises(typer.Exit) as excinfo:
             _resolve_bench_target(_container(), "/workspace", "frappe-bench")
         assert excinfo.value.exit_code == 0
+        init_mod.add_path.assert_not_called()
+
+    def test_replacement_name_is_normalized_to_lowercase(self, patched):
+        # A valid mixed-case/whitespace replacement is accepted and normalized
+        # without hard-aborting via _validate_slug.
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.side_effect = [True, False]
+        questionary_mock.confirm.return_value.ask.return_value = False
+        questionary_mock.text.return_value.ask.return_value = "  Primis-Bench  "
+
+        name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+
+        assert (name, path, exists) == ("primis-bench", "/workspace/primis-bench", False)
+        init_mod.add_path.assert_called_once_with("/workspace/primis-bench")
+
+
+class TestBenchNameValidation:
+    """The reuse-decline prompt validates in place instead of aborting init."""
+
+    @pytest.mark.parametrize("value", ["", "   "])
+    def test_blank_is_allowed_so_cancel_path_can_handle_it(self, value):
+        assert _bench_name_validation(value) is True
+
+    @pytest.mark.parametrize("value", ["frappe-bench", "my_bench2", "Primis-Bench", "  abc  "])
+    def test_valid_names_pass(self, value):
+        assert _bench_name_validation(value) is True
+
+    @pytest.mark.parametrize("value", ["my bench", "bad/name", "name!", "a.b"])
+    def test_disallowed_characters_return_error_string(self, value):
+        result = _bench_name_validation(value)
+        assert isinstance(result, str)
+
+    @pytest.mark.parametrize("value", ["-bench", "bench-", "_bench", "bench_"])
+    def test_leading_or_trailing_separator_returns_error_string(self, value):
+        result = _bench_name_validation(value)
+        assert isinstance(result, str)

--- a/tests/test_init_reuse_bench.py
+++ b/tests/test_init_reuse_bench.py
@@ -1,0 +1,100 @@
+"""Tests for bench-target resolution during ``cwcli init``.
+
+Regression coverage for issue #20: when the chosen bench already exists and the
+user declines to reuse it, ``init`` must continue site setup on a different
+bench name instead of dead-ending with "No changes made".
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+import typer
+
+from caffeinated_whale_cli.commands import init as init_mod
+from caffeinated_whale_cli.commands.init import _resolve_bench_target
+
+
+@pytest.fixture
+def patched(monkeypatch):
+    """Patch questionary, add_path, and _directory_exists used by the resolver.
+
+    Returns ``(questionary_mock, directory_exists_mock)`` so each test can wire
+    up prompt answers and bench-existence results.
+    """
+    questionary_mock = MagicMock()
+    directory_exists_mock = MagicMock()
+    monkeypatch.setattr(init_mod, "questionary", questionary_mock)
+    monkeypatch.setattr(init_mod, "add_path", MagicMock())
+    monkeypatch.setattr(init_mod, "_directory_exists", directory_exists_mock)
+    return questionary_mock, directory_exists_mock
+
+
+def _container():
+    return MagicMock(name="frappe_container")
+
+
+class TestResolveBenchTarget:
+    def test_fresh_bench_is_returned_without_prompting(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = False
+
+        name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+
+        assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", False)
+        questionary_mock.confirm.assert_not_called()
+        questionary_mock.text.assert_not_called()
+
+    def test_existing_bench_reused_when_confirmed(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+        questionary_mock.confirm.return_value.ask.return_value = True
+
+        name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+
+        assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", True)
+        questionary_mock.text.assert_not_called()
+
+    def test_declining_reuse_continues_with_new_bench_name(self, patched):
+        # Regression for issue #20: declining must NOT abort. The user supplies a
+        # different bench name and setup continues on a fresh bench.
+        questionary_mock, directory_exists_mock = patched
+        # First probe: the default bench exists. Second probe: the new name is free.
+        directory_exists_mock.side_effect = [True, False]
+        questionary_mock.confirm.return_value.ask.return_value = False
+        questionary_mock.text.return_value.ask.return_value = "primis-bench"
+
+        name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+
+        assert (name, path, exists) == ("primis-bench", "/workspace/primis-bench", False)
+
+    def test_declining_then_naming_another_existing_bench_can_reuse_it(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        # Both the default and the chosen replacement already exist.
+        directory_exists_mock.side_effect = [True, True]
+        # Decline the first bench, then reuse the second.
+        questionary_mock.confirm.return_value.ask.side_effect = [False, True]
+        questionary_mock.text.return_value.ask.return_value = "other-bench"
+
+        name, path, exists = _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+
+        assert (name, path, exists) == ("other-bench", "/workspace/other-bench", True)
+
+    def test_declining_reuse_with_blank_name_cancels_cleanly(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+        questionary_mock.confirm.return_value.ask.return_value = False
+        questionary_mock.text.return_value.ask.return_value = ""
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+        assert excinfo.value.exit_code == 0
+
+    def test_cancelled_confirm_prompt_exits_cleanly(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+        # Ctrl-C / cancelled confirm yields None.
+        questionary_mock.confirm.return_value.ask.return_value = None
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_bench_target(_container(), "/workspace", "frappe-bench")
+        assert excinfo.value.exit_code == 0


### PR DESCRIPTION
## Intent

Fix issue #20: cwcli init stops after the user declines to reuse an existing frappe-bench. The devcontainer image ships a default bench at /workspace/frappe-bench, so a fresh 'cwcli init' almost always finds an existing bench and asks whether to reuse it. Answering No previously aborted the whole command with 'No changes made.', leaving the user stuck with no way to continue. The fix makes declining the reuse prompt ask for a different bench name and continue site setup on a fresh bench. A blank name or a cancelled prompt still exits cleanly with code 0, and answering Yes reuses the existing bench exactly as before. The bench resolution logic was extracted into a new testable helper _resolve_bench_target in init.py (returning bench_name, bench_full_path, bench_exists), which lets the reuse prompt loop be unit tested without Docker. Regression tests were added in tests/test_init_reuse_bench.py covering: fresh bench, reuse on confirm, decline then continue with a new name, decline then reuse a second existing bench, blank name cancel, and cancelled confirm. A sharp edge note was added to AGENTS.md. The change is intentionally scoped to the existing-bench branch of init; the broader init flow, the other interactive prompts, and the per-branch version gating are left unchanged.

## What Changed

- Extracted bench resolution into a new testable `_resolve_bench_target(...)` helper in `init.py` that returns `(bench_name, bench_full_path, bench_exists)`; declining the "Reuse the existing bench?" prompt now loops to ask for a different bench name and continues site setup on a fresh bench instead of aborting with "No changes made." (issue #20). A blank replacement name or a cancelled prompt still exits cleanly with code 0, and answering Yes reuses the existing bench as before.
- Hardened the decline-recovery flow: the replacement name is validated in place via a `_bench_name_validation` check that re-prompts on bad input rather than hard-exiting, and `add_path` is deduplicated so declined-but-existing benches are no longer leaked into the custom search-paths config.
- Added regression coverage in `tests/test_init_reuse_bench.py` (fresh bench, reuse-on-confirm, decline-then-continue, decline-then-reuse-second, blank-name cancel, cancelled-confirm exit, name normalization, and validation rules), plus a sharp-edge note in `AGENTS.md` and the continue path documented in `README.md`.

## Risk Assessment

✅ Low: The change is small, well-bounded, and thoroughly tested; it correctly resolves both prior-round findings (no more hard-abort on a typo'd replacement name, and add_path is called once on the resolved path) with no new functional issues found.

## Testing

`Ran the full pytest suite (122 passed) and the new regression file tests/test_init_reuse_bench.py (21 passed), then produced reviewer-visible end-to-end evidence by driving the real production helper _resolve_bench_target through five terminal scenarios. The transcript shows the core issue #20 fix (decline reuse -> prompt for a new bench name -> site setup continues on a fresh bench), plus blank-name clean exit (code 0, nothing persisted), Yes-reuses-as-before, decline-then-reuse-a-second-existing-bench, and the no-prompt fresh-machine path. As a CLI tool there is no GUI surface to screenshot, so the captured terminal transcript is the appropriate end-user product artifact. All checks pass with no failures or setup issues.`

<details>
<summary>Evidence: CLI transcript: init bench-resolution across 5 end-user scenarios (real _resolve_bench_target)</summary>

<code>Scenario 1 Decline reuse, give a new name -&gt; CONTINUES (issue #20 fix)&#10;Bench &#39;frappe-bench&#39; already exists at /workspace/frappe-bench.&#10;? Reuse the existing bench &#39;frappe-bench&#39; and continue with site setup? [Y/n] -&gt; user answers: No&#10;? Enter a different bench name to create (leave blank to cancel): -&gt; user types: &#39;primis-bench&#39;&#10;=&gt; site setup CONTINUES on bench &#39;primis-bench&#39; at /workspace/primis-bench&#10;=&gt; decision: create FRESH bench (run &#39;bench init&#39;)&#10;&#10;Scenario 2 Decline reuse, leave name blank -&gt; clean exit, no changes&#10;? ... user types: &lt;blank / Enter&gt;&#10;No changes made.&#10;=&gt; init exits cleanly with code 0 (no changes made); add_path persisted? False&#10;&#10;Scenario 3 Accept reuse -&gt; reuses existing bench (unchanged behavior)&#10;? ... user answers: Yes&#10;=&gt; REUSE existing bench (skip &#39;bench init&#39;)</code>

```text
cwcli init - bench resolution (issue #20)

==============================================================================
Scenario 1  Decline reuse, give a new name  ->  CONTINUES (issue #20 fix)
------------------------------------------------------------------------------
Bench 'frappe-bench' already exists at /workspace/frappe-bench.
  ? Reuse the existing bench 'frappe-bench' and continue with site setup? [Y/n]  ->  user answers: No
  ? Enter a different bench name to create (leave blank to cancel):  ->  user types: 'primis-bench'
  => site setup CONTINUES on bench 'primis-bench' at /workspace/primis-bench
  => decision: create FRESH bench (run 'bench init')
  => path persisted for 'cwcli open': /workspace/primis-bench

==============================================================================
Scenario 2  Decline reuse, leave name blank  ->  clean exit, no changes
------------------------------------------------------------------------------
Bench 'frappe-bench' already exists at /workspace/frappe-bench.
  ? Reuse the existing bench 'frappe-bench' and continue with site setup? [Y/n]  ->  user answers: No
  ? Enter a different bench name to create (leave blank to cancel):  ->  user types: <blank / Enter>
No changes made.
  => init exits cleanly with code 0 (no changes made)
  => add_path persisted? False

==============================================================================
Scenario 3  Accept reuse  ->  reuses existing bench (unchanged behavior)
------------------------------------------------------------------------------
Bench 'frappe-bench' already exists at /workspace/frappe-bench.
  ? Reuse the existing bench 'frappe-bench' and continue with site setup? [Y/n]  ->  user answers: Yes
  => site setup CONTINUES on bench 'frappe-bench' at /workspace/frappe-bench
  => decision: REUSE existing bench (skip 'bench init')
  => path persisted for 'cwcli open': /workspace/frappe-bench

==============================================================================
Scenario 4  Decline, name another existing bench, reuse it
------------------------------------------------------------------------------
Bench 'frappe-bench' already exists at /workspace/frappe-bench.
  ? Reuse the existing bench 'frappe-bench' and continue with site setup? [Y/n]  ->  user answers: No
  ? Enter a different bench name to create (leave blank to cancel):  ->  user types: 'other-bench'
Bench 'other-bench' already exists at /workspace/other-bench.
  ? Reuse the existing bench 'other-bench' and continue with site setup? [Y/n]  ->  user answers: Yes
  => site setup CONTINUES on bench 'other-bench' at /workspace/other-bench
  => decision: REUSE existing bench (skip 'bench init')
  => path persisted for 'cwcli open': /workspace/other-bench

==============================================================================
Scenario 5  Fresh machine, no existing bench  ->  no prompt at all
------------------------------------------------------------------------------
  => site setup CONTINUES on bench 'frappe-bench' at /workspace/frappe-bench
  => decision: create FRESH bench (run 'bench init')
  => path persisted for 'cwcli open': /workspace/frappe-bench

All scenarios exercised the real _resolve_bench_target shipping code.
```
</details>
<details>
<summary>Evidence: Driver script (drives real shipping helper, simulates only prompt + Docker probe)</summary>

```text
"""End-to-end driver for issue #20 fix.

Exercises the REAL production helper ``_resolve_bench_target`` from
``caffeinated_whale_cli.commands.init``. Only the two boundaries an end user
does not type code against are simulated:

  * ``questionary`` -> the interactive keystrokes the user enters at the prompt.
  * ``_directory_exists`` -> the Docker probe that reports whether a bench dir
    exists inside the frappe container (the devcontainer ships /workspace/frappe-bench).

Everything else - the prompt wording, the yellow console messages, the loop,
the lowercase normalization, the exit codes - is the unmodified shipping code.
This reproduces, at the terminal level, exactly what an end user sees.
"""

import sys
from unittest.mock import MagicMock

import typer

from caffeinated_whale_cli.commands import init as init_mod
from caffeinated_whale_cli.commands.init import _resolve_bench_target


def make_questionary(confirm_answers, text_answers):
    """Build a questionary stand-in that replays scripted user input.

    ``confirm_answers`` feeds successive ``confirm(...).ask()`` calls (the
    Yes/No reuse prompt). ``text_answers`` feeds successive ``text(...).ask()``
    calls (the "type a different bench name" prompt). Each call echoes what the
    "user" typed so the transcript reads like a real session.
    """
    q = MagicMock()
    confirm_iter = iter(confirm_answers)
    text_iter = iter(text_answers)

    def confirm(prompt, **kwargs):
        ans = next(confirm_iter)
        shown = {True: "Yes", False: "No", None: "<Ctrl-C>"}.get(ans, ans)
        print(f"  ? {prompt} [Y/n]  ->  user answers: {shown}")
        m = MagicMock()
        m.ask.return_value = ans
        return m

    def text(prompt, **kwargs):
        ans = next(text_iter)
        typed = "<blank / Enter>" if ans == "" else repr(ans)
        print(f"  ? {prompt}  ->  user types: {typed}")
        m = MagicMock()
        m.ask.return_value = ans
        return m

    q.confirm.side_effect = confirm
    q.text.side_effect = text
    return q


def run_scenario(title, *, dir_exists, confirm_answers, text_answers):
    print("=" * 78)
    print(title)
    print("-" * 78)
    init_mod.questionary = make_questionary(confirm_answers, text_answers)
    init_mod.add_path = MagicMock()
    init_mod._directory_exists = MagicMock(side_effect=dir_exists)

    container = MagicMock(name="frappe_container")
    try:
        name, path, exists = _resolve_bench_target(container, "/workspace", "frappe-bench")
    except typer.Exit as exc:
        print(f"  => init exits cleanly with code {exc.exit_code} (no changes made)")
        print(f"  => add_path persisted? {init_mod.add_path.called}")
        print()
        return

    action = "REUSE existing bench (skip 'bench init')" if exists else "create FRESH bench (run 'bench init')"
    print(f"  => site setup CONTINUES on bench '{name}' at {path}")
    print(f"  => decision: {action}")
    print(f"  => path persisted for 'cwcli open': {init_mod.add_path.call_args.args[0]}")
    print()


if __name__ == "__main__":
    print("cwcli init - bench resolution (issue #20)\n")

    # Scenario 1: the issue #20 bug path. Default bench exists, user declines
    # reuse, supplies a new name -> setup continues instead of dead-ending.
    run_scenario(
        "Scenario 1  Decline reuse, give a new name  ->  CONTINUES (issue #20 fix)",
        dir_exists=[True, False],
        confirm_answers=[False],
        text_answers=["primis-bench"],
    )

    # Scenario 2: decline, then leave the name blank -> clean exit, no changes.
    run_scenario(
        "Scenario 2  Decline reuse, leave name blank  ->  clean exit, no changes",
        dir_exists=[True],
        confirm_answers=[False],
        text_answers=[""],
    )

    # Scenario 3: answer Yes -> reuse the existing bench, exactly as before.
    run_scenario(
        "Scenario 3  Accept reuse  ->  reuses existing bench (unchanged behavior)",
        dir_exists=[True],
        confirm_answers=[True],
        text_answers=[],
    )

    # Scenario 4: decline first bench, name a second that ALSO exists -> offered
    # reuse again, accept it.
    run_scenario(
        "Scenario 4  Decline, name another existing bench, reuse it",
        dir_exists=[True, True],
        confirm_answers=[False, True],
        text_answers=["other-bench"],
    )

    # Scenario 5: no existing bench at all -> no prompt, straight to fresh setup.
    run_scenario(
        "Scenario 5  Fresh machine, no existing bench  ->  no prompt at all",
        dir_exists=[False],
        confirm_answers=[],
        text_answers=[],
    )

    print("All scenarios exercised the real _resolve_bench_target shipping code.")
    sys.exit(0)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ⚠️ `src/caffeinated_whale_cli/commands/init.py:256` - In the decline-recovery prompt, an invalid replacement name is passed to `_validate_slug`, which calls `raise typer.Exit(code=1)` on bad input (a space, leading/trailing dash, or other disallowed char). Because the containers are already started and the bench loop runs late in init, a single typo in the new bench name hard-aborts the entire command with exit 1 - re-introducing exactly the kind of dead-end the issue #20 fix set out to remove. Consider catching the validation failure and re-prompting (continue the loop) instead of letting `_validate_slug` exit the whole command.
- ℹ️ `src/caffeinated_whale_cli/commands/init.py:229` - `add_path(bench_full_path)` is invoked for every candidate path inside `_resolve_bench_target` (lines 229 and 258), including benches the user declines to reuse. Each declined-but-existing bench is therefore persisted to the custom search-paths config and produces an &#39;Added .../already exists&#39; console line. Calling `add_path` once on the final resolved `bench_full_path` just before `return` would avoid leaking declined benches into config and remove the repeated prompt-loop noise, while keeping the reuse and fresh-bench cases identical.

🔧 Fix: harden init reuse-decline prompt: validate in place, dedupe add_path
1 info still open:
- ℹ️ `src/caffeinated_whale_cli/commands/init.py:215` - _bench_name_validation duplicates the allowed-character and leading/trailing-separator rules of _validate_slug, and its docstring states the rules &#34;match&#34; _validate_slug. The two are kept in sync only by hand, so a future change to _validate_slug&#39;s rules can silently diverge from the reuse-decline validator. The functions have intentionally different contracts (stderr+raise vs questionary bool|str return), so the small duplication is defensible; this is only a drift-hazard note, not a required change. If desired, factor the shared rule check into a helper returning an error string or None, consumed by both.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest -q` (full suite: 122 passed)</code>
- <code>`uv run pytest tests/test_init_reuse_bench.py -v` (21 passed: fresh bench, reuse-on-confirm, decline-then-continue, decline-then-reuse-second, blank-name cancel, cancelled-confirm exit, lowercase normalization, and `_bench_name_validation` rules)</code>
- <code>Drove the real `_resolve_bench_target` shipping code via `drive_resolve_bench.py` across 5 end-user scenarios, simulating only questionary keystrokes and the `_directory_exists` Docker probe, capturing the actual console prompts/messages an end user sees</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
