### PR TITLE
fix(restore,inspect): correct receive path, credential prompts, site/default-site detection, and post-restore migrate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,8 +196,14 @@ On Frappe `version-15` bench has a "trying alternative directories" fallback tha
 
 Shared by the normal and receive paths.
 Interactive (a TTY): prompt for the username (default `root`, blank keeps `root`) AND the password (blank is an error).
-The normal path previously had NO username prompt and, because the confirm's Enter leaked into the immediately-following password prompt, the password came back empty (`Error: Password cannot be empty.`); adding the username prompt absorbs that stray Enter and the password is collected.
 Non-interactive (flags / non-TTY): the username defaults to `root`; the password is a required secret, so a non-TTY WITHOUT `--mariadb-root-password` refuses with a non-zero exit rather than hanging or proceeding empty.
+
+The interactive "empty password" bug and its ROOT fix (sharp edge, worth remembering for ANY questionary confirm followed by another prompt):
+`questionary.confirm(...)` with the default `auto_enter=True` submits on the `y`/`n` keypress and leaves the user's habitual trailing Enter in prompt_toolkit's INTERNAL input buffer.
+That stray Enter is then read by the immediately-following prompt as an empty submit, so the password prompt returned empty (`Error: Password cannot be empty.`).
+A `termios.tcflush` stdin drain was tried and proven INEFFECTIVE: `FIONREAD` shows the OS tty queue is empty (the Enter is inside prompt_toolkit, not the OS queue), so a tcflush reaches nothing - it was removed.
+The fix is `auto_enter=False` on EVERY restore confirm (both the destructive `Are you sure you want to restore?` and the missing-apps `continue anyway?`, on both paths): with `auto_enter=False` the confirm REQUIRES Enter to submit and thus CONSUMES its own trailing Enter, so nothing leaks into the next prompt - robust regardless of which credential flags are set.
+(An earlier partial mechanism - the username prompt absorbing the stray Enter - only worked in the default flow where the username prompt runs; it silently failed for `--mariadb-root-username <flag>` + habitual `y`+Enter, which is why a realistic pty E2E must press `y` THEN Enter.)
 
 ### Missing-apps warning reads the BACKUP's apps (`check_missing_apps` + `_read_backup_installed_apps`)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,11 +207,14 @@ The correct question is "does the BACKUP need apps this bench lacks" (the captai
 `check_missing_apps(frappe_container, project_name, bench_path, backup_db_path, ...)` (the `site` arg became `backup_db_path`) compares those against the bench's apps read LIVE from `ls {bench_path}/apps`, and returns `backup_apps - available_apps`.
 It fails safe: an unreadable dump / absent marker yields `None` -> no warning (never a false positive).
 Both call sites pass the backup's container path (`selected_backup["database"]["full_path"]` on the normal path; `{backup_dir}/{database_file.name}` on the receive path).
+Because both sides are now read LIVE (the backup's dump and `ls apps`), the check no longer touches cwcli's cache, so `check_missing_apps` dropped its `cache.recache_project` call and `--no-recache` became a DEPRECATED no-op - the flag (and its `no_recache` param) is kept only for backward compatibility with existing callers.
 
 ### Post-restore: migrate then restart (`_post_restore_migrate_and_restart`)
 
 After a successful `bench restore`, both paths run `bench --site <site> migrate` then restart the instance (via `_start_project`, which kills the old `bench start` and relaunches it - the same app restart `cwcli restart` does).
+The restart targets the SAME bench that was just restored via `_start_project`'s new `bench_path_override` (used verbatim, bypassing the `resolve_bench_path` guessing), so a multi-bench restore into a non-first bench restarts the right dev server, never bench 0.
 A failed migrate does NOT undo the restore; it is surfaced and the restart still runs, but the function returns False so the caller exits non-zero.
+A Docker/API exception raised by the migrate `exec_run` is treated as a failed-but-reported migrate (`exit_code=1`) that STILL continues to the restart, so an exec error can never skip bringing the instance back up.
 `--no-migrate` skips the whole post-restore step.
 
 Regression coverage: `tests/test_restore_inspect_fixes.py` (all six) and `tests/test_bench_labels`-style DB tests; `tests/test_inspect_partial_refresh.py` and `tests/test_restore_safety.py` fakes were updated for the shared site probe and the `no_migrate` param.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,3 +163,76 @@ Two supporting fixes travel with it, and BOTH the receive path and the normal re
 
 Regression coverage is in `tests/test_restore_safety.py`: it drives `restore_receive_mode` with a `FakeReceiveContainer` that records every `exec_run` (command, workdir, environment) and asserts a declined/non-TTY confirm does NOT run `bench restore --force` and exits non-zero, `--yes` proceeds, an origin mismatch is surfaced, and the DB password rides in `environment=` (never in the recorded argv).
 Testing note: `restore_receive_mode` is a plain function (not the Typer command), so tests call it directly with all args explicit; stub `TipSpinner` to a no-op (it starts a Rich spinner even with `enabled=False`) and fake `subprocess.run` to write the "downloaded" backup into its `cwd`.
+
+## `restore` + `inspect`: currentsite, default site, receive path, credential prompts, missing-apps, migrate+restart
+
+Six bugs the captain hit on a live 0.33.0 session (Frappe `version-14`, site `development.localhost`) were fixed together.
+The authoritative repros and the real-instance E2E evidence are in `docs/e2e/restore-inspect-e2e-r6.md`.
+
+### Site detection is shared (`utils/bench_sites.py`)
+
+`bench_sites.list_sites(container, bench_path)` is the single canonical "what are the real sites" implementation, used by BOTH `commands/rm.py:_list_sites` (which now just delegates) and `commands/inspect.py:_get_sites`.
+A real Frappe site is a DIRECTORY containing `site_config.json`; detection probes for that per entry rather than denylisting known non-site names.
+It is fail-safe: an entry is excluded only on a positive NOTASITE (a non-directory, or a readable dir with no `site_config.json`); anything ambiguous (probe error, unreadable dir) is treated as a site.
+This replaced `inspect._get_sites`' old denylist `{"apps.txt", "assets", "common_site_config.json", "example.com", "apps.json"}`, which did NOT list `currentsite.txt` (a plain file written by `bench use`), so inspect reported it as a site and then errored `bench --site currentsite.txt list-apps -> "Site currentsite.txt does not exist!"`.
+`bench_sites.read_current_site(container, bench_path)` reads `sites/currentsite.txt` (the default-site pointer), failing safe to `None`.
+The probe string in `list_sites` is byte-identical to the one rm's tests already assert, so rm's fakes stay green; `tests/test_inspect_partial_refresh.py`'s fake gained the same SITE/NOTASITE probe handling.
+
+### Default site resolves from EITHER source (`currentsite.txt` OR `common_site_config.json`)
+
+A bench records its default site in `common_site_config.json`'s `default_site` OR `sites/currentsite.txt`; a plain `bench use`d dev bench only has the latter (the captain's `ners` had no `default_site` key at all).
+`Bench.current_site` is a new nullable column (idempotent `_migrate_bench_current_site_column`, mirroring the `label` migration) populated by a full inspect from `currentsite.txt`, carried forward by the T2 partial pass, and surfaced by `get_cached_project_data`.
+`db_utils.get_default_site` now returns `common_site_config.default_site` if set, else the cached `current_site` (via `get_current_site`) - so `restore`/`backup`/`unlock` all resolve the default even with no `default_site` key.
+`inspect`'s tree marks `(default)` from either source too.
+`restore.py:_resolve_default_site` adds a LIVE `currentsite.txt` read as a final fallback for the destructive restore path (a cold/stale cache still resolves correctly); it is used by both the normal and receive paths in place of the bare `get_default_site`.
+
+### `--receive` restore: full container path, not the bare filename
+
+Receive-mode built `bench restore <bare-filename>` with `workdir=backup_dir`; on Frappe `version-14` bench rejects that with `Invalid path <db filename>` (data restore broken).
+The fix passes the FULL container path `{backup_dir}/{database_file.name}` and reorders the args to exactly match the normal path (db path, credentials, `--force`, then `--with-public-files`/`--with-private-files`).
+On Frappe `version-15` bench has a "trying alternative directories" fallback that masks the bare-filename bug, so this only reproduces on v14 - which is why the E2E built a v14 bench (`docs/e2e/`).
+
+### Credential prompting works in BOTH modes (`_prompt_mariadb_credentials`)
+
+Shared by the normal and receive paths.
+Interactive (a TTY): prompt for the username (default `root`, blank keeps `root`) AND the password (blank is an error).
+The normal path previously had NO username prompt and, because the confirm's Enter leaked into the immediately-following password prompt, the password came back empty (`Error: Password cannot be empty.`); adding the username prompt absorbs that stray Enter and the password is collected.
+Non-interactive (flags / non-TTY): the username defaults to `root`; the password is a required secret, so a non-TTY WITHOUT `--mariadb-root-password` refuses with a non-zero exit rather than hanging or proceeding empty.
+
+### Missing-apps warning reads the BACKUP's apps (`check_missing_apps` + `_read_backup_installed_apps`)
+
+The warning regressed to silence because `check_missing_apps` read `sites/{site}/apps.json`, which Frappe does NOT write per site (it lives at the bench level, `sites/apps.json`), so the `cat` always failed and it returned `[]`.
+The correct question is "does the BACKUP need apps this bench lacks" (the captain's words), not "what does the about-to-be-overwritten site have" - and a site whose app code is already missing cannot even be listed by `bench list-apps` (the import crashes).
+`_read_backup_installed_apps` `zcat -f`s the backup's DB dump and greps the `installed_apps` global (`...,'["frappe","widgets"]','installed_apps',...` - exactly what `frappe.get_installed_apps()` reads), extracting the app-name tokens.
+`check_missing_apps(frappe_container, project_name, bench_path, backup_db_path, ...)` (the `site` arg became `backup_db_path`) compares those against the bench's apps read LIVE from `ls {bench_path}/apps`, and returns `backup_apps - available_apps`.
+It fails safe: an unreadable dump / absent marker yields `None` -> no warning (never a false positive).
+Both call sites pass the backup's container path (`selected_backup["database"]["full_path"]` on the normal path; `{backup_dir}/{database_file.name}` on the receive path).
+
+### Post-restore: migrate then restart (`_post_restore_migrate_and_restart`)
+
+After a successful `bench restore`, both paths run `bench --site <site> migrate` then restart the instance (via `_start_project`, which kills the old `bench start` and relaunches it - the same app restart `cwcli restart` does).
+A failed migrate does NOT undo the restore; it is surfaced and the restart still runs, but the function returns False so the caller exits non-zero.
+`--no-migrate` skips the whole post-restore step.
+
+Regression coverage: `tests/test_restore_inspect_fixes.py` (all six) and `tests/test_bench_labels`-style DB tests; `tests/test_inspect_partial_refresh.py` and `tests/test_restore_safety.py` fakes were updated for the shared site probe and the `no_migrate` param.
+
+## Interactive AND non-interactive modes: support and test BOTH (captain standard, 2026-07-04)
+
+Every cwcli command that prompts the user (destructive confirmations, credential entry, selection menus) MUST work in two modes and be E2E-verified in BOTH on a real instance, not just unit tests:
+
+- **Interactive** (a human at a TTY): every prompt is shown AND its input is actually collected.
+  A prompt that is skipped, or that returns empty without waiting for input, is a bug (e.g. the restore flow's MariaDB username/password prompts skipping after the "are you sure?" confirm).
+- **Non-interactive** (an agent/automation, or any non-TTY): every prompt has a corresponding flag so the command runs to completion with NO prompt - `--yes`/`-y` for confirmations, `--mariadb-root-username`/`--mariadb-root-password` for credentials, `--site` and backup selectors, etc.
+  Under a non-TTY WITHOUT the needed flag, a destructive or blocking prompt must refuse with a non-zero exit rather than silently proceeding, defaulting, or hanging.
+
+This is an AXI requirement (agents drive cwcli non-interactively) and a UX requirement (humans get working prompts).
+When adding or changing any prompting command: add/verify the non-interactive flags, make the interactive prompts genuinely collect input, and exercise BOTH paths in a real-instance E2E (drive the TTY prompts via a pty/expect, waiting for prompt_toolkit's raw-mode readiness marker `ESC[?2004h` before each keystroke).
+
+## Re-run the real-instance E2E AFTER the no-mistakes run and AFTER any CodeRabbit fixes (captain standard, 2026-07-05)
+
+Unit tests + a green no-mistakes pipeline are NOT sufficient proof for a behavior change.
+The no-mistakes review/document steps and CodeRabbit's post-pipeline suggestions frequently produce behavior-altering fixes (e.g. `start` skip-and-continue vs abort, `label --clear` DB/marker consistency, `inspect` Tier-2 read-only, restore path/prompt changes).
+Those fixes land AFTER the original E2E was run, so they ship re-validated only by unit tests.
+
+Standard: after the no-mistakes run completes AND after applying any CodeRabbit fixes, run the real-instance E2E AGAIN (on an isolated throwaway instance) to confirm the final shipped code still behaves correctly end-to-end - not just that the unit suite is green.
+Treat "CodeRabbit fixes applied" as a trigger to re-E2E, the same way you would after any late behavior change.

--- a/README.md
+++ b/README.md
@@ -546,7 +546,8 @@ cwcli inspect [OPTIONS] PROJECT_NAME
 - Sites and installed apps for each bench
 - Site configurations (database credentials, developer mode settings)
 - Common site configuration (Redis URLs, ports, default site, etc.)
-- Default site is labeled with `(default)` in output
+- Default-site pointer from `sites/currentsite.txt` (written by `bench use`), so the `(default)` marker and default-site resolution work even when `common_site_config.json` has no `default_site` key
+- Default site is labeled with `(default)` in output (resolved from either source)
 
 **Example Output:**
 
@@ -819,7 +820,7 @@ cwcli unlock [OPTIONS] PROJECT_NAME
 
 | Option | Description |
 |--------|-------------|
-| `-s`, `--site TEXT` | Site name to unlock. If not provided, uses the default site from `common_site_config.json` |
+| `-s`, `--site TEXT` | Site name to unlock. If not provided, uses the default site (from `common_site_config.json`'s `default_site` or `sites/currentsite.txt`) |
 | `--bench TEXT` | Which bench to target: its numeric index or label (see [Working with Multiple Benches](#working-with-multiple-benches)) |
 | `-p`, `--path TEXT` | Explicit bench directory inside the container (lower-level alternative to `--bench`; cannot be combined with it) |
 | `-y`, `--yes` | Auto-start stopped containers without prompting |
@@ -830,7 +831,7 @@ cwcli unlock [OPTIONS] PROJECT_NAME
 Removes the `{bench_path}/sites/{site_name}/locks` directory, which can help resolve issues when a site is stuck in a locked state due to incomplete migrations or background jobs.
 
 **Smart Defaults:**
-- If `--site` is not specified, automatically uses the default site from your bench's `common_site_config.json`
+- If `--site` is not specified, automatically uses your bench's default site (from `common_site_config.json`'s `default_site`, or `sites/currentsite.txt` when that key is absent)
 - Shows "Using default site: {site}" when using the default
 - Run `cwcli inspect {project}` first to cache the configuration
 
@@ -893,7 +894,7 @@ cwcli backup [OPTIONS] PROJECT_NAME
 
 | Option | Description |
 |--------|-------------|
-| `-s`, `--site TEXT` | Site name to back up. If not provided, uses the default site from `common_site_config.json` |
+| `-s`, `--site TEXT` | Site name to back up. If not provided, uses the default site (from `common_site_config.json`'s `default_site` or `sites/currentsite.txt`) |
 | `--bench TEXT` | Which bench to target: its numeric index or label (see [Working with Multiple Benches](#working-with-multiple-benches)) |
 | `-p`, `--path TEXT` | Explicit bench directory inside the container (lower-level alternative to `--bench`; cannot be combined with it) |
 | `--with-files` | Include public and private files in the backup |
@@ -936,15 +937,16 @@ cwcli restore [OPTIONS] PROJECT_NAME
 
 | Option | Description |
 |--------|-------------|
-| `-s`, `--site TEXT` | Site name to restore. If not provided, uses the default site from `common_site_config.json` |
+| `-s`, `--site TEXT` | Site name to restore. If not provided, uses the default site (from `common_site_config.json`'s `default_site` or `sites/currentsite.txt`) |
 | `--bench TEXT` | Which bench to target: its numeric index or label (see [Working with Multiple Benches](#working-with-multiple-benches)) |
 | `-p`, `--path TEXT` | Explicit bench directory inside the container (lower-level alternative to `--bench`; cannot be combined with it) |
-| `--mariadb-root-username TEXT` | MariaDB root username (default: root) |
-| `--mariadb-root-password TEXT` | MariaDB root password (will prompt if not provided) |
+| `--mariadb-root-username TEXT` | MariaDB root username (defaults to `root`; prompted interactively when omitted) |
+| `--mariadb-root-password TEXT` | MariaDB root password. Prompted interactively when omitted; a non-TTY without this flag refuses rather than proceeding with an empty password |
 | `--admin-password TEXT` | Set administrator password after restore |
 | `--send` | **P2P Mode:** Share backup with another machine via peer-to-peer transfer |
 | `--receive` | **P2P Mode:** Receive backup from another machine via peer-to-peer transfer |
-| `--no-recache` | Skip re-caching the project before checking for missing apps (uses the existing cache) |
+| `--no-recache` | **Deprecated no-op:** the missing-apps check now reads app availability live from the bench, so it never re-caches. Kept for backward compatibility |
+| `--no-migrate` | Skip the post-restore `bench migrate` and instance restart. By default a successful restore runs `bench migrate` (bringing the restored DB to the code's schema) then restarts the instance |
 | `-y`, `--yes` | **`--receive` mode only:** Skip the restore confirmation prompts (the destructive-restore confirmation and the missing-apps prompt). A non-TTY without `--yes` refuses these and exits non-zero. Has no effect on the normal restore path |
 | `-v`, `--verbose` | Enable verbose output and show restore command details |
 
@@ -953,9 +955,11 @@ cwcli restore [OPTIONS] PROJECT_NAME
 1. Scans all backup files across all sites in the bench
 2. Presents an interactive menu with backups grouped by target site
 3. Shows badges indicating backup contents: `[FILES]`, `[PRIVATE]`, `[DATABASE ONLY]`
-4. Automatically detects and restores public/private file archives
-5. Restores encryption key from backup's site_config if available
-6. Displays helpful error messages on failure with common causes
+4. Warns if the selected backup needs apps this bench does not have (read from the backup's own database dump, so a missing app is caught before the restore)
+5. Automatically detects and restores public/private file archives
+6. Restores encryption key from backup's site_config if available
+7. Runs `bench migrate` and restarts the instance after a successful restore, so the restored database is brought to the code's schema and the app comes back up cleanly (skip with `--no-migrate`; a failed migrate is surfaced and exits non-zero but does not undo the restore)
+8. Displays helpful error messages on failure with common causes
 
 **Interactive Features:**
 
@@ -999,12 +1003,18 @@ From: 2025-11-12 10:56:38
 Will restore: Database, Public files, Private files
 
 ? Are you sure you want to restore? (y/N) y
+? MariaDB root username: root
 MariaDB root password: ********
 
 ✓ Successfully restored site 'development.localhost'
 From backup: 20251112_105638-development_localhost-database.sql.gz
 Including file archives
 Updated encryption_key from backup site_config
+
+✓ Migrated site 'development.localhost'
+
+Restarting instance...
+✓ Instance restarted (logs: /workspace/frappe-bench/logs/web.dev.log)
 ```
 
 **P2P Backup Transfer:**

--- a/docs/e2e/restore-inspect-e2e-r6.md
+++ b/docs/e2e/restore-inspect-e2e-r6.md
@@ -1,0 +1,136 @@
+# E2E evidence: restore + inspect fixes (currentsite, default site, receive path, credential prompts, missing-apps, migrate+restart)
+
+Real-instance end-to-end run on **isolated** throwaway environments (a temporary
+`HOME` so `~/.cwcli` was a fresh DB, unique docker-compose projects, and dedicated
+volumes). The captain's real projects and real `~/.cwcli` were never touched, and
+the instances were torn down afterwards. Two genuine benches were built with
+`cwcli init` + `bench init`:
+
+- **`cwe2e6`** - Frappe **version-15** (`15.113.4`).
+- **`cwe2e6v14`** - Frappe **version-14** (`14.101.1`), the captain's exact version,
+  where the `--receive` "Invalid path" bug actually manifests.
+
+Both were put into the captain's reported state: `sites/currentsite.txt` present
+and holding `development.localhost`, with **no** `default_site` in
+`common_site_config.json` (the default site lives only in `currentsite.txt`).
+
+Interactive prompts were driven through a real pty (pexpect); non-interactive
+paths were driven with flags. prompt_toolkit's raw-mode readiness marker
+(`ESC[?2004h`) was awaited before each keystroke so nothing raced the prompt.
+
+## What it proves
+
+- **#1 `--receive` uses the full DB path (Frappe v14).** With cwd = the site's
+  `private/backups`, `bench restore <bare-filename>` fails with the captain's exact
+  error `Invalid path <db>`; `bench restore <full-path>` succeeds. The receive path
+  now builds the full path, and a real receive-mode restore completes on v14.
+- **#2 credential prompts in BOTH modes.** Interactive: the MariaDB **username**
+  prompt (previously skipped) appears and the **password** is actually collected.
+  Non-interactive: `--mariadb-root-username/--mariadb-root-password` run the restore
+  with no prompt; a non-TTY without a password refuses (unit-pinned).
+- **#3 `currentsite.txt` is not a site.** `inspect` went from `Sites (2)`
+  (`currentsite.txt` + the real site, the stray one erroring on `bench list-apps`)
+  to `Sites (1)` (the real site only).
+- **#4 default site from `currentsite.txt`.** With no `default_site` in
+  `common_site_config.json`, `inspect` marks `development.localhost (default)` from
+  `currentsite.txt`, `get_default_site` resolves it through the cache, and restore
+  (normal + receive) uses it with no `--site`.
+- **#5 missing-apps warning fires again.** A backup taken with `widgets` installed,
+  restored into a bench with `widgets` removed from `apps/`, warns that the backup
+  needs `widgets` (read from the backup's own DB dump, not the about-to-be-
+  overwritten site).
+- **#6 post-restore migrate + restart.** A successful restore runs
+  `bench migrate` then restarts the instance.
+
+## #1 - `--receive` full DB path, on Frappe v14 (the captain's version)
+
+```
+# BUGGY (bare filename, cwd = private/backups) - the captain's exact error:
+$ cd .../private/backups && bench --site development.localhost restore 20260705_092753-...-database.sql.gz --force ...
+Invalid path 20260705_092753-development_localhost-database.sql.gz
+
+# FIXED (full path, cwd = private/backups) - what restore.py now builds:
+$ cd .../private/backups && bench --site development.localhost restore /workspace/frappe-bench/sites/development.localhost/private/backups/20260705_092753-...-database.sql.gz --force ...
+Site development.localhost has been restored
+```
+
+Real receive-mode restore through the receive code path on v14 (default site
+resolved from `currentsite.txt`, then restore + migrate + restart):
+
+```
+[info] driving real receive-mode restore on cwe2e6v14 (Frappe v14)
+Using default site: development.localhost
+✓ Files copied to container
+✓ Successfully restored backup to site 'development.localhost'
+✓ Migrated site 'development.localhost'
+Restarting instance...
+[OK] receive-mode restore + migrate + restart completed on real v14 Frappe
+```
+
+A full **real sendme loopback** through the CLI (`restore --send` serving a ticket,
+`restore --receive` pasting it) also completed on v14 (exit 0); the deterministic
+harness above stubs only the P2P transfer, which is orthogonal to the path bug.
+
+## #2 - credential prompts, interactive (pty) and non-interactive (flags)
+
+Interactive `cwcli restore cwe2e6` (no `--site`, no creds):
+
+```
+Using default site: development.localhost
+? Select a backup to restore: 2026-07-05 09:16:49  [DATABASE ONLY]
+? Are you sure you want to restore? Yes
+? MariaDB root username: root          <- previously SKIPPED; now shown + collected
+? MariaDB root password:               <- input actually collected (123)
+✓ Successfully restored site 'development.localhost'
+[OK] MariaDB root username prompt appeared
+[OK] MariaDB root password prompt collected input
+```
+
+Non-interactive (`--mariadb-root-username root --mariadb-root-password 123`): no
+credential prompt fires; the restore runs straight through after the confirm
+(`[OK] no credential prompt fired; restore ran non-interactively via flags`).
+
+## #3 / #4 - inspect: currentsite.txt not a site; default from currentsite.txt
+
+```
+############ BUGGY (original code) ############
+    └── Sites (2)
+        ├── currentsite.txt
+        │       └── Error fetching apps for site currentsite.txt
+        └── development.localhost
+
+############ FIXED (this change) ############
+    └── Sites (1)
+        └── development.localhost (default)
+```
+
+`development.localhost` is marked `(default)` even though `common_site_config.json`
+has no `default_site` - it is resolved from `currentsite.txt`. Confirmed through
+the cache too: `get_default_site('cwe2e6', ...) -> development.localhost`.
+
+## #5 - missing-apps warning (through the CLI)
+
+Backup taken with `widgets` installed; `widgets` then removed from the bench's
+`apps/`. `cwcli restore cwe2e6 --site development.localhost`:
+
+```
+backup apps in dump: {'widgets', 'frappe'}     # read from the backup's own dump
+MISSING APPS DETECTED: ['widgets']
+
+⚠ Warning: The following apps are installed on the backup site but not available on this bench:
+  • widgets
+? Do you want to continue with the restore anyway? No
+Restore cancelled.
+[OK] MISSING-APPS WARNING PROVEN THROUGH THE CLI
+```
+
+## #6 - post-restore migrate + restart
+
+Tail of the successful interactive restore:
+
+```
+✓ Successfully restored site 'development.localhost'
+✓ Migrated site 'development.localhost'
+Restarting instance...
+✓ Instance restarted (logs: /tmp/bench-cwe2e6.log)
+```

--- a/docs/e2e/restore-inspect-e2e-r6.md
+++ b/docs/e2e/restore-inspect-e2e-r6.md
@@ -139,21 +139,23 @@ Restarting instance...
 
 Per the "re-run the real-instance E2E after no-mistakes and after any CodeRabbit
 fixes" standard, the whole E2E was re-run against the final shipped code (the
-no-mistakes review fixes - restart the restored bench, drop the unused recache,
-flush stdin before the password prompt - plus the four CodeRabbit fixes). All
-green on real Frappe v15 (`cwe2e6`) and v14 (`cwe2e6v14`):
+no-mistakes review fixes - restart the restored bench, drop the unused recache -
+the CodeRabbit fixes, and the `auto_enter=False` credential root fix). Crucially,
+the confirm is driven the way a human types it: `y` THEN Enter. All green on real
+Frappe v15 (`cwe2e6`) and v14 (`cwe2e6v14`):
 
 ```bash
 # #3/#4 inspect (injection-safe positional-arg site probe):
     └── Sites (1)
         └── development.localhost (default)     # currentsite.txt excluded; default from it
 
-# #2/#6 interactive normal restore (pty): username prompt shown, password collected,
-#        restore + bench migrate + instance restart all succeed.
+# #2/#6 interactive normal restore (pty, y+Enter at the confirm): username prompt shown,
+#        password collected, restore + bench migrate + instance restart all succeed.
 
-# stdin-flush fix - interactive restore with --mariadb-root-username as a FLAG and NO
-#   password flag (username prompt skipped): the password prompt STILL collects input
-#   (the drained stray Enter cannot empty it) and the restore succeeds.
+# credential root fix (auto_enter=False) - interactive restore with --mariadb-root-username
+#   as a FLAG and NO password flag (username prompt skipped) + habitual y+Enter: the
+#   confirm consumes its own Enter, so the password prompt STILL collects input (this
+#   case failed before the fix, when a tcflush drain could not reach the buffered Enter).
 
 # non-interactive: --mariadb-root-username/--mariadb-root-password run with no prompt.
 

--- a/docs/e2e/restore-inspect-e2e-r6.md
+++ b/docs/e2e/restore-inspect-e2e-r6.md
@@ -44,7 +44,7 @@ paths were driven with flags. prompt_toolkit's raw-mode readiness marker
 
 ## #1 - `--receive` full DB path, on Frappe v14 (the captain's version)
 
-```
+```bash
 # BUGGY (bare filename, cwd = private/backups) - the captain's exact error:
 $ cd .../private/backups && bench --site development.localhost restore 20260705_092753-...-database.sql.gz --force ...
 Invalid path 20260705_092753-development_localhost-database.sql.gz
@@ -57,7 +57,7 @@ Site development.localhost has been restored
 Real receive-mode restore through the receive code path on v14 (default site
 resolved from `currentsite.txt`, then restore + migrate + restart):
 
-```
+```bash
 [info] driving real receive-mode restore on cwe2e6v14 (Frappe v14)
 Using default site: development.localhost
 ✓ Files copied to container
@@ -75,7 +75,7 @@ harness above stubs only the P2P transfer, which is orthogonal to the path bug.
 
 Interactive `cwcli restore cwe2e6` (no `--site`, no creds):
 
-```
+```bash
 Using default site: development.localhost
 ? Select a backup to restore: 2026-07-05 09:16:49  [DATABASE ONLY]
 ? Are you sure you want to restore? Yes
@@ -92,7 +92,7 @@ credential prompt fires; the restore runs straight through after the confirm
 
 ## #3 / #4 - inspect: currentsite.txt not a site; default from currentsite.txt
 
-```
+```bash
 ############ BUGGY (original code) ############
     └── Sites (2)
         ├── currentsite.txt
@@ -113,7 +113,7 @@ the cache too: `get_default_site('cwe2e6', ...) -> development.localhost`.
 Backup taken with `widgets` installed; `widgets` then removed from the bench's
 `apps/`. `cwcli restore cwe2e6 --site development.localhost`:
 
-```
+```bash
 backup apps in dump: {'widgets', 'frappe'}     # read from the backup's own dump
 MISSING APPS DETECTED: ['widgets']
 
@@ -128,9 +128,39 @@ Restore cancelled.
 
 Tail of the successful interactive restore:
 
-```
+```bash
 ✓ Successfully restored site 'development.localhost'
 ✓ Migrated site 'development.localhost'
 Restarting instance...
 ✓ Instance restarted (logs: /tmp/bench-cwe2e6.log)
+```
+
+## Re-validation on the final code (after the no-mistakes run and CodeRabbit fixes)
+
+Per the "re-run the real-instance E2E after no-mistakes and after any CodeRabbit
+fixes" standard, the whole E2E was re-run against the final shipped code (the
+no-mistakes review fixes - restart the restored bench, drop the unused recache,
+flush stdin before the password prompt - plus the four CodeRabbit fixes). All
+green on real Frappe v15 (`cwe2e6`) and v14 (`cwe2e6v14`):
+
+```bash
+# #3/#4 inspect (injection-safe positional-arg site probe):
+    └── Sites (1)
+        └── development.localhost (default)     # currentsite.txt excluded; default from it
+
+# #2/#6 interactive normal restore (pty): username prompt shown, password collected,
+#        restore + bench migrate + instance restart all succeed.
+
+# stdin-flush fix - interactive restore with --mariadb-root-username as a FLAG and NO
+#   password flag (username prompt skipped): the password prompt STILL collects input
+#   (the drained stray Enter cannot empty it) and the restore succeeds.
+
+# non-interactive: --mariadb-root-username/--mariadb-root-password run with no prompt.
+
+# #5 missing-apps (recache dropped): backup needing widgets, bench without widgets ->
+MISSING (final code, no recache): ['widgets']
+
+# #1 receive on v14: full-path bench restore succeeds, then migrate + restart.
+✓ Successfully restored backup to site 'development.localhost'
+✓ Migrated site 'development.localhost'
 ```

--- a/src/caffeinated_whale_cli/commands/backup.py
+++ b/src/caffeinated_whale_cli/commands/backup.py
@@ -19,7 +19,8 @@ def backup(
         None,
         "--site",
         "-s",
-        help="Site name to backup. If not provided, uses the default site from common_site_config.",
+        help="Site name to backup. If not provided, uses the default site "
+        "(from common_site_config.json's default_site or sites/currentsite.txt).",
         autocompletion=complete_site_names,
     ),
     bench: str = typer.Option(
@@ -49,7 +50,8 @@ def backup(
     This command runs 'bench backup' for the specified site. By default, it backs up
     only the database. Use --with-files to include public and private files.
 
-    If --site is not provided, the default site from common_site_config.json will be used.
+    If --site is not provided, the default site is used, resolved from either
+    common_site_config.json's `default_site` or sites/currentsite.txt.
 
     Examples:
         cwcli backup my-project

--- a/src/caffeinated_whale_cli/commands/inspect.py
+++ b/src/caffeinated_whale_cli/commands/inspect.py
@@ -7,7 +7,7 @@ import typer
 from rich.console import Console
 from rich.tree import Tree
 
-from ..utils import bench_labels, config_utils, db_utils
+from ..utils import bench_labels, bench_sites, config_utils, db_utils
 from ..utils.completion_utils import complete_project_names
 from ..utils.docker_utils import (
     get_frappe_container,
@@ -51,11 +51,15 @@ def _is_bench_directory(
 def _get_sites(
     container: docker.models.containers.Container, bench_dir: str, verbose: bool = False
 ) -> list[str]:
-    exit_code, output = _run_command(container, f"ls -1 {bench_dir}/sites", verbose)
-    if exit_code != 0:
-        return []
-    excluded = {"apps.txt", "assets", "common_site_config.json", "example.com", "apps.json"}
-    return [item for item in output.split("\n") if item and item not in excluded]
+    # A real Frappe site is a DIRECTORY containing site_config.json. Detect sites
+    # by that shape via the canonical shared helper, never by denylisting known
+    # non-site names - a denylist can never be complete, so a stray entry like
+    # currentsite.txt (a plain file written by `bench use`) was being reported as
+    # a site and then failed `bench list-apps`. See utils/bench_sites.py.
+    if verbose:
+        console_err.print(f"[dim]$ ls -1 {bench_dir}/sites (site detection)[/dim]")
+    sites = bench_sites.list_sites(container, bench_dir, verbose)
+    return sites if sites is not None else []
 
 
 def _get_installed_apps(
@@ -210,6 +214,20 @@ def _gather_bench_data(
 
     bench_data: dict = {"path": bench_dir, "sites": sites_info, "available_apps": available_apps}
 
+    # Record the default site pointer from currentsite.txt (written by `bench use`).
+    # A bench records its default site in TWO places: common_site_config.json's
+    # `default_site` OR sites/currentsite.txt. Persisting currentsite.txt lets the
+    # cache-served default-site resolution (restore/backup/unlock and the inspect
+    # "(default)" marker) work even when common_site_config has no default_site
+    # key - the exact shape a plain `bench use`d dev bench has.
+    current_site = bench_sites.read_current_site(frappe_container, bench_dir, verbose)
+    if current_site:
+        bench_data["current_site"] = current_site
+        if verbose:
+            console_err.print(
+                f"[dim]VERBOSE: Default site from currentsite.txt: {current_site}[/dim]"
+            )
+
     # Recover the user label from the per-bench marker file. This is what lets a
     # full inspect rebuild labels after the SQLite cache is lost: the marker lives
     # inside the bench, so it survives a cache wipe. The marker is the source of
@@ -309,6 +327,11 @@ def partial_inspect_known_benches(
         # updates the cache directly).
         if cached_bench.get("label"):
             bench_data["label"] = cached_bench["label"]
+        # Carry the cached default-site pointer forward too. T2 is a cheap
+        # freshness pass and does not re-read currentsite.txt; a change to the
+        # default site is picked up by the full inspect (Tier 3).
+        if cached_bench.get("current_site"):
+            bench_data["current_site"] = cached_bench["current_site"]
         if "common_site_config" in cached_bench:
             bench_data["common_site_config"] = cached_bench["common_site_config"]
         refreshed.append(bench_data)
@@ -615,10 +638,14 @@ def inspect(
             for app in bench_instance["available_apps"]:
                 apps_branch.add(f"[dim]{app}[/dim]")
 
-            # Get default site from common config
+            # Resolve the default site from EITHER common_site_config.json's
+            # `default_site` OR the currentsite.txt pointer (recorded as
+            # `current_site`). A plain `bench use`d dev bench only has the latter.
             default_site = None
             if "common_site_config" in bench_instance:
                 default_site = bench_instance["common_site_config"].get("default_site")
+            if not default_site:
+                default_site = bench_instance.get("current_site")
 
             sites_branch = bench_node.add(f"Sites ({len(bench_instance['sites'])})")
             for site_data in bench_instance["sites"]:

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -81,25 +81,6 @@ def transform_site_name_to_backup_format(site_name: str) -> str:
     return site_name.replace(".", "_")
 
 
-def _flush_stdin_buffer() -> None:
-    """Discard any input already buffered on stdin (best-effort, TTY-only).
-
-    Called right before an interactive secret prompt so a stray keystroke left in
-    the terminal input buffer by a PRECEDING prompt - e.g. the Enter that answered
-    the "Are you sure you want to restore?" confirmation - cannot be swallowed as an
-    empty password. Guarded by ``isatty`` and wrapped in a broad ``except`` so a
-    non-TTY, or a platform without ``termios`` (Windows), is a safe no-op.
-    """
-    try:
-        if not sys.stdin.isatty():
-            return
-        import termios
-
-        termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
-    except Exception:
-        pass
-
-
 def _prompt_mariadb_credentials(
     mariadb_root_username: str | None,
     mariadb_root_password: str | None,
@@ -113,11 +94,11 @@ def _prompt_mariadb_credentials(
       and the password, actually collecting the input. A blank username keeps the
       ``root`` default; a blank password is an error (a restore needs the real
       root password). This fixes the normal path silently skipping the username
-      prompt and never collecting the password. The stray Enter that a preceding
-      confirmation leaves in the input buffer is drained (see
-      :func:`_flush_stdin_buffer`) right before the password prompt, so the
-      password prompt always waits for real input regardless of which credential
-      flags were passed - the username prompt is no longer load-bearing for this.
+      prompt and never collecting the password. The preceding restore confirmation
+      disables questionary's auto-enter, so it consumes its own trailing Enter and
+      can never leave a stray keystroke for the password prompt to swallow as empty
+      input - the password prompt always waits for real input regardless of which
+      credential flags were passed.
     - **Non-interactive (flags / non-TTY):** use the ``--mariadb-root-*`` flags.
       The username has a safe default (``root``) so it may be omitted, but the
       password is a secret with no default: a non-TTY WITHOUT
@@ -146,9 +127,6 @@ def _prompt_mariadb_credentials(
     # Password: a required secret with no default.
     if not mariadb_root_password:
         if is_tty:
-            # Drain any buffered input (e.g. the Enter that answered the preceding
-            # restore confirmation) so it cannot be consumed as an empty password.
-            _flush_stdin_buffer()
             try:
                 mariadb_root_password = questionary.password("MariaDB root password:").ask()
             except (KeyboardInterrupt, EOFError):
@@ -1248,7 +1226,9 @@ def restore_receive_mode(
             else:
                 try:
                     proceed = questionary.confirm(
-                        "Do you want to continue with the restore anyway?", default=False
+                        "Do you want to continue with the restore anyway?",
+                        default=False,
+                        auto_enter=False,
                     ).ask()
                 except (KeyboardInterrupt, EOFError):
                     console.print("\n[yellow]Restore cancelled.[/yellow]")
@@ -1291,7 +1271,7 @@ def restore_receive_mode(
         else:
             try:
                 confirm = questionary.confirm(
-                    "Are you sure you want to restore?", default=False
+                    "Are you sure you want to restore?", default=False, auto_enter=False
                 ).ask()
             except (KeyboardInterrupt, EOFError):
                 console.print("\n[yellow]Restore cancelled.[/yellow]")
@@ -1779,7 +1759,9 @@ def restore(
 
         try:
             proceed = questionary.confirm(
-                "Do you want to continue with the restore anyway?", default=False
+                "Do you want to continue with the restore anyway?",
+                default=False,
+                auto_enter=False,
             ).ask()
         except (KeyboardInterrupt, EOFError):
             console.print("\n[yellow]Restore cancelled.[/yellow]")
@@ -1807,7 +1789,9 @@ def restore(
     console.print()
 
     try:
-        confirm = questionary.confirm("Are you sure you want to restore?", default=False).ask()
+        confirm = questionary.confirm(
+            "Are you sure you want to restore?", default=False, auto_enter=False
+        ).ask()
     except (KeyboardInterrupt, EOFError):
         console.print("\n[yellow]Restore cancelled.[/yellow]")
         raise typer.Exit(code=0) from None

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -8,7 +8,7 @@ import questionary
 import typer
 from questionary import Style
 
-from ..utils import bench_sites, cache, config_utils, db_utils
+from ..utils import bench_sites, config_utils, db_utils
 from ..utils.completion_utils import complete_project_names, complete_site_names
 from ..utils.console import console, stderr_console
 from ..utils.docker_utils import get_project_containers, handle_docker_errors
@@ -81,6 +81,25 @@ def transform_site_name_to_backup_format(site_name: str) -> str:
     return site_name.replace(".", "_")
 
 
+def _flush_stdin_buffer() -> None:
+    """Discard any input already buffered on stdin (best-effort, TTY-only).
+
+    Called right before an interactive secret prompt so a stray keystroke left in
+    the terminal input buffer by a PRECEDING prompt - e.g. the Enter that answered
+    the "Are you sure you want to restore?" confirmation - cannot be swallowed as an
+    empty password. Guarded by ``isatty`` and wrapped in a broad ``except`` so a
+    non-TTY, or a platform without ``termios`` (Windows), is a safe no-op.
+    """
+    try:
+        if not sys.stdin.isatty():
+            return
+        import termios
+
+        termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH)
+    except Exception:
+        pass
+
+
 def _prompt_mariadb_credentials(
     mariadb_root_username: str | None,
     mariadb_root_password: str | None,
@@ -94,7 +113,11 @@ def _prompt_mariadb_credentials(
       and the password, actually collecting the input. A blank username keeps the
       ``root`` default; a blank password is an error (a restore needs the real
       root password). This fixes the normal path silently skipping the username
-      prompt and never collecting the password.
+      prompt and never collecting the password. The stray Enter that a preceding
+      confirmation leaves in the input buffer is drained (see
+      :func:`_flush_stdin_buffer`) right before the password prompt, so the
+      password prompt always waits for real input regardless of which credential
+      flags were passed - the username prompt is no longer load-bearing for this.
     - **Non-interactive (flags / non-TTY):** use the ``--mariadb-root-*`` flags.
       The username has a safe default (``root``) so it may be omitted, but the
       password is a secret with no default: a non-TTY WITHOUT
@@ -123,6 +146,9 @@ def _prompt_mariadb_credentials(
     # Password: a required secret with no default.
     if not mariadb_root_password:
         if is_tty:
+            # Drain any buffered input (e.g. the Enter that answered the preceding
+            # restore confirmation) so it cannot be consumed as an empty password.
+            _flush_stdin_buffer()
             try:
                 mariadb_root_password = questionary.password("MariaDB root password:").ask()
             except (KeyboardInterrupt, EOFError):
@@ -222,7 +248,10 @@ def _post_restore_migrate_and_restart(
 
     console.print()
     console.print("[bold cyan]Restarting instance...[/bold cyan]")
-    log_file = _start_project(project_name, verbose=verbose)
+    # Restart the SAME bench that was just migrated/restored (bench_path), never the
+    # first sorted bench: pass it as an explicit override so a multi-bench restore
+    # into a non-first bench does not kill/restart the wrong dev server.
+    log_file = _start_project(project_name, verbose=verbose, bench_path_override=bench_path)
     if log_file:
         console.print(f"[bold green]✓[/bold green] Instance restarted (logs: {log_file})")
     else:
@@ -461,30 +490,23 @@ def check_missing_apps(
     even name an app whose code is already missing (that import crashes). Available
     apps are read live from ``apps/`` so the check never depends on cache freshness.
 
+    Because both sides of the comparison are read live, this check no longer
+    touches cwcli's cache. ``no_recache`` is therefore a DEPRECATED no-op, kept
+    only so existing callers (and the ``--no-recache`` CLI flag) keep working.
+
     Args:
         frappe_container: Docker container object
-        project_name: Name of the project (used only for the optional recache)
+        project_name: Name of the project (unused; kept for signature stability)
         bench_path: Path to bench directory
         backup_db_path: Full container path to the backup's database dump
         verbose: Enable verbose output
-        no_recache: Skip re-caching cwcli's view of the project before checking
+        no_recache: Deprecated no-op (the check reads everything live; retained for
+            backward compatibility with the ``--no-recache`` flag and callers)
 
     Returns:
         Sorted list of missing app names (empty when none, or when the backup's app
         list could not be determined - fail safe, never a false warning).
     """
-    # Refresh cwcli's cached view of the project (side effect only) unless skipped.
-    if not no_recache:
-        if verbose:
-            stderr_console.print("[dim]Re-caching project to verify app availability...[/dim]")
-        if not cache.recache_project(project_name, verbose=verbose):
-            if verbose:
-                stderr_console.print(
-                    "[yellow]Warning:[/yellow] Failed to recache project. App check may be inaccurate."
-                )
-    elif verbose:
-        stderr_console.print("[dim]Using existing cache (--no-recache flag set)...[/dim]")
-
     # Apps physically present in the bench (its apps/ directory), read live.
     quoted_apps_dir = shlex.quote(f"{bench_path}/apps")
     exit_code, output = frappe_container.exec_run(["sh", "-c", f"ls -1 {quoted_apps_dir}"])
@@ -1455,7 +1477,8 @@ def restore(
     no_recache: bool = typer.Option(
         False,
         "--no-recache",
-        help="Skip re-caching project before checking for missing apps (uses existing cache).",
+        help="Deprecated no-op: the missing-apps check now reads app availability "
+        "live from the bench, so it never re-caches. Kept for backward compatibility.",
     ),
     yes: bool = typer.Option(
         False,

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -221,8 +221,17 @@ def _post_restore_migrate_and_restart(
         stderr_console.print(f"[dim]$ {migrate_cmd}[/dim]")
 
     console.print()
-    with TipSpinner(f"Migrating site '{site}'", console=stderr_console, enabled=show_tips):
-        exit_code, output = frappe_container.exec_run(["sh", "-c", migrate_cmd], workdir=bench_path)
+    # A Docker/API exception from exec_run must NOT skip the restart: treat it as a
+    # failed-but-reported migrate (exit_code=1) so the restart below still runs. A
+    # failed migrate is surfaced but never prevents the instance from coming back up.
+    try:
+        with TipSpinner(f"Migrating site '{site}'", console=stderr_console, enabled=show_tips):
+            exit_code, output = frappe_container.exec_run(
+                ["sh", "-c", migrate_cmd], workdir=bench_path
+            )
+    except Exception as exc:
+        exit_code = 1
+        output = f"Failed to run migrate: {exc}".encode("utf-8", errors="replace")
 
     if verbose or exit_code != 0:
         if output:

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -8,7 +8,7 @@ import questionary
 import typer
 from questionary import Style
 
-from ..utils import cache, config_utils, db_utils
+from ..utils import bench_sites, cache, config_utils, db_utils
 from ..utils.completion_utils import complete_project_names, complete_site_names
 from ..utils.console import console, stderr_console
 from ..utils.docker_utils import get_project_containers, handle_docker_errors
@@ -79,6 +79,156 @@ def transform_site_name_to_backup_format(site_name: str) -> str:
         Transformed name (e.g., 'development_localhost')
     """
     return site_name.replace(".", "_")
+
+
+def _prompt_mariadb_credentials(
+    mariadb_root_username: str | None,
+    mariadb_root_password: str | None,
+) -> tuple[str, str]:
+    """Resolve the MariaDB root credentials for a restore, in BOTH modes.
+
+    Shared by the normal and receive restore paths so credential handling is
+    identical everywhere:
+
+    - **Interactive (a TTY):** prompt for the username (defaulting to ``root``)
+      and the password, actually collecting the input. A blank username keeps the
+      ``root`` default; a blank password is an error (a restore needs the real
+      root password). This fixes the normal path silently skipping the username
+      prompt and never collecting the password.
+    - **Non-interactive (flags / non-TTY):** use the ``--mariadb-root-*`` flags.
+      The username has a safe default (``root``) so it may be omitted, but the
+      password is a secret with no default: a non-TTY WITHOUT
+      ``--mariadb-root-password`` refuses with a non-zero exit rather than
+      hanging on a prompt or proceeding with an empty password.
+
+    Returns ``(username, password)`` with both guaranteed non-empty.
+    """
+    is_tty = sys.stdin.isatty()
+
+    # Username: defaults to root; only prompted interactively.
+    if not mariadb_root_username:
+        if is_tty:
+            try:
+                answer = questionary.text("MariaDB root username:", default="root").ask()
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n[yellow]Restore cancelled.[/yellow]")
+                raise typer.Exit(code=1) from None
+            if answer is None:  # Ctrl-C / no input
+                console.print("\n[yellow]Restore cancelled.[/yellow]")
+                raise typer.Exit(code=1)
+            mariadb_root_username = answer.strip() or "root"
+        else:
+            mariadb_root_username = "root"
+
+    # Password: a required secret with no default.
+    if not mariadb_root_password:
+        if is_tty:
+            try:
+                mariadb_root_password = questionary.password("MariaDB root password:").ask()
+            except (KeyboardInterrupt, EOFError):
+                console.print("\n[yellow]Restore cancelled.[/yellow]")
+                raise typer.Exit(code=1) from None
+            if not mariadb_root_password:
+                stderr_console.print("[bold red]Error:[/bold red] Password cannot be empty.")
+                raise typer.Exit(code=1)
+        else:
+            stderr_console.print(
+                "[bold red]Error:[/bold red] No MariaDB root password provided and not running "
+                "interactively.\n[dim]Pass --mariadb-root-password (and, if not 'root', "
+                "--mariadb-root-username) to restore non-interactively.[/dim]"
+            )
+            raise typer.Exit(code=1)
+
+    return mariadb_root_username, mariadb_root_password
+
+
+def _resolve_default_site(
+    project_name: str,
+    bench_path: str | None,
+    frappe_container,
+    verbose: bool = False,
+) -> str | None:
+    """Resolve a bench's default site from EITHER of the two places it is recorded.
+
+    Frappe records the default site in ``common_site_config.json``'s
+    ``default_site`` OR ``sites/currentsite.txt`` (the pointer ``bench use``
+    writes). The cache-backed :func:`db_utils.get_default_site` already checks
+    both (``default_site`` then the cached ``current_site``); this adds a LIVE
+    read of ``currentsite.txt`` as a final fallback so a cold or stale cache still
+    resolves the default for this (destructive) restore. Returns None if neither
+    source names a site.
+    """
+    site = db_utils.get_default_site(project_name, bench_path)
+    if site:
+        return site
+    if frappe_container is not None and bench_path:
+        site = bench_sites.read_current_site(frappe_container, bench_path, verbose)
+        if site and verbose:
+            stderr_console.print(f"[dim]Default site from currentsite.txt: {site}[/dim]")
+    return site
+
+
+def _post_restore_migrate_and_restart(
+    frappe_container,
+    project_name: str,
+    bench_path: str,
+    site: str,
+    verbose: bool = False,
+) -> bool:
+    """Run ``bench migrate`` then restart the instance after a successful restore.
+
+    A restored database is at the backup's schema, which may lag the bench's app
+    code, so ``bench --site <site> migrate`` brings it up to date; the instance is
+    then restarted so its running processes reconnect and pick up the migrated DB
+    (``_start_project`` kills the old ``bench start`` and relaunches it - the same
+    thing ``cwcli restart`` does for the app).
+
+    A failed migrate does NOT undo the (successful) restore; it is surfaced clearly
+    and the instance is still restarted, but the function returns False so the
+    caller can exit non-zero to flag that the site needs attention.
+    """
+    migrate_ok = True
+
+    show_tips = config_utils.get_show_tips()
+    migrate_cmd = f"bench --site {shlex.quote(site)} migrate"
+    if verbose:
+        stderr_console.print(f"[dim]$ {migrate_cmd}[/dim]")
+
+    console.print()
+    with TipSpinner(f"Migrating site '{site}'", console=stderr_console, enabled=show_tips):
+        exit_code, output = frappe_container.exec_run(["sh", "-c", migrate_cmd], workdir=bench_path)
+
+    if verbose or exit_code != 0:
+        if output:
+            console.print()
+            console.print("[dim]Migrate output:[/dim]")
+            console.print(output.decode("utf-8", errors="replace"))
+
+    if exit_code == 0:
+        console.print(f"[bold green]✓[/bold green] Migrated site '{site}'")
+    else:
+        migrate_ok = False
+        stderr_console.print(
+            f"[bold yellow]⚠ Warning:[/bold yellow] 'bench migrate' failed for site '{site}'. "
+            "The database was restored, but the schema may be out of date."
+        )
+        stderr_console.print(
+            f"[dim]Run it manually: cwcli run {project_name} -- bench --site {site} migrate[/dim]"
+        )
+
+    # Restart the instance so the app reconnects to the restored/migrated DB.
+    # Imported lazily to avoid any import cycle at module load.
+    from .start import _start_project
+
+    console.print()
+    console.print("[bold cyan]Restarting instance...[/bold cyan]")
+    log_file = _start_project(project_name, verbose=verbose)
+    if log_file:
+        console.print(f"[bold green]✓[/bold green] Instance restarted (logs: {log_file})")
+    else:
+        console.print("[bold green]✓[/bold green] Instance restart requested")
+
+    return migrate_ok
 
 
 def scan_backups_for_all_sites(frappe_container, bench_path: str, verbose: bool = False) -> list:
@@ -241,36 +391,92 @@ def group_and_sort_backups(backups: list, target_site: str) -> tuple:
     return target_backups, other_backups
 
 
+def _read_backup_installed_apps(
+    frappe_container,
+    backup_db_path: str,
+    verbose: bool = False,
+) -> set[str] | None:
+    """Read the list of apps a backup's site had installed, from the DB dump.
+
+    Frappe records a site's installed apps as a JSON list under the ``__global`` /
+    ``installed_apps`` default (this is exactly what ``frappe.get_installed_apps()``
+    reads), so the dump contains a row like::
+
+        ...,'["frappe", "widgets"]','installed_apps',...
+
+    We ``zcat -f`` the dump (``-f`` streams a plain ``.sql`` too) and grep out that
+    one array, then extract the app-name tokens from it. This tells us which apps
+    the BACKUP needs - the right question for "will this restore + migrate break
+    because an app's code is missing", which the current (about-to-be-overwritten)
+    site cannot answer.
+
+    Returns the set of app names, or ``None`` when the list could not be read
+    (unreadable dump, or the marker not present) so the caller can fail safe and
+    NOT warn on a false negative.
+    """
+    quoted = shlex.quote(backup_db_path)
+    # Grab the installed_apps global's JSON array. ``zcat -f`` handles gzip AND an
+    # already-plain .sql; grep is byte-oriented (-a) since the dump is binary-ish.
+    extract = (
+        f"zcat -f {quoted} 2>/dev/null | " "grep -aoE \"\\[[^]]*\\]','installed_apps'\" | head -1"
+    )
+    if verbose:
+        stderr_console.print(f"[dim]$ {extract}[/dim]")
+    exit_code, output = frappe_container.exec_run(["sh", "-c", extract])
+    if exit_code != 0:
+        return None
+    try:
+        text = output.decode("utf-8", errors="replace").strip()
+    except Exception:
+        return None
+    if not text:
+        return None
+    # ``text`` looks like: [\"frappe\", \"widgets\"]','installed_apps'
+    # Take everything up to the first ``]`` (the JSON array body) and pull out the
+    # app-name tokens, tolerant of mysqldump's escaping of the inner quotes.
+    array_body = text.split("]", 1)[0]
+    apps = set(re.findall(r"[A-Za-z_][A-Za-z0-9_]*", array_body))
+    return apps or None
+
+
 def check_missing_apps(
     frappe_container,
     project_name: str,
     bench_path: str,
-    site: str,
+    backup_db_path: str,
     verbose: bool = False,
     no_recache: bool = False,
 ) -> list[str]:
     """
-    Check for apps that are installed on the site but missing from the bench.
+    Return the apps the BACKUP needs that the bench does not physically have.
 
-    Reads the site's apps.json file and compares against available apps on the bench.
-    Re-caches the project to ensure accurate app availability data unless no_recache is True.
+    Warns the user, before a destructive restore, that the backup was taken on a
+    site with apps whose code is not in this bench's ``apps/`` - those apps will
+    fail ``bench migrate`` after the restore. This is the captain's exact concern
+    ("the backup uses apps the bench does NOT have installed").
+
+    The backup's app list is read from its own DB dump
+    (:func:`_read_backup_installed_apps`), NOT from the current site: the site is
+    about to be overwritten, and reading its apps via ``bench list-apps`` cannot
+    even name an app whose code is already missing (that import crashes). Available
+    apps are read live from ``apps/`` so the check never depends on cache freshness.
 
     Args:
         frappe_container: Docker container object
-        project_name: Name of the project
+        project_name: Name of the project (used only for the optional recache)
         bench_path: Path to bench directory
-        site: Site name to check
+        backup_db_path: Full container path to the backup's database dump
         verbose: Enable verbose output
-        no_recache: Skip re-caching (use existing cache)
+        no_recache: Skip re-caching cwcli's view of the project before checking
 
     Returns:
-        List of missing app names
+        Sorted list of missing app names (empty when none, or when the backup's app
+        list could not be determined - fail safe, never a false warning).
     """
-    # Re-cache the project to get fresh app data (unless skipped)
+    # Refresh cwcli's cached view of the project (side effect only) unless skipped.
     if not no_recache:
         if verbose:
             stderr_console.print("[dim]Re-caching project to verify app availability...[/dim]")
-
         if not cache.recache_project(project_name, verbose=verbose):
             if verbose:
                 stderr_console.print(
@@ -279,56 +485,31 @@ def check_missing_apps(
     elif verbose:
         stderr_console.print("[dim]Using existing cache (--no-recache flag set)...[/dim]")
 
-    # Get available apps from cache
-    cached_data = db_utils.get_cached_project_data(project_name)
-    if not cached_data or not cached_data.get("bench_instances"):
-        if verbose:
-            stderr_console.print(
-                "[yellow]Warning:[/yellow] No cached bench data. Cannot verify apps."
-            )
-        return []
-
-    # Find the bench instance that matches our bench_path
-    bench_instance = None
-    for bench in cached_data["bench_instances"]:
-        if bench["path"] == bench_path:
-            bench_instance = bench
-            break
-
-    if not bench_instance:
-        if verbose:
-            stderr_console.print(
-                f"[yellow]Warning:[/yellow] Bench at {bench_path} not found in cache."
-            )
-        return []
-
-    available_apps = set(bench_instance.get("available_apps", []))
-
-    # Read site's apps.json
-    apps_json_path = f"{bench_path}/sites/{site}/apps.json"
-    quoted_path = shlex.quote(apps_json_path)
-    exit_code, output = frappe_container.exec_run(f"sh -c 'cat {quoted_path}'")
-
+    # Apps physically present in the bench (its apps/ directory), read live.
+    quoted_apps_dir = shlex.quote(f"{bench_path}/apps")
+    exit_code, output = frappe_container.exec_run(["sh", "-c", f"ls -1 {quoted_apps_dir}"])
     if exit_code != 0:
         if verbose:
             stderr_console.print(
-                f"[yellow]Warning:[/yellow] Could not read apps.json for site {site}"
+                f"[yellow]Warning:[/yellow] Could not list apps in {bench_path}/apps."
+            )
+        return []
+    available_apps = {
+        a.strip() for a in output.decode("utf-8", errors="replace").split("\n") if a.strip()
+    }
+
+    # Apps the backup needs (from its own dump).
+    backup_apps = _read_backup_installed_apps(frappe_container, backup_db_path, verbose)
+    if backup_apps is None:
+        # Could not read the backup's app list -> fail safe, do not warn.
+        if verbose:
+            stderr_console.print(
+                "[yellow]Warning:[/yellow] Could not read the backup's installed apps; "
+                "skipping the missing-apps check."
             )
         return []
 
-    try:
-        apps_data = json.loads(output.decode("utf-8"))
-    except (json.JSONDecodeError, UnicodeDecodeError) as e:
-        if verbose:
-            stderr_console.print(f"[yellow]Warning:[/yellow] Failed to parse apps.json: {e}")
-        return []
-
-    # Get list of apps from the site
-    site_apps = set(apps_data.keys())
-
-    # Find missing apps
-    missing_apps = site_apps - available_apps
-
+    missing_apps = backup_apps - available_apps
     return sorted(missing_apps)
 
 
@@ -692,6 +873,7 @@ def restore_receive_mode(
     no_recache: bool,
     verbose: bool,
     yes: bool = False,
+    no_migrate: bool = False,
 ):
     """
     Receive mode: Download backup from sendme and restore it.
@@ -706,6 +888,7 @@ def restore_receive_mode(
         no_recache: Skip re-caching before the missing-apps check
         verbose: Enable verbose output
         yes: Skip the destructive-restore confirmation (non-interactive)
+        no_migrate: Skip the post-restore ``bench migrate`` + instance restart
     """
     import subprocess
     import tempfile
@@ -787,10 +970,14 @@ def restore_receive_mode(
                 if verbose:
                     stderr_console.print(f"[dim]Inspect error: {e}[/dim]")
 
-    # Get site if not provided
+    # Get site if not provided. Resolve the default from EITHER
+    # common_site_config.json's default_site OR sites/currentsite.txt (a plain
+    # `bench use`d dev bench only has the latter).
     if not site:
         try:
-            default_site = db_utils.get_default_site(project_name, bench_path)
+            default_site = _resolve_default_site(
+                project_name, bench_path, frappe_container, verbose=verbose
+            )
         except typer.Exit:
             raise
         except Exception as e:
@@ -982,30 +1169,23 @@ def restore_receive_mode(
         console.print("[bold cyan]Starting restore process...[/bold cyan]")
         console.print()
 
-        # Get MariaDB credentials if not provided
-        if not mariadb_root_username:
-            mariadb_root_username = questionary.text("MariaDB root username:", default="root").ask()
-
-            if not mariadb_root_username:
-                stderr_console.print("[bold red]Error:[/bold red] MariaDB username is required")
-                raise typer.Exit(code=1)
-
-        if not mariadb_root_password:
-            mariadb_root_password = questionary.password("MariaDB root password:").ask()
-
-            if not mariadb_root_password:
-                stderr_console.print("[bold red]Error:[/bold red] MariaDB password is required")
-                raise typer.Exit(code=1)
+        # Resolve MariaDB credentials (interactive prompts or flags; a non-TTY
+        # without --mariadb-root-password refuses rather than proceeding empty).
+        mariadb_root_username, mariadb_root_password = _prompt_mariadb_credentials(
+            mariadb_root_username, mariadb_root_password
+        )
 
         # Check for missing apps before proceeding with restore
         console.print()
         show_tips = config_utils.get_show_tips()
         with TipSpinner("Checking for missing apps", console=stderr_console, enabled=show_tips):
+            # The downloaded backup is already copied into the container's backup
+            # dir; check the apps IT needs against this bench.
             missing_apps = check_missing_apps(
                 frappe_container,
                 project_name,
                 bench_path,
-                site,
+                f"{backup_dir}/{database_file.name}",
                 verbose=verbose,
                 no_recache=no_recache,
             )
@@ -1092,18 +1272,15 @@ def restore_receive_mode(
 
         # Build restore command. Secrets are passed via the environment (never on
         # the argv) so they do not appear in the container process list (M5).
+        #
+        # The database backup MUST be the FULL container path
+        # (``<backup_dir>/<file>``), not the bare filename: `bench restore` rejects
+        # a bare filename with "Invalid path <file>". The arg ORDER also mirrors the
+        # normal restore path exactly (db path, credentials, --force, then the file
+        # archives) so the two paths behave identically.
         restore_env: dict[str, str] = {}
-        cmd = f"bench --site {shlex.quote(site)} restore"
-        cmd += f" {shlex.quote(database_file.name)}"
-
-        if files_archive:
-            # Use full path to file in backup directory
-            files_path = f"{backup_dir}/{files_archive.name}"
-            cmd += f" --with-public-files {shlex.quote(files_path)}"
-        if private_files_archive:
-            # Use full path to file in backup directory
-            private_files_path = f"{backup_dir}/{private_files_archive.name}"
-            cmd += f" --with-private-files {shlex.quote(private_files_path)}"
+        database_path = f"{backup_dir}/{database_file.name}"
+        cmd = f"bench --site {shlex.quote(site)} restore {shlex.quote(database_path)}"
 
         cmd += f" --mariadb-root-username {shlex.quote(mariadb_root_username)}"
         restore_env["CWCLI_MARIADB_ROOT_PASSWORD"] = mariadb_root_password
@@ -1113,6 +1290,15 @@ def restore_receive_mode(
         if admin_password:
             restore_env["CWCLI_ADMIN_PASSWORD"] = admin_password
             cmd += ' --admin-password "$CWCLI_ADMIN_PASSWORD"'
+
+        if files_archive:
+            # Use full path to file in backup directory
+            files_path = f"{backup_dir}/{files_archive.name}"
+            cmd += f" --with-public-files {shlex.quote(files_path)}"
+        if private_files_archive:
+            # Use full path to file in backup directory
+            private_files_path = f"{backup_dir}/{private_files_archive.name}"
+            cmd += f" --with-private-files {shlex.quote(private_files_path)}"
 
         if verbose:
             # Secrets live in the environment, so the command itself is safe to print.
@@ -1194,6 +1380,15 @@ def restore_receive_mode(
                         stderr_console.print(
                             f"[yellow]Warning:[/yellow] Could not update encryption key: {e}"
                         )
+
+            # Migrate the restored DB to the code's schema, then restart the
+            # instance so it comes back up cleanly (skippable with --no-migrate).
+            if not no_migrate:
+                migrate_ok = _post_restore_migrate_and_restart(
+                    frappe_container, project_name, bench_path, site, verbose=verbose
+                )
+                if not migrate_ok:
+                    raise typer.Exit(code=1)
         else:
             stderr_console.print(
                 f"[bold red]✗[/bold red] Failed to restore backup to site '{site}'"
@@ -1272,6 +1467,13 @@ def restore(
         "Does not remove the sendme-ticket or MariaDB-credential prompts, and "
         "has no effect on the normal restore path.",
     ),
+    no_migrate: bool = typer.Option(
+        False,
+        "--no-migrate",
+        help="Skip the post-restore 'bench migrate' and instance restart. By "
+        "default a successful restore is followed by 'bench migrate' (to bring "
+        "the restored DB to the code's schema) and an instance restart.",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
 ):
     """
@@ -1324,6 +1526,7 @@ def restore(
                 no_recache,
                 verbose,
                 yes,
+                no_migrate,
             )
 
     # Ensure containers are running (needed for both normal restore and send mode)
@@ -1406,10 +1609,14 @@ def restore(
                 if verbose:
                     stderr_console.print(f"[dim]Inspect error: {e}[/dim]")
 
-    # Get default site if not provided
+    # Get default site if not provided. Resolve from EITHER
+    # common_site_config.json's default_site OR sites/currentsite.txt (a plain
+    # `bench use`d dev bench only has the latter).
     if not site:
         try:
-            default_site = db_utils.get_default_site(project_name, bench_path)
+            default_site = _resolve_default_site(
+                project_name, bench_path, frappe_container, verbose=verbose
+            )
         except typer.Exit:
             raise
         except Exception as e:
@@ -1506,13 +1713,20 @@ def restore(
             no_recache,
             verbose,
             yes,
+            no_migrate,
         )
 
-    # Check for missing apps before proceeding with restore
+    # Check for missing apps before proceeding with restore: does the SELECTED
+    # backup need apps this bench does not physically have?
     console.print()
     with TipSpinner("Checking for missing apps", console=stderr_console, enabled=show_tips):
         missing_apps = check_missing_apps(
-            frappe_container, project_name, bench_path, site, verbose=verbose, no_recache=no_recache
+            frappe_container,
+            project_name,
+            bench_path,
+            selected_backup["database"]["full_path"],
+            verbose=verbose,
+            no_recache=no_recache,
         )
 
     if missing_apps:
@@ -1570,29 +1784,23 @@ def restore(
         console.print("[yellow]Restore cancelled.[/yellow]")
         raise typer.Exit(code=0)
 
-    # Prompt for MariaDB password if not provided
-    if not mariadb_root_password:
-        try:
-            mariadb_root_password = questionary.password("MariaDB root password:").ask()
-        except (KeyboardInterrupt, EOFError):
-            console.print("\n[yellow]Restore cancelled.[/yellow]")
-            raise typer.Exit(code=0) from None
+    # Resolve MariaDB credentials AFTER the confirm. Interactive: prompt for the
+    # username (default root) and password, actually collecting input; the username
+    # prompt was previously missing entirely and the password was never collected.
+    # Non-interactive: use the --mariadb-root-* flags; a non-TTY without a password
+    # refuses rather than proceeding empty.
+    mariadb_root_username, mariadb_root_password = _prompt_mariadb_credentials(
+        mariadb_root_username, mariadb_root_password
+    )
 
-        if not mariadb_root_password:
-            stderr_console.print("[bold red]Error:[/bold red] Password cannot be empty.")
-            raise typer.Exit(code=1)
-
-    # Validate mariadb_root_username if provided
-    if mariadb_root_username:
-        if not mariadb_root_username.strip():
-            stderr_console.print("[bold red]Error:[/bold red] MariaDB username cannot be empty.")
-            raise typer.Exit(code=1)
-        if any(char in mariadb_root_username for char in invalid_chars):
-            stderr_console.print(
-                "[bold red]Error:[/bold red] Invalid MariaDB username. "
-                "Username cannot contain special shell characters."
-            )
-            raise typer.Exit(code=1)
+    # Defense-in-depth: reject a username with shell-special characters (it is also
+    # shlex-quoted below, so this can never inject - it just fails fast on a typo).
+    if any(char in mariadb_root_username for char in invalid_chars):
+        stderr_console.print(
+            "[bold red]Error:[/bold red] Invalid MariaDB username. "
+            "Username cannot contain special shell characters."
+        )
+        raise typer.Exit(code=1)
 
     # Build restore command
     backup_file = selected_backup["database"]["full_path"]
@@ -1614,12 +1822,8 @@ def restore(
     restore_env: dict[str, str] = {}
     cmd = f"bench --site {shlex.quote(site)} restore {shlex.quote(backup_file)}"
 
-    # Add database credentials
-    if mariadb_root_username:
-        cmd += f" --mariadb-root-username {shlex.quote(mariadb_root_username)}"
-    else:
-        # Default to root if not specified
-        cmd += " --mariadb-root-username root"
+    # Add database credentials (username is always resolved - defaults to root).
+    cmd += f" --mariadb-root-username {shlex.quote(mariadb_root_username)}"
 
     restore_env["CWCLI_MARIADB_ROOT_PASSWORD"] = mariadb_root_password
     cmd += ' --mariadb-root-password "$CWCLI_MARIADB_ROOT_PASSWORD"'
@@ -1727,6 +1931,15 @@ def restore(
                     stderr_console.print(
                         f"[yellow]Warning:[/yellow] Failed to update encryption_key: {e}"
                     )
+
+        # Migrate the restored DB to the code's schema, then restart the instance
+        # so it comes back up cleanly (skippable with --no-migrate).
+        if not no_migrate:
+            migrate_ok = _post_restore_migrate_and_restart(
+                frappe_container, project_name, bench_path, site, verbose=verbose
+            )
+            if not migrate_ok:
+                raise typer.Exit(code=1)
     else:
         stderr_console.print(f"[bold red]✗[/bold red] Failed to restore site '{site}'")
         stderr_console.print()

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -894,7 +894,9 @@ def restore_receive_mode(
         mariadb_root_username: Optional MariaDB username
         mariadb_root_password: Optional MariaDB password
         admin_password: Optional admin password
-        no_recache: Skip re-caching before the missing-apps check
+        no_recache: Deprecated no-op (the missing-apps check reads everything
+            live from the bench and the backup dump; retained for backward
+            compatibility with the ``--no-recache`` flag)
         verbose: Enable verbose output
         yes: Skip the destructive-restore confirmation (non-interactive)
         no_migrate: Skip the post-restore ``bench migrate`` + instance restart
@@ -1424,7 +1426,8 @@ def restore(
         None,
         "--site",
         "-s",
-        help="Site name to restore. If not provided, uses the default site from common_site_config.",
+        help="Site name to restore. If not provided, uses the default site "
+        "(from common_site_config.json's default_site or sites/currentsite.txt).",
         autocompletion=complete_site_names,
     ),
     bench: str = typer.Option(
@@ -1495,7 +1498,11 @@ def restore(
     presents them in an interactive menu grouped by the target site, and
     executes the restore using 'bench restore'.
 
-    If --site is not provided, the default site from common_site_config.json will be used.
+    If --site is not provided, the default site is used, resolved from either
+    common_site_config.json's `default_site` or sites/currentsite.txt.
+
+    After a successful restore, `bench migrate` is run and the instance is
+    restarted (skip with --no-migrate).
 
     Use --send to share a backup via P2P transfer, or --receive to restore from a remote backup.
 

--- a/src/caffeinated_whale_cli/commands/rm.py
+++ b/src/caffeinated_whale_cli/commands/rm.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import questionary
 import typer
 
-from ..utils import cache, db_utils
+from ..utils import bench_sites, cache, db_utils
 from ..utils.completion_utils import complete_project_names
 from ..utils.config_utils import PROJECTS_DIR
 from ..utils.console import console, stderr_console
@@ -81,54 +81,19 @@ def _is_valid_project_name(name: str) -> bool:
 
 def _list_sites(container, bench_path: str) -> list[str] | None:
     """
-    Return the real Frappe sites under ``{bench_path}/sites``.
+    Return the real Frappe sites under ``{bench_path}/sites`` (fail-safe).
 
-    A bench ``sites/`` directory holds more than sites: ``apps.txt``,
-    ``apps.json``, ``assets``, ``common_site_config.json``, ``currentsite.txt``
-    (written by ``bench use``), lock files, and so on. A real site is a directory
-    that contains a ``site_config.json``, so detect sites by probing for that file
-    rather than denylisting known non-site names - a denylist can never be
-    complete, and any unlisted entry (e.g. ``currentsite.txt``) would be mistaken
-    for a site, fail its ``bench backup``, and wrongly block removal.
-
-    Detection is deliberately FAIL-SAFE: an entry is excluded only when we can
-    positively confirm it is not a site - a non-directory, or a readable directory
-    with no ``site_config.json``. Anything ambiguous (the probe erroring, an
-    unreadable directory, or unexpected output) is treated as a real site that
-    must be backed up, so a transiently unreadable/erroring ``site_config.json``
-    can never let a site's volume be deleted with no backup. This keeps C1's
-    guarantee fail-closed under ambiguity: worst case it blocks a delete (which
-    ``--no-backup`` can override), never loses data.
+    Thin wrapper over the canonical :func:`bench_sites.list_sites` so ``rm`` and
+    ``inspect`` share one site-detection implementation. A real site is a
+    directory containing a ``site_config.json``; a stray entry like
+    ``currentsite.txt`` is never a site. Detection is fail-safe (anything
+    ambiguous is treated as a real site) so ``rm`` never deletes a site's volume
+    without first backing it up. See :mod:`..utils.bench_sites`.
 
     Returns the list of site names (possibly empty), or ``None`` if the sites
     directory itself could not be listed.
     """
-    exit_code, output = container.exec_run(f"ls -1 {bench_path}/sites")
-    if exit_code != 0:
-        return None
-
-    sites: list[str] = []
-    for entry in output.decode("utf-8").split("\n"):
-        entry = entry.strip()
-        if not entry:
-            continue
-        entry_dir = f"{bench_path}/sites/{entry}"
-        # One shell probe with three positive verdicts: SITE (has
-        # site_config.json), NOTASITE (not a dir, or a readable dir with no
-        # config), AMBIGUOUS (dir exists but is unreadable so we cannot confirm).
-        probe = (
-            f'sh -c \'if [ ! -d "{entry_dir}" ]; then echo NOTASITE; '
-            f'elif [ -f "{entry_dir}/site_config.json" ]; then echo SITE; '
-            f'elif [ -r "{entry_dir}" ]; then echo NOTASITE; '
-            f"else echo AMBIGUOUS; fi'"
-        )
-        probe_code, probe_out = container.exec_run(probe)
-        verdict = probe_out.decode("utf-8").strip() if probe_code == 0 else ""
-        # Exclude ONLY on a positive NOTASITE. SITE, AMBIGUOUS, an unexpected
-        # token, empty output, or a non-zero probe exit all fail closed -> site.
-        if verdict != "NOTASITE":
-            sites.append(entry)
-    return sites
+    return bench_sites.list_sites(container, bench_path)
 
 
 class _ChunkStreamReader(io.RawIOBase):

--- a/src/caffeinated_whale_cli/commands/start.py
+++ b/src/caffeinated_whale_cli/commands/start.py
@@ -223,7 +223,13 @@ def _check_port_conflicts(
 
 
 @handle_docker_errors
-def _start_project(project_name: str, verbose: bool = False, status=None, bench_selector=None):
+def _start_project(
+    project_name: str,
+    verbose: bool = False,
+    status=None,
+    bench_selector=None,
+    bench_path_override: str | None = None,
+):
     """
     The core logic for starting a single project's containers.
 
@@ -234,6 +240,13 @@ def _start_project(project_name: str, verbose: bool = False, status=None, bench_
         project_name: The name of the docker-compose project.
         verbose: Enable verbose output.
         status: Optional rich status object for progress updates.
+        bench_selector: Optional ``--bench`` selector to pick which bench runs
+            ``bench start`` (resolved against the cache, ``on_ambiguous="first"``).
+        bench_path_override: Optional explicit bench path used VERBATIM, skipping
+            the ``resolve_bench_path`` guessing entirely. Callers that already know
+            the exact bench (e.g. the post-restore restart, which must restart the
+            SAME bench it just migrated) pass it so a multi-bench project never
+            falls back to the first sorted bench.
     """
     containers = get_project_containers(project_name)
 
@@ -263,14 +276,21 @@ def _start_project(project_name: str, verbose: bool = False, status=None, bench_
         )
         return
 
-    # Resolve which bench to run `bench start` in. Unlike the data commands, `start`
-    # KEEPS WORKING on a multi-bench project when no --bench is given: it starts the
-    # first sorted bench and prints a note listing the others (on_ambiguous="first").
+    # Resolve which bench to run `bench start` in. An explicit bench_path_override
+    # is used VERBATIM (the caller already knows the exact bench - e.g. the
+    # post-restore restart must restart the SAME bench it just migrated, never the
+    # first sorted one). Otherwise, unlike the data commands, `start` KEEPS WORKING
+    # on a multi-bench project when no --bench is given: it starts the first sorted
+    # bench and prints a note listing the others (on_ambiguous="first").
     from .utils import resolve_bench_path
 
-    bench_path = resolve_bench_path(
-        project_name, bench_selector, None, verbose=verbose, on_ambiguous="first"
-    )
+    bench_path: str | None
+    if bench_path_override:
+        bench_path = bench_path_override
+    else:
+        bench_path = resolve_bench_path(
+            project_name, bench_selector, None, verbose=verbose, on_ambiguous="first"
+        )
 
     if not bench_path:
         # No cache found, run inspect

--- a/src/caffeinated_whale_cli/commands/unlock.py
+++ b/src/caffeinated_whale_cli/commands/unlock.py
@@ -18,7 +18,8 @@ def unlock(
         None,
         "--site",
         "-s",
-        help="Site name to unlock. If not provided, uses the default site from common_site_config.",
+        help="Site name to unlock. If not provided, uses the default site "
+        "(from common_site_config.json's default_site or sites/currentsite.txt).",
         autocompletion=complete_site_names,
     ),
     bench: str = typer.Option(
@@ -43,7 +44,8 @@ def unlock(
     This command removes the {bench_path}/sites/{site_name}/locks directory,
     which can help resolve issues when a site is stuck in a locked state.
 
-    If --site is not provided, the default site from common_site_config.json will be used.
+    If --site is not provided, the default site is used, resolved from either
+    common_site_config.json's `default_site` or sites/currentsite.txt.
 
     Examples:
         cwcli unlock my-project --site example.com

--- a/src/caffeinated_whale_cli/utils/bench_sites.py
+++ b/src/caffeinated_whale_cli/utils/bench_sites.py
@@ -1,0 +1,88 @@
+"""Canonical Frappe site detection inside a bench container.
+
+A bench ``sites/`` directory holds far more than sites: ``apps.txt``,
+``apps.json``, ``assets``, ``common_site_config.json``, ``currentsite.txt``
+(written by ``bench use``), lock files, and so on. A real Frappe site is a
+*directory* that contains a ``site_config.json``. Detecting sites by that shape -
+rather than denylisting known non-site names - is the only correct approach: a
+denylist can never be complete, so any unlisted stray entry (``currentsite.txt``
+is the classic one) gets mistaken for a site.
+
+This module is the single home for that logic so ``rm`` (which must back up every
+real site before deletion) and ``inspect`` (which must not display a stray file as
+a site) share one implementation instead of drifting apart.
+
+``list_sites`` is deliberately FAIL-SAFE: an entry is excluded only when we can
+positively confirm it is not a site (a non-directory, or a readable directory with
+no ``site_config.json``). Anything ambiguous - the probe erroring, an unreadable
+directory, or unexpected output - is treated as a real site. For ``rm`` this keeps
+data safe under ambiguity (worst case it blocks a delete, never loses data); for
+``inspect`` it errs toward showing a possible site rather than hiding one.
+
+``read_current_site`` reads ``sites/currentsite.txt``, the pointer ``bench use``
+writes to record the default site. It is a *pointer*, not a site, so it is never
+returned by ``list_sites``; it is the second place (besides
+``common_site_config.json``'s ``default_site``) a bench records which site is the
+default.
+"""
+
+from __future__ import annotations
+
+
+def list_sites(container, bench_path: str, verbose: bool = False) -> list[str] | None:
+    """Return the real Frappe sites under ``{bench_path}/sites``.
+
+    A real site is a directory containing a ``site_config.json``; see the module
+    docstring for the fail-safe classification rules.
+
+    Returns the list of site names (possibly empty), or ``None`` if the sites
+    directory itself could not be listed (a Docker/permission error), so callers
+    can tell "no sites" apart from "could not look".
+    """
+    exit_code, output = container.exec_run(f"ls -1 {bench_path}/sites")
+    if exit_code != 0:
+        return None
+
+    sites: list[str] = []
+    for entry in output.decode("utf-8").split("\n"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        entry_dir = f"{bench_path}/sites/{entry}"
+        # One shell probe with three positive verdicts: SITE (has
+        # site_config.json), NOTASITE (not a dir, or a readable dir with no
+        # config), AMBIGUOUS (dir exists but is unreadable so we cannot confirm).
+        probe = (
+            f'sh -c \'if [ ! -d "{entry_dir}" ]; then echo NOTASITE; '
+            f'elif [ -f "{entry_dir}/site_config.json" ]; then echo SITE; '
+            f'elif [ -r "{entry_dir}" ]; then echo NOTASITE; '
+            f"else echo AMBIGUOUS; fi'"
+        )
+        probe_code, probe_out = container.exec_run(probe)
+        verdict = probe_out.decode("utf-8").strip() if probe_code == 0 else ""
+        # Exclude ONLY on a positive NOTASITE. SITE, AMBIGUOUS, an unexpected
+        # token, empty output, or a non-zero probe exit all fail closed -> site.
+        if verdict != "NOTASITE":
+            sites.append(entry)
+    return sites
+
+
+def read_current_site(container, bench_path: str, verbose: bool = False) -> str | None:
+    """Return the default site recorded in ``{bench_path}/sites/currentsite.txt``.
+
+    ``currentsite.txt`` holds exactly the default site name (written by
+    ``bench use``). It is a pointer to the default site, not a site itself, so it
+    is the fallback source for the default site when ``common_site_config.json``
+    has no ``default_site`` key.
+
+    Reads FAIL SAFE: a missing/unreadable/empty file yields ``None`` (never an
+    error), and the content is stripped of surrounding whitespace/newlines.
+    """
+    exit_code, output = container.exec_run(f"cat {bench_path}/sites/currentsite.txt")
+    if exit_code != 0:
+        return None
+    try:
+        name = output.decode("utf-8").strip()
+    except (UnicodeDecodeError, AttributeError):
+        return None
+    return name or None

--- a/src/caffeinated_whale_cli/utils/bench_sites.py
+++ b/src/caffeinated_whale_cli/utils/bench_sites.py
@@ -28,6 +28,8 @@ default.
 
 from __future__ import annotations
 
+import shlex
+
 
 def list_sites(container, bench_path: str, verbose: bool = False) -> list[str] | None:
     """Return the real Frappe sites under ``{bench_path}/sites``.
@@ -42,24 +44,41 @@ def list_sites(container, bench_path: str, verbose: bool = False) -> list[str] |
     exit_code, output = container.exec_run(f"ls -1 {bench_path}/sites")
     if exit_code != 0:
         return None
+    try:
+        listing = output.decode("utf-8")
+    except (UnicodeDecodeError, AttributeError):
+        # A non-UTF-8 listing must fail safe (like read_current_site), never raise.
+        return None
+
+    # One shell probe with three positive verdicts: SITE (has site_config.json),
+    # NOTASITE (not a dir, or a readable dir with no config), AMBIGUOUS (dir exists
+    # but is unreadable so we cannot confirm). The entry path is passed as the
+    # positional argument ``$1`` (referenced only via ``$1`` in the script, never
+    # interpolated into it) and shlex-quoted, so a directory name containing quotes
+    # or shell metacharacters can neither break the quoting (defeating the fail-safe
+    # promise by raising) nor inject. docker-py shlex-splits the string command, so
+    # ``sh -c <script> sh <entry_dir>`` runs the script with ``$1 = entry_dir``.
+    probe_script = (
+        'if [ ! -d "$1" ]; then echo NOTASITE; '
+        'elif [ -f "$1/site_config.json" ]; then echo SITE; '
+        'elif [ -r "$1" ]; then echo NOTASITE; '
+        "else echo AMBIGUOUS; fi"
+    )
+    quoted_script = shlex.quote(probe_script)
 
     sites: list[str] = []
-    for entry in output.decode("utf-8").split("\n"):
+    for entry in listing.split("\n"):
         entry = entry.strip()
         if not entry:
             continue
         entry_dir = f"{bench_path}/sites/{entry}"
-        # One shell probe with three positive verdicts: SITE (has
-        # site_config.json), NOTASITE (not a dir, or a readable dir with no
-        # config), AMBIGUOUS (dir exists but is unreadable so we cannot confirm).
-        probe = (
-            f'sh -c \'if [ ! -d "{entry_dir}" ]; then echo NOTASITE; '
-            f'elif [ -f "{entry_dir}/site_config.json" ]; then echo SITE; '
-            f'elif [ -r "{entry_dir}" ]; then echo NOTASITE; '
-            f"else echo AMBIGUOUS; fi'"
-        )
+        probe = f"sh -c {quoted_script} sh {shlex.quote(entry_dir)}"
         probe_code, probe_out = container.exec_run(probe)
-        verdict = probe_out.decode("utf-8").strip() if probe_code == 0 else ""
+        try:
+            verdict = probe_out.decode("utf-8").strip() if probe_code == 0 else ""
+        except (UnicodeDecodeError, AttributeError):
+            # Can't read the verdict -> not a positive NOTASITE -> fail safe (site).
+            verdict = ""
         # Exclude ONLY on a positive NOTASITE. SITE, AMBIGUOUS, an unexpected
         # token, empty output, or a non-zero probe exit all fail closed -> site.
         if verdict != "NOTASITE":

--- a/src/caffeinated_whale_cli/utils/db_utils.py
+++ b/src/caffeinated_whale_cli/utils/db_utils.py
@@ -49,6 +49,13 @@ class Bench(BaseModel):
     # was added after the initial schema, so initialize_database() migrates old
     # caches in place (see _migrate_bench_label_column).
     label = CharField(null=True)
+    # Default site recorded in this bench's sites/currentsite.txt (written by
+    # `bench use`). A bench records its default site in EITHER
+    # common_site_config.json's `default_site` OR currentsite.txt; persisting the
+    # latter lets get_default_site() resolve the default even when common config
+    # has no `default_site` key. NULL when currentsite.txt is absent/unreadable.
+    # Added after the initial schema (see _migrate_bench_current_site_column).
+    current_site = CharField(null=True)
 
 
 class Site(BaseModel):
@@ -189,6 +196,25 @@ def _migrate_bench_label_column():
         print(f"Warning: could not migrate bench.label column: {e}", file=sys.stderr)
 
 
+def _migrate_bench_current_site_column():
+    """Add the ``bench.current_site`` column to pre-existing caches that lack it.
+
+    Same idempotent, in-place ``ALTER TABLE`` pattern as
+    :func:`_migrate_bench_label_column` (``create_tables(safe=True)`` never adds a
+    column to an existing table). Old caches get NULL, so they keep working and
+    ``get_default_site`` falls back to ``common_site_config``'s ``default_site``
+    until the next full inspect repopulates ``current_site`` from currentsite.txt.
+    """
+    try:
+        columns = {row[1] for row in db.execute_sql("PRAGMA table_info(bench)").fetchall()}
+        if "bench" not in db.get_tables():
+            return
+        if "current_site" not in columns:
+            db.execute_sql("ALTER TABLE bench ADD COLUMN current_site VARCHAR")
+    except Exception as e:  # pragma: no cover - defensive; never block on migration
+        print(f"Warning: could not migrate bench.current_site column: {e}", file=sys.stderr)
+
+
 def initialize_database():
     if db.is_closed():
         db.connect()
@@ -201,6 +227,9 @@ def initialize_database():
     # feature. Must run after create_tables (so the table exists) and before any
     # read/write that references bench.label.
     _migrate_bench_label_column()
+    # Same for the current_site column (added with the currentsite.txt default-site
+    # resolution). Idempotent; NULL on old caches.
+    _migrate_bench_current_site_column()
     # Secure the database file with restrictive permissions
     _set_secure_db_permissions()
 
@@ -232,10 +261,14 @@ def cache_project_data(project_name, bench_instances_data):
         # Persist the user label when present. An empty string is normalized to
         # NULL so "no label" has a single representation in the DB.
         label_value = bench_data.get("label") or None
+        # Normalize empty/missing currentsite pointer to NULL for a single
+        # "no default recorded" representation.
+        current_site_value = bench_data.get("current_site") or None
         bench = Bench.create(
             project=project,
             path=bench_data["path"],
             label=label_value,
+            current_site=current_site_value,
         )
 
         # Store common site config if present (including empty configs)
@@ -340,6 +373,11 @@ def get_cached_project_data(project_name):
             # common_site_config is included. Absent key == no user label.
             if bench.label:
                 bench_data["label"] = bench.label
+
+            # Surface the default-site pointer (from currentsite.txt) when present,
+            # so cache-served default-site resolution and the "(default)" marker work.
+            if bench.current_site:
+                bench_data["current_site"] = bench.current_site
 
             if common_config is not None:
                 bench_data["common_site_config"] = common_config
@@ -505,9 +543,40 @@ def get_all_site_configs(project_name: str, bench_path: str | None = None) -> di
         return {}
 
 
+def get_current_site(project_name: str, bench_path: str | None = None) -> str | None:
+    """
+    Get the default-site pointer (from currentsite.txt) cached for a project/bench.
+
+    This is the fallback source for the default site when
+    ``common_site_config.json`` has no ``default_site`` key. Returns the first
+    non-empty ``current_site`` found (scoped to ``bench_path`` when given).
+    """
+    initialize_database()
+    try:
+        project = Project.get(Project.name == project_name)
+
+        if bench_path:
+            bench = Bench.get((Bench.project == project) & (Bench.path == bench_path))
+            current: str | None = bench.current_site
+            return current or None
+
+        for bench in project.benches:
+            current = bench.current_site
+            if current:
+                return current
+        return None
+    except (Project.DoesNotExist, Bench.DoesNotExist):
+        return None
+
+
 def get_default_site(project_name: str, bench_path: str | None = None) -> str | None:
     """
-    Get the default site for a project from the common_site_config.
+    Get the default site for a project/bench.
+
+    A bench records its default site in EITHER ``common_site_config.json``'s
+    ``default_site`` OR ``sites/currentsite.txt`` (the pointer ``bench use``
+    writes). Resolve from the former first, then fall back to the latter (cached
+    as ``current_site``) - a plain ``bench use``d dev bench only has the pointer.
 
     Args:
         project_name: Name of the project
@@ -517,6 +586,6 @@ def get_default_site(project_name: str, bench_path: str | None = None) -> str | 
         Default site name or None if not found
     """
     common_config = get_common_site_config(project_name, bench_path)
-    if common_config:
+    if common_config and common_config.get("default_site"):
         return common_config.get("default_site")
-    return None
+    return get_current_site(project_name, bench_path)

--- a/tests/test_inspect_partial_refresh.py
+++ b/tests/test_inspect_partial_refresh.py
@@ -29,6 +29,7 @@ return, and ``open --app`` reuses the T2 pass in-memory without writing the cach
 """
 
 import json
+import shlex
 from unittest.mock import MagicMock
 
 import pytest
@@ -68,6 +69,14 @@ class FakeFrappeContainer:
         self.calls.append(cmd)
         b = self.bench_path
 
+        # Fail-safe site-classification probe (bench_sites.list_sites). The entry
+        # dir is passed as the positional arg (the last shlex token), never
+        # interpolated; a real site echoes SITE, a stray non-site (apps.txt,
+        # common_site_config.json, currentsite.txt) echoes NOTASITE.
+        if cmd.startswith("sh -c '") and "echo SITE" in cmd and "site_config.json" in cmd:
+            entry = shlex.split(cmd)[-1].rsplit("/", 1)[-1]
+            return (0, b"SITE\n") if entry in self.sites else (0, b"NOTASITE\n")
+
         if "test -d" in cmd:  # _is_bench_directory
             return (0, b"")
         if cmd.startswith("find "):  # _find_bench_instances (full inspect only)
@@ -78,16 +87,15 @@ class FakeFrappeContainer:
         if cmd == f"ls -1 {b}/apps":  # _get_available_apps (cheap)
             return (0, "\n".join(self.apps).encode())
         if cmd == f"ls -1 {b}/sites":  # _get_sites (cheap) lists real + stray entries
-            listing = ["apps.txt", "common_site_config.json", *self.sites.keys()]
+            # Keep the stray currentsite.txt in the listing so the partial-refresh
+            # regression (a stray file must NOT be treated as a site) stays covered.
+            listing = [
+                "apps.txt",
+                "common_site_config.json",
+                "currentsite.txt",
+                *self.sites.keys(),
+            ]
             return (0, "\n".join(listing).encode())
-        # Fail-safe site-classification probe (bench_sites.list_sites): a real site
-        # (has site_config.json) echoes SITE; a stray non-site (apps.txt,
-        # common_site_config.json) echoes NOTASITE.
-        if cmd.startswith("sh -c '") and "echo SITE" in cmd and "site_config.json" in cmd:
-            for site in self.sites:
-                if f"/sites/{site}/site_config.json" in cmd:
-                    return (0, b"SITE\n")
-            return (0, b"NOTASITE\n")
         if cmd == f"cat {b}/sites/common_site_config.json":
             return (0, json.dumps({"default_site": next(iter(self.sites), "")}).encode())
         if cmd.startswith(f"cat {b}/sites/") and cmd.endswith("/site_config.json"):

--- a/tests/test_inspect_partial_refresh.py
+++ b/tests/test_inspect_partial_refresh.py
@@ -77,9 +77,17 @@ class FakeFrappeContainer:
             return (0, b"")
         if cmd == f"ls -1 {b}/apps":  # _get_available_apps (cheap)
             return (0, "\n".join(self.apps).encode())
-        if cmd == f"ls -1 {b}/sites":  # _get_sites (cheap)
+        if cmd == f"ls -1 {b}/sites":  # _get_sites (cheap) lists real + stray entries
             listing = ["apps.txt", "common_site_config.json", *self.sites.keys()]
             return (0, "\n".join(listing).encode())
+        # Fail-safe site-classification probe (bench_sites.list_sites): a real site
+        # (has site_config.json) echoes SITE; a stray non-site (apps.txt,
+        # common_site_config.json) echoes NOTASITE.
+        if cmd.startswith("sh -c '") and "echo SITE" in cmd and "site_config.json" in cmd:
+            for site in self.sites:
+                if f"/sites/{site}/site_config.json" in cmd:
+                    return (0, b"SITE\n")
+            return (0, b"NOTASITE\n")
         if cmd == f"cat {b}/sites/common_site_config.json":
             return (0, json.dumps({"default_site": next(iter(self.sites), "")}).encode())
         if cmd.startswith(f"cat {b}/sites/") and cmd.endswith("/site_config.json"):

--- a/tests/test_restore_inspect_fixes.py
+++ b/tests/test_restore_inspect_fixes.py
@@ -18,6 +18,7 @@ Each class pins one of the bugs the captain hit on a live 0.33.0 session:
 6. After a successful restore, cwcli runs ``bench migrate`` then restarts.
 """
 
+import shlex
 from types import SimpleNamespace
 
 import pytest
@@ -92,16 +93,15 @@ class RecordingContainer:
         if cmd_str == f"ls -1 {BENCH_PATH}/sites":
             listing = list(self.sites.keys()) + self.stray
             return (0, "\n".join(listing).encode())
-        # Fail-safe site classification probe.
+        # Fail-safe site classification probe: the entry dir is the positional arg
+        # (the last shlex token), never interpolated into the script.
         if (
             cmd_str.startswith("sh -c '")
             and "echo SITE" in cmd_str
             and "site_config.json" in cmd_str
         ):
-            for site in self.sites:
-                if f"/sites/{site}/site_config.json" in cmd_str:
-                    return (0, b"SITE\n")
-            return (0, b"NOTASITE\n")
+            entry = shlex.split(cmd_str)[-1].rsplit("/", 1)[-1]
+            return (0, b"SITE\n") if entry in self.sites else (0, b"NOTASITE\n")
         # currentsite.txt read.
         if cmd_str == f"cat {BENCH_PATH}/sites/currentsite.txt":
             if self.currentsite is None:
@@ -536,5 +536,24 @@ class TestPostRestoreMigrateAndRestart:
         )
         # A failed migrate does not abort the restart, but is reported as False so
         # the caller can exit non-zero.
+        assert ok is False
+        assert calls["start"] == ["proj"]
+
+    def test_migrate_exec_exception_still_restarts_and_returns_false(self, monkeypatch):
+        # A Docker/API EXCEPTION from exec_run (not just a non-zero exit) must be
+        # treated as a failed-but-reported migrate and MUST still restart.
+        calls = self._patch(monkeypatch)
+
+        class RaisingMigrate(RecordingContainer):
+            def exec_run(self, cmd, workdir=None, environment=None):
+                s = " ".join(cmd) if isinstance(cmd, (list, tuple)) else str(cmd)
+                if "migrate" in s:
+                    raise RuntimeError("docker exec boom")
+                return super().exec_run(cmd, workdir=workdir, environment=environment)
+
+        container = RaisingMigrate(sites={SITE: ["frappe"]})
+        ok = restore_mod._post_restore_migrate_and_restart(
+            container, "proj", BENCH_PATH, SITE, verbose=False
+        )
         assert ok is False
         assert calls["start"] == ["proj"]

--- a/tests/test_restore_inspect_fixes.py
+++ b/tests/test_restore_inspect_fixes.py
@@ -287,6 +287,31 @@ class TestMariadbCredentialModes:
         user, pw = restore_mod._prompt_mariadb_credentials(None, "flagpw")
         assert user == "root" and pw == "flagpw"
 
+    def test_stdin_is_flushed_before_password_prompt(self, monkeypatch):
+        # Root-cause guard: the stray Enter left by a preceding confirm is drained
+        # right before the password prompt so it cannot be read as an empty
+        # password. This must hold even when --mariadb-root-username is passed (the
+        # username prompt is skipped), which was the reintroduced-bug scenario.
+        self._tty(monkeypatch, True)
+        events = []
+        monkeypatch.setattr(restore_mod, "_flush_stdin_buffer", lambda: events.append("flush"))
+
+        def fake_password(msg):
+            events.append("password")
+            return SimpleNamespace(ask=lambda: "s3cret")
+
+        monkeypatch.setattr(restore_mod.questionary, "password", fake_password)
+        # Username supplied by flag -> username prompt skipped; the flush must still
+        # run and it must run BEFORE the password prompt.
+        user, pw = restore_mod._prompt_mariadb_credentials("root", None)
+        assert (user, pw) == ("root", "s3cret")
+        assert events == ["flush", "password"]
+
+    def test_flush_stdin_buffer_is_noop_off_tty(self, monkeypatch):
+        # A non-TTY (or missing termios) must be a safe no-op, never raising.
+        monkeypatch.setattr(restore_mod.sys.stdin, "isatty", lambda: False)
+        restore_mod._flush_stdin_buffer()  # does not raise
+
 
 # ===================================================== #3 site detection (inspect)
 
@@ -429,23 +454,17 @@ class TestMissingAppsCheck:
     """#5: compare the apps the BACKUP needs (from its dump) against the bench's
     available apps - the captain's "the backup uses apps the bench does NOT have"."""
 
-    def _no_recache(self, monkeypatch):
-        monkeypatch.setattr(restore_mod.cache, "recache_project", lambda *a, **k: True)
-
-    def test_warns_when_backup_app_absent_from_bench(self, monkeypatch):
-        self._no_recache(monkeypatch)
+    def test_warns_when_backup_app_absent_from_bench(self):
         # Backup was taken on a site with [frappe, widgets]; bench only has frappe.
         c = _AppsContainer(available=["frappe"], dump_apps=["frappe", "widgets"])
         missing = restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True)
         assert missing == ["widgets"]
 
-    def test_no_warning_when_all_present(self, monkeypatch):
-        self._no_recache(monkeypatch)
+    def test_no_warning_when_all_present(self):
         c = _AppsContainer(available=["frappe", "widgets"], dump_apps=["frappe", "widgets"])
         assert restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True) == []
 
-    def test_fail_safe_when_backup_apps_unreadable(self, monkeypatch):
-        self._no_recache(monkeypatch)
+    def test_fail_safe_when_backup_apps_unreadable(self):
         # Dump marker not found -> cannot tell -> no false warning.
         c = _AppsContainer(available=["frappe"], dump_apps=None)
         assert restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True) == []
@@ -462,7 +481,7 @@ class TestPostRestoreMigrateAndRestart:
     """#6: a successful restore is followed by bench migrate then an instance restart."""
 
     def _patch(self, monkeypatch):
-        calls = {"start": []}
+        calls = {"start": [], "start_kwargs": []}
         monkeypatch.setattr(restore_mod, "TipSpinner", _NullSpinner)
         monkeypatch.setattr(restore_mod.config_utils, "get_show_tips", lambda: False)
         monkeypatch.setattr(restore_mod.console, "print", lambda *a, **k: None)
@@ -471,6 +490,7 @@ class TestPostRestoreMigrateAndRestart:
 
         def fake_start(project_name, verbose=False, **k):
             calls["start"].append(project_name)
+            calls["start_kwargs"].append(k)
             return "/tmp/bench-proj.log"
 
         monkeypatch.setattr(start_mod, "_start_project", fake_start)
@@ -494,6 +514,19 @@ class TestPostRestoreMigrateAndRestart:
         assert migrates[0]["workdir"] == BENCH_PATH
         # ...then the instance was restarted.
         assert calls["start"] == ["proj"]
+
+    def test_restart_targets_the_restored_bench_not_the_first(self, monkeypatch):
+        # A multi-bench restore into a NON-first bench must restart THAT bench: the
+        # restored bench_path is threaded through as an explicit override so
+        # _start_project never falls back to resolve_bench_path's first-bench guess.
+        calls = self._patch(monkeypatch)
+        other_bench = "/workspace/second-bench"
+        container = RecordingContainer(sites={SITE: ["frappe"]}, migrate_exit=0)
+        restore_mod._post_restore_migrate_and_restart(
+            container, "proj", other_bench, SITE, verbose=False
+        )
+        assert calls["start"] == ["proj"]
+        assert calls["start_kwargs"][0].get("bench_path_override") == other_bench
 
     def test_migrate_failure_still_restarts_and_returns_false(self, monkeypatch):
         calls = self._patch(monkeypatch)

--- a/tests/test_restore_inspect_fixes.py
+++ b/tests/test_restore_inspect_fixes.py
@@ -287,30 +287,34 @@ class TestMariadbCredentialModes:
         user, pw = restore_mod._prompt_mariadb_credentials(None, "flagpw")
         assert user == "root" and pw == "flagpw"
 
-    def test_stdin_is_flushed_before_password_prompt(self, monkeypatch):
-        # Root-cause guard: the stray Enter left by a preceding confirm is drained
-        # right before the password prompt so it cannot be read as an empty
-        # password. This must hold even when --mariadb-root-username is passed (the
-        # username prompt is skipped), which was the reintroduced-bug scenario.
+    def test_password_prompt_collects_input_with_username_flag(self, monkeypatch):
+        # Root-cause guard for the reintroduced-bug scenario: with
+        # --mariadb-root-username supplied by flag the username prompt is skipped,
+        # yet the password prompt must still fire and collect the real password.
+        # (The stray-Enter-from-the-confirm problem is fixed at its root by
+        # auto_enter=False on the restore confirms - see the confirm guard below -
+        # so no stdin-flush helper is involved here.)
         self._tty(monkeypatch, True)
         events = []
-        monkeypatch.setattr(restore_mod, "_flush_stdin_buffer", lambda: events.append("flush"))
 
         def fake_password(msg):
             events.append("password")
             return SimpleNamespace(ask=lambda: "s3cret")
 
         monkeypatch.setattr(restore_mod.questionary, "password", fake_password)
-        # Username supplied by flag -> username prompt skipped; the flush must still
-        # run and it must run BEFORE the password prompt.
         user, pw = restore_mod._prompt_mariadb_credentials("root", None)
         assert (user, pw) == ("root", "s3cret")
-        assert events == ["flush", "password"]
+        assert events == ["password"]
 
-    def test_flush_stdin_buffer_is_noop_off_tty(self, monkeypatch):
-        # A non-TTY (or missing termios) must be a safe no-op, never raising.
-        monkeypatch.setattr(restore_mod.sys.stdin, "isatty", lambda: False)
-        restore_mod._flush_stdin_buffer()  # does not raise
+    def test_restore_confirms_disable_auto_enter(self):
+        # Root fix: every questionary.confirm in the restore flow must pass
+        # auto_enter=False so it consumes its own trailing Enter and cannot leave a
+        # stray keystroke for the following password prompt to swallow as empty.
+        import inspect
+
+        src = inspect.getsource(restore_mod)
+        assert src.count("questionary.confirm(") == 4
+        assert src.count("auto_enter=False") == 4
 
 
 # ===================================================== #3 site detection (inspect)

--- a/tests/test_restore_inspect_fixes.py
+++ b/tests/test_restore_inspect_fixes.py
@@ -1,0 +1,507 @@
+"""Regression tests for the six restore + inspect fixes (cwcli-restore-e2e-r6).
+
+Each class pins one of the bugs the captain hit on a live 0.33.0 session:
+
+1. ``--receive`` restore passed the BARE database filename to ``bench restore``
+   (rejected as "Invalid path"); it must use the full container path and mirror
+   the normal path's arg order.
+2. The normal path skipped the interactive MariaDB username prompt and never
+   collected the password; both modes (interactive prompt / non-interactive flag)
+   must work, and a non-TTY without a password must refuse.
+3. ``inspect`` treated ``currentsite.txt`` (a plain file) as a site; sites are
+   directories containing ``site_config.json`` only.
+4. The default site can live in ``currentsite.txt``, not only
+   ``common_site_config.json``'s ``default_site``.
+5. The missing-apps warning silently never fired (it read a per-site
+   ``apps.json`` Frappe does not write); it must compare the site's real
+   installed apps against the bench's available apps.
+6. After a successful restore, cwcli runs ``bench migrate`` then restarts.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import typer
+
+from caffeinated_whale_cli.commands import restore as restore_mod
+from caffeinated_whale_cli.utils import bench_sites, db_utils
+
+BENCH_PATH = "/workspace/frappe-bench"
+SITE = "development.localhost"
+
+
+# --------------------------------------------------------------------------- db
+
+
+@pytest.fixture()
+def temp_db(tmp_path, monkeypatch):
+    """Point the peewee cache at a throwaway SQLite file for the test's lifetime."""
+    orig_path = db_utils.DB_PATH
+    dbfile = tmp_path / "cache.db"
+    monkeypatch.setattr(db_utils, "DB_PATH", dbfile)
+    if not db_utils.db.is_closed():
+        db_utils.db.close()
+    db_utils.db.init(str(dbfile))
+    db_utils.initialize_database()
+    yield
+    if not db_utils.db.is_closed():
+        db_utils.db.close()
+    db_utils.db.init(str(orig_path))
+
+
+class _NullSpinner:
+    def __init__(self, *a, **k):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def update(self, *a, **k):
+        pass
+
+
+# ---------------------------------------------------------------- fake container
+
+
+class RecordingContainer:
+    """A frappe container stand-in that records every ``exec_run`` and answers the
+    filesystem probes the site/currentsite helpers issue.
+
+    ``sites`` maps a real site name -> its ``bench list-apps`` lines. Stray, non-site
+    entries in ``sites/`` (a file like ``currentsite.txt``) are listed by ``ls`` but
+    classified NOTASITE by the probe. ``currentsite`` is the currentsite.txt content.
+    """
+
+    def __init__(self, sites=None, stray=None, currentsite=None, migrate_exit=0):
+        self.sites = dict(sites or {})
+        self.stray = list(stray or [])
+        self.currentsite = currentsite
+        self.migrate_exit = migrate_exit
+        self.labels = {"com.docker.compose.service": "frappe"}
+        self.status = "running"
+        self.exec_calls: list[dict] = []
+
+    def exec_run(self, cmd, workdir=None, environment=None):
+        self.exec_calls.append({"cmd": cmd, "workdir": workdir, "environment": environment})
+        cmd_str = " ".join(cmd) if isinstance(cmd, (list, tuple)) else str(cmd)
+
+        # ls the sites dir: real sites + stray non-site entries.
+        if cmd_str == f"ls -1 {BENCH_PATH}/sites":
+            listing = list(self.sites.keys()) + self.stray
+            return (0, "\n".join(listing).encode())
+        # Fail-safe site classification probe.
+        if (
+            cmd_str.startswith("sh -c '")
+            and "echo SITE" in cmd_str
+            and "site_config.json" in cmd_str
+        ):
+            for site in self.sites:
+                if f"/sites/{site}/site_config.json" in cmd_str:
+                    return (0, b"SITE\n")
+            return (0, b"NOTASITE\n")
+        # currentsite.txt read.
+        if cmd_str == f"cat {BENCH_PATH}/sites/currentsite.txt":
+            if self.currentsite is None:
+                return (1, b"")
+            return (0, self.currentsite.encode())
+        # bench migrate.
+        if "migrate" in cmd_str:
+            return (self.migrate_exit, b"migrate output")
+        return (0, b"")
+
+    def put_archive(self, path, data):
+        # The receive flow streams each downloaded backup file into the container.
+        return True
+
+    def restore_calls(self):
+        return [
+            c
+            for c in self.exec_calls
+            if "restore"
+            in (" ".join(c["cmd"]) if isinstance(c["cmd"], (list, tuple)) else str(c["cmd"]))
+            and "--force"
+            in (" ".join(c["cmd"]) if isinstance(c["cmd"], (list, tuple)) else str(c["cmd"]))
+        ]
+
+
+# =========================================================== #1 receive full path
+
+
+class TestReceiveUsesFullDbPath:
+    """#1: receive-mode must pass the FULL container path, not the bare filename,
+    and mirror the normal path's arg order."""
+
+    def _run(self, monkeypatch, db_filename, files=None, private=None):
+        import subprocess
+        from pathlib import Path
+
+        container = RecordingContainer(sites={SITE: ["frappe 15.0.0 version-15"]})
+
+        def fake_sendme_run(cmd, cwd=None, capture_output=True, text=True):
+            for name in [db_filename] + (files or []) + (private or []):
+                Path(cwd).joinpath(name).write_text("DATA")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_sendme_run)
+        monkeypatch.setattr(restore_mod, "ensure_containers_running", lambda *a, **k: True)
+        monkeypatch.setattr(restore_mod, "get_project_containers", lambda name: [container])
+        monkeypatch.setattr(restore_mod, "get_sendme_command", lambda: "sendme")
+        monkeypatch.setattr(restore_mod, "check_missing_apps", lambda *a, **k: [])
+        monkeypatch.setattr(restore_mod, "TipSpinner", _NullSpinner)
+        monkeypatch.setattr(restore_mod.config_utils, "get_show_tips", lambda: False)
+        monkeypatch.setattr(
+            restore_mod.questionary,
+            "text",
+            lambda *a, **k: SimpleNamespace(ask=lambda: "ticket-abc"),
+        )
+        monkeypatch.setattr(restore_mod.console, "print", lambda *a, **k: None)
+        monkeypatch.setattr(restore_mod.stderr_console, "print", lambda *a, **k: None)
+
+        restore_mod.restore_receive_mode(
+            project_name="proj",
+            site=SITE,
+            bench_path=BENCH_PATH,
+            mariadb_root_username="root",
+            mariadb_root_password="pw",
+            admin_password=None,
+            no_recache=True,
+            verbose=False,
+            yes=True,
+            no_migrate=True,
+        )
+        return container
+
+    def test_db_arg_is_full_container_path_not_bare_filename(self, monkeypatch):
+        db = "20260704_173426-development_localhost-database.sql.gz"
+        container = self._run(monkeypatch, db)
+        calls = container.restore_calls()
+        assert len(calls) == 1
+        cmd = (
+            " ".join(calls[0]["cmd"])
+            if isinstance(calls[0]["cmd"], (list, tuple))
+            else calls[0]["cmd"]
+        )
+        # The bug: `restore <bare-filename>`. The fix: full path under backups dir.
+        full = f"{BENCH_PATH}/sites/{SITE}/private/backups/{db}"
+        assert f"restore {full}" in cmd
+        assert f"restore {db} " not in cmd  # never the bare filename
+
+    def test_arg_order_matches_normal_path(self, monkeypatch):
+        db = "20260704_173426-development_localhost-database.sql.gz"
+        files = "20260704_173426-development_localhost-files.tar"
+        private = "20260704_173426-development_localhost-private-files.tar"
+        container = self._run(monkeypatch, db, files=[files], private=[private])
+        cmd = " ".join(container.restore_calls()[0]["cmd"])
+        # Order: db path, then credentials + --force, THEN the file archives (the
+        # normal path's shape) - not --with-public-files immediately after the db.
+        i_db = cmd.index("restore ")
+        i_user = cmd.index("--mariadb-root-username")
+        i_force = cmd.index("--force")
+        i_pub = cmd.index("--with-public-files")
+        i_priv = cmd.index("--with-private-files")
+        assert i_db < i_user < i_force < i_pub < i_priv
+
+
+# ================================================= #2 credential prompting modes
+
+
+class TestMariadbCredentialModes:
+    """#2: username+password prompting works interactively AND non-interactively."""
+
+    def _tty(self, monkeypatch, is_tty):
+        monkeypatch.setattr(restore_mod.sys.stdin, "isatty", lambda: is_tty)
+        monkeypatch.setattr(restore_mod.console, "print", lambda *a, **k: None)
+        monkeypatch.setattr(restore_mod.stderr_console, "print", lambda *a, **k: None)
+
+    def test_interactive_prompts_collect_username_and_password(self, monkeypatch):
+        self._tty(monkeypatch, True)
+        asked = []
+
+        def fake_text(msg, default=None):
+            asked.append(("text", msg))
+            return SimpleNamespace(ask=lambda: "root")
+
+        def fake_password(msg):
+            asked.append(("password", msg))
+            return SimpleNamespace(ask=lambda: "s3cret")
+
+        monkeypatch.setattr(restore_mod.questionary, "text", fake_text)
+        monkeypatch.setattr(restore_mod.questionary, "password", fake_password)
+
+        user, pw = restore_mod._prompt_mariadb_credentials(None, None)
+        assert (user, pw) == ("root", "s3cret")
+        # BOTH the username AND the password prompt actually fired (the bug skipped
+        # the username prompt and returned an empty password).
+        assert [k for k, _ in asked] == ["text", "password"]
+
+    def test_interactive_blank_username_defaults_to_root(self, monkeypatch):
+        self._tty(monkeypatch, True)
+        monkeypatch.setattr(
+            restore_mod.questionary, "text", lambda *a, **k: SimpleNamespace(ask=lambda: "")
+        )
+        monkeypatch.setattr(
+            restore_mod.questionary, "password", lambda *a, **k: SimpleNamespace(ask=lambda: "pw")
+        )
+        user, pw = restore_mod._prompt_mariadb_credentials(None, None)
+        assert user == "root" and pw == "pw"
+
+    def test_interactive_empty_password_is_error(self, monkeypatch):
+        self._tty(monkeypatch, True)
+        monkeypatch.setattr(
+            restore_mod.questionary, "text", lambda *a, **k: SimpleNamespace(ask=lambda: "root")
+        )
+        monkeypatch.setattr(
+            restore_mod.questionary, "password", lambda *a, **k: SimpleNamespace(ask=lambda: "")
+        )
+        with pytest.raises(typer.Exit) as e:
+            restore_mod._prompt_mariadb_credentials(None, None)
+        assert e.value.exit_code != 0
+
+    def test_non_tty_without_password_refuses(self, monkeypatch):
+        self._tty(monkeypatch, False)
+        # A prompt must NEVER be reached under a non-TTY.
+        monkeypatch.setattr(
+            restore_mod.questionary,
+            "password",
+            lambda *a, **k: pytest.fail("must not prompt under a non-TTY"),
+        )
+        with pytest.raises(typer.Exit) as e:
+            restore_mod._prompt_mariadb_credentials(None, None)
+        assert e.value.exit_code != 0
+
+    def test_non_tty_with_flags_uses_them_without_prompting(self, monkeypatch):
+        self._tty(monkeypatch, False)
+        monkeypatch.setattr(
+            restore_mod.questionary,
+            "password",
+            lambda *a, **k: pytest.fail("must not prompt when flags are given"),
+        )
+        user, pw = restore_mod._prompt_mariadb_credentials("admin", "flagpw")
+        assert (user, pw) == ("admin", "flagpw")
+
+    def test_non_tty_password_flag_defaults_username_to_root(self, monkeypatch):
+        self._tty(monkeypatch, False)
+        user, pw = restore_mod._prompt_mariadb_credentials(None, "flagpw")
+        assert user == "root" and pw == "flagpw"
+
+
+# ===================================================== #3 site detection (inspect)
+
+
+class TestSiteDetectionExcludesStrayFiles:
+    """#3: currentsite.txt (and other stray entries) are never sites."""
+
+    def test_currentsite_txt_is_not_a_site(self):
+        c = RecordingContainer(
+            sites={SITE: ["frappe"]},
+            stray=["apps.txt", "apps.json", "assets", "common_site_config.json", "currentsite.txt"],
+        )
+        assert bench_sites.list_sites(c, BENCH_PATH) == [SITE]
+
+    def test_ls_failure_returns_none(self):
+        class Boom:
+            def exec_run(self, cmd, workdir=None, environment=None):
+                return (1, b"")
+
+        assert bench_sites.list_sites(Boom(), BENCH_PATH) is None
+
+    def test_ambiguous_entry_is_failsafe_included(self):
+        class Ambiguous:
+            def exec_run(self, cmd, workdir=None, environment=None):
+                s = " ".join(cmd) if isinstance(cmd, (list, tuple)) else cmd
+                if s == f"ls -1 {BENCH_PATH}/sites":
+                    return (0, b"weird\n")
+                if "echo SITE" in s:
+                    return (0, b"AMBIGUOUS\n")
+                return (0, b"")
+
+        # AMBIGUOUS (unreadable/erroring) fails closed -> treated as a real site.
+        assert bench_sites.list_sites(Ambiguous(), BENCH_PATH) == ["weird"]
+
+
+# =============================================== #4 default site from currentsite
+
+
+class TestDefaultSiteFromCurrentSite:
+    """#4: default resolves from currentsite.txt when common config lacks it."""
+
+    def test_read_current_site(self):
+        c = RecordingContainer(currentsite="development.localhost\n")
+        assert bench_sites.read_current_site(c, BENCH_PATH) == "development.localhost"
+
+    def test_read_current_site_missing_is_none(self):
+        c = RecordingContainer(currentsite=None)
+        assert bench_sites.read_current_site(c, BENCH_PATH) is None
+
+    def test_cache_roundtrips_current_site(self, temp_db):
+        db_utils.cache_project_data(
+            "proj",
+            [{"path": BENCH_PATH, "sites": [], "available_apps": [], "current_site": SITE}],
+        )
+        data = db_utils.get_cached_project_data("proj")
+        assert data["bench_instances"][0]["current_site"] == SITE
+
+    def test_get_default_site_falls_back_to_current_site(self, temp_db):
+        # common_site_config has NO default_site, but currentsite.txt named the site.
+        db_utils.cache_project_data(
+            "proj",
+            [
+                {
+                    "path": BENCH_PATH,
+                    "sites": [],
+                    "available_apps": [],
+                    "current_site": SITE,
+                    "common_site_config": {"db_host": "mariadb"},  # no default_site
+                }
+            ],
+        )
+        assert db_utils.get_default_site("proj", BENCH_PATH) == SITE
+
+    def test_get_default_site_prefers_explicit_default_site(self, temp_db):
+        db_utils.cache_project_data(
+            "proj",
+            [
+                {
+                    "path": BENCH_PATH,
+                    "sites": [],
+                    "available_apps": [],
+                    "current_site": "pointer.localhost",
+                    "common_site_config": {"default_site": "explicit.localhost"},
+                }
+            ],
+        )
+        assert db_utils.get_default_site("proj", BENCH_PATH) == "explicit.localhost"
+
+    def test_migration_adds_current_site_column(self, temp_db):
+        db_utils.db.execute_sql("DROP TABLE bench")
+        db_utils.db.execute_sql(
+            "CREATE TABLE bench (id INTEGER PRIMARY KEY, project_id INTEGER, path VARCHAR)"
+        )
+        cols = {r[1] for r in db_utils.db.execute_sql("PRAGMA table_info(bench)").fetchall()}
+        assert "current_site" not in cols
+        db_utils._migrate_bench_current_site_column()
+        cols = {r[1] for r in db_utils.db.execute_sql("PRAGMA table_info(bench)").fetchall()}
+        assert "current_site" in cols
+        db_utils._migrate_bench_current_site_column()  # idempotent
+
+    def test_resolve_default_site_live_fallback(self, temp_db, monkeypatch):
+        # No cache entry -> get_default_site returns None -> live currentsite read.
+        container = RecordingContainer(currentsite="live.localhost")
+        site = restore_mod._resolve_default_site("proj", BENCH_PATH, container)
+        assert site == "live.localhost"
+
+
+# ===================================================== #5 missing-apps warning
+
+
+DB_PATH = f"{BENCH_PATH}/sites/{SITE}/private/backups/20260705_000000-development_localhost-database.sql.gz"
+
+
+class _AppsContainer:
+    """Serves `ls apps` and the dump's installed_apps grep for check_missing_apps.
+
+    ``available`` are the apps physically in apps/. ``dump_apps`` is what the backup
+    dump records under the installed_apps global; None means the grep finds nothing
+    (unreadable/absent marker) -> the check must fail safe.
+    """
+
+    def __init__(self, available, dump_apps):
+        self.available = list(available)
+        self.dump_apps = dump_apps
+
+    def exec_run(self, cmd, workdir=None, environment=None):
+        s = " ".join(cmd) if isinstance(cmd, (list, tuple)) else str(cmd)
+        if f"ls -1 {BENCH_PATH}/apps" in s:
+            return (0, "\n".join(self.available).encode())
+        if "installed_apps" in s and "zcat" in s:
+            if self.dump_apps is None:
+                return (0, b"")  # marker not found -> empty output
+            # Mimic mysqldump's escaped-quote array before ,'installed_apps'.
+            arr = ", ".join(f'\\"{a}\\"' for a in self.dump_apps)
+            return (0, f"[{arr}]','installed_apps'".encode())
+        return (0, b"")
+
+
+class TestMissingAppsCheck:
+    """#5: compare the apps the BACKUP needs (from its dump) against the bench's
+    available apps - the captain's "the backup uses apps the bench does NOT have"."""
+
+    def _no_recache(self, monkeypatch):
+        monkeypatch.setattr(restore_mod.cache, "recache_project", lambda *a, **k: True)
+
+    def test_warns_when_backup_app_absent_from_bench(self, monkeypatch):
+        self._no_recache(monkeypatch)
+        # Backup was taken on a site with [frappe, widgets]; bench only has frappe.
+        c = _AppsContainer(available=["frappe"], dump_apps=["frappe", "widgets"])
+        missing = restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True)
+        assert missing == ["widgets"]
+
+    def test_no_warning_when_all_present(self, monkeypatch):
+        self._no_recache(monkeypatch)
+        c = _AppsContainer(available=["frappe", "widgets"], dump_apps=["frappe", "widgets"])
+        assert restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True) == []
+
+    def test_fail_safe_when_backup_apps_unreadable(self, monkeypatch):
+        self._no_recache(monkeypatch)
+        # Dump marker not found -> cannot tell -> no false warning.
+        c = _AppsContainer(available=["frappe"], dump_apps=None)
+        assert restore_mod.check_missing_apps(c, "proj", BENCH_PATH, DB_PATH, no_recache=True) == []
+
+    def test_reads_backup_apps_from_dump_helper(self):
+        c = _AppsContainer(available=[], dump_apps=["frappe", "widgets"])
+        assert restore_mod._read_backup_installed_apps(c, DB_PATH) == {"frappe", "widgets"}
+
+
+# ==================================================== #6 post-restore migrate/restart
+
+
+class TestPostRestoreMigrateAndRestart:
+    """#6: a successful restore is followed by bench migrate then an instance restart."""
+
+    def _patch(self, monkeypatch):
+        calls = {"start": []}
+        monkeypatch.setattr(restore_mod, "TipSpinner", _NullSpinner)
+        monkeypatch.setattr(restore_mod.config_utils, "get_show_tips", lambda: False)
+        monkeypatch.setattr(restore_mod.console, "print", lambda *a, **k: None)
+        monkeypatch.setattr(restore_mod.stderr_console, "print", lambda *a, **k: None)
+        import caffeinated_whale_cli.commands.start as start_mod
+
+        def fake_start(project_name, verbose=False, **k):
+            calls["start"].append(project_name)
+            return "/tmp/bench-proj.log"
+
+        monkeypatch.setattr(start_mod, "_start_project", fake_start)
+        return calls
+
+    def test_runs_migrate_then_restart_on_success(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        container = RecordingContainer(sites={SITE: ["frappe"]}, migrate_exit=0)
+        ok = restore_mod._post_restore_migrate_and_restart(
+            container, "proj", BENCH_PATH, SITE, verbose=False
+        )
+        assert ok is True
+        # bench migrate ran at the bench path...
+        migrates = [
+            c
+            for c in container.exec_calls
+            if "migrate"
+            in (" ".join(c["cmd"]) if isinstance(c["cmd"], (list, tuple)) else c["cmd"])
+        ]
+        assert len(migrates) == 1
+        assert migrates[0]["workdir"] == BENCH_PATH
+        # ...then the instance was restarted.
+        assert calls["start"] == ["proj"]
+
+    def test_migrate_failure_still_restarts_and_returns_false(self, monkeypatch):
+        calls = self._patch(monkeypatch)
+        container = RecordingContainer(sites={SITE: ["frappe"]}, migrate_exit=1)
+        ok = restore_mod._post_restore_migrate_and_restart(
+            container, "proj", BENCH_PATH, SITE, verbose=False
+        )
+        # A failed migrate does not abort the restart, but is reported as False so
+        # the caller can exit non-zero.
+        assert ok is False
+        assert calls["start"] == ["proj"]

--- a/tests/test_restore_safety.py
+++ b/tests/test_restore_safety.py
@@ -157,6 +157,9 @@ def _run_receive(
         no_recache=True,
         verbose=False,
         yes=yes,
+        # These tests pin the restore command/confirm behavior only; skip the
+        # post-restore migrate + instance restart (covered by its own tests).
+        no_migrate=True,
     )
 
 

--- a/tests/test_rm_safety.py
+++ b/tests/test_rm_safety.py
@@ -19,6 +19,7 @@ code issues) and ``tests/test_rm_truth.py``'s tmp-filesystem approach.
 """
 
 import io
+import shlex
 import tarfile
 from unittest.mock import MagicMock
 
@@ -117,16 +118,16 @@ class FakeFrappeContainer:
             ]
             return (0, "\n".join(listing).encode())
 
-        # Fail-safe site-classification probe: a real site echoes SITE, a
-        # readable stray entry echoes NOTASITE, and an unreadable/ambiguous entry
-        # echoes AMBIGUOUS. The entry is identified by its unique config path.
+        # Fail-safe site-classification probe: the entry dir is passed as the
+        # positional arg (the last shlex token), never interpolated, so classify
+        # by that entry's basename. A real site echoes SITE, a readable stray
+        # entry NOTASITE, an unreadable/ambiguous entry AMBIGUOUS.
         if cmd.startswith("sh -c '") and "echo SITE" in cmd and "site_config.json" in cmd:
-            for site in self.sites:
-                if f"/sites/{site}/site_config.json" in cmd:
-                    return (0, b"SITE\n")
-            for entry in self.ambiguous_entries:
-                if f"/sites/{entry}/site_config.json" in cmd:
-                    return (0, b"AMBIGUOUS\n")
+            entry = shlex.split(cmd)[-1].rsplit("/", 1)[-1]
+            if entry in self.sites:
+                return (0, b"SITE\n")
+            if entry in self.ambiguous_entries:
+                return (0, b"AMBIGUOUS\n")
             return (0, b"NOTASITE\n")
 
         if cmd.startswith("sh -c 'cd ") and "bench --site " in cmd and "backup" in cmd:

--- a/tests/test_yes_flag.py
+++ b/tests/test_yes_flag.py
@@ -238,6 +238,44 @@ class TestStartInspectExitPropagates:
         )
 
 
+class TestStartProjectBenchPathOverride:
+    """An explicit ``bench_path_override`` is used VERBATIM: ``_start_project`` must
+    NOT consult ``resolve_bench_path`` (which would guess the first bench on a
+    multi-bench project) - so the post-restore restart hits the SAME bench that was
+    just restored/migrated."""
+
+    def test_override_is_used_and_resolve_is_skipped(self, monkeypatch):
+        monkeypatch.setattr(docker_utils.shutil, "which", lambda _n: "/usr/bin/docker")
+        monkeypatch.setattr(
+            docker_utils.docker, "from_env", lambda: type("C", (), {"ping": lambda s: True})()
+        )
+        monkeypatch.setattr(start_mod, "get_project_containers", lambda name: [_RunningFrappe()])
+
+        def _fail_resolve(*a, **k):
+            raise AssertionError("resolve_bench_path must not be called when an override is given")
+
+        monkeypatch.setattr(cmd_utils, "resolve_bench_path", _fail_resolve)
+
+        captured = {"cmds": []}
+
+        def fake_run(cmd, **k):
+            captured["cmds"].append(cmd)
+            return type("R", (), {"returncode": 0})()
+
+        monkeypatch.setattr(start_mod.subprocess, "run", fake_run)
+
+        override = "/workspace/second-bench"
+        log_file = start_mod._start_project(
+            "proj", verbose=False, status=None, bench_path_override=override
+        )
+        assert log_file == "/tmp/bench-proj.log"
+        # The `bench start` command cd's into the override path, verbatim (match the
+        # nohup launch, not the `pkill -f 'bench start'` cleanup that precedes it).
+        bench_cmds = [c for c in captured["cmds"] if any("nohup bench start" in str(t) for t in c)]
+        assert bench_cmds
+        assert any(f"cd {override} &&" in str(t) for t in bench_cmds[0])
+
+
 # ------------------------------------------------ start multi-project loop
 
 


### PR DESCRIPTION
## Intent

Final validation of the six restore+inspect fixes the captain hit on cwcli 0.33.0 (Frappe version-14), proven E2E on real Frappe v14+v15 in BOTH interactive and non-interactive modes. All decisions are deliberate; the branch has been through the original change plus three fix rounds (no-mistakes review, CodeRabbit, and the test-step's E2E finding), and this final commit is docs-only.

SIX FIXES: (1) --receive uses the FULL container db path (v14 rejected the bare filename as 'Invalid path'), arg order mirrors the normal path. (2) shared _prompt_mariadb_credentials: interactive prompts collect username(default root)+password, non-interactive uses --mariadb-root-* flags, non-TTY without a password refuses non-zero. (3) inspect detects sites as directories with site_config.json via shared utils/bench_sites (rm delegates); currentsite.txt is never a site. (4) default site resolves from common_site_config default_site OR sites/currentsite.txt (new nullable Bench.current_site column + idempotent migration; live fallback in restore). (5) missing-apps reads the BACKUP's installed apps from its own dump vs the bench's live ls apps/ (check_missing_apps' site arg became backup_db_path); fail safe. (6) post-restore bench migrate then restart; failed/exception migrate is reported but never blocks the restart; --no-migrate opts out.

REVIEW-ROUND FIXES (deliberate): restart the SAME restored bench via _start_project's bench_path_override (never bench 0); check_missing_apps dropped the unused cache.recache_project (--no-recache kept as a deprecated no-op); a migrate exec exception is a failed-but-reported migrate that still restarts.

CODERABBIT FIXES (deliberate): bench_sites.list_sites passes the entry dir as a shlex-quoted positional arg (injection safe) + guards decodes; test fixture keeps currentsite.txt; e2e doc fences tagged bash.

CREDENTIAL ROOT FIX (deliberate, from the test-step's realistic y+Enter E2E): the interactive empty-password bug was NOT fixed by the termios.tcflush stdin drain (FIONREAD proved the stray Enter is in prompt_toolkit's internal buffer, not the OS tty queue). The real fix is auto_enter=False on every restore confirm, so the confirm consumes its own trailing Enter and nothing leaks into the password prompt - robust regardless of credential flags. The tcflush was removed. Re-proven E2E on real v14+v15 driving the confirm as a human does (y THEN Enter), including the --mariadb-root-username flag path that previously failed.

THIS COMMIT is documentation only: it records the auto_enter=False root fix as a sharp edge in AGENTS.md and corrects the E2E doc's re-validation note (the earlier note still referenced the removed stdin flush). No code change. 284 unit tests pass, mypy and lint green.

## What Changed

- Fixed six restore/inspect defects hit on Frappe version-14: `--receive` now restores from the full container DB path (v14 rejected the bare filename) with argument order matching the normal path; credential entry is a shared helper (`_prompt_mariadb_credentials`) that prompts interactively and accepts `--mariadb-root-username/--mariadb-root-password`, refusing non-zero on a non-TTY with no password; site detection moved into a new shared `utils/bench_sites.py` that treats a directory containing `site_config.json` as a site (so `currentsite.txt` is never misread as one, with `rm` delegating to it); the default site now resolves from `common_site_config.json`'s `default_site` or `sites/currentsite.txt` via a new nullable `Bench.current_site` column and idempotent migration; the missing-apps warning reads the backup's own DB dump versus the bench's live `apps/`; and a successful restore now runs `bench migrate` then restarts the same restored bench (via `_start_project`'s `bench_path_override`), with `--no-migrate` opting out and `--no-recache` kept as a deprecated no-op.
- Fixed the interactive empty-password bug by setting `auto_enter=False` on every restore confirmation so the confirm consumes its own trailing Enter, and removed the ineffective `termios`/`tcflush` stdin drain (the stray Enter lived in prompt_toolkit's internal buffer, not the OS tty queue).
- Added `tests/test_restore_inspect_fixes.py` plus updates to existing suites and fakes for the shared site probe and new parameters, and documented the fixes and the `auto_enter=False` sharp edge in `AGENTS.md`, `README.md`, and a new `docs/e2e/restore-inspect-e2e-r6.md`.

## Risk Assessment

✅ Low: The change is large but well-bounded, extensively documented, multi-round reviewed and E2E-validated on Frappe v14/v15; the only findings are a trivial whitespace-username validation gap and an intentional, documented behavior change.

## Testing

Ran the full unit suite (284 passed) and targeted regression subset (61 passed), verified the docs-only commit's claims against source, and reproduced all six restore/inspect fixes plus the auto_enter=False root fix end-to-end on live Frappe v14 and v15 containers via pty-driven CLI transcripts and a source-free counterfactual; all green, worktree left clean.

<details>
<summary>Evidence: cwcli inspect on real Frappe v14 (fixes #3 currentsite-not-a-site, #4 default from currentsite.txt)</summary>

<code>Project cwe2e6v14&#10;└── Bench [0] at /workspace/frappe-bench&#10;├── Available Apps (1)&#10;│ └── frappe&#10;└── Sites (1)&#10;└── development.localhost (default) # currentsite.txt/apps.json/assets excluded; (default) from currentsite.txt though common_site_config has no default_site&#10;└── Installed Apps (1)&#10;└── frappe 14.101.1 version-14</code>

```text
Project cwe2e6v14
└── Bench [0] at /workspace/frappe-bench
    ├── Available Apps (1)
    │   └── frappe
    └── Sites (1)
        └── development.localhost (default)
            └── Installed Apps (1)
                └── frappe 14.101.1 version-14
```
</details>
<details>
<summary>Evidence: Headline auto_enter=False root fix — source-free counterfactual (y THEN Enter)</summary>

<code>=== auto_enter=True (OLD behavior - the confirm submits on &#39;y&#39;, Enter leaks) ===&#10;RESULT confirm=True password=&#39;&#39;&#10;&#10;=== auto_enter=False (THE FIX - the confirm consumes its own Enter) ===&#10;RESULT confirm=True password=&#39;123&#39;&#10;&#10;[verdict] auto_enter=True -&gt; password empty (leaked-Enter bug present): True&#10;[verdict] auto_enter=False -&gt; password collected &#39;123&#39; (fix holds): True</code>

```text
=== auto_enter=True  (OLD behavior - the confirm submits on 'y', Enter leaks) ===
RESULT confirm=True password=''

=== auto_enter=False (THE FIX - the confirm consumes its own Enter) ===
RESULT confirm=True password='123'

[verdict] auto_enter=True  -> password empty (leaked-Enter bug present): True
[verdict] auto_enter=False -> password collected '123' (fix holds):      True
```
</details>
<details>
<summary>Evidence: Interactive restore on real v14 — --mariadb-root-username FLAG path (previously failed), y THEN Enter</summary>

<code>? Are you sure you want to restore? (y/N)yYes -&gt; Yes&#10;(no MariaDB username prompt: skipped by --mariadb-root-username flag)&#10;? MariaDB root password: 123*** -&gt; input collected (masked), NOT empty&#10;✓ Successfully restored site &#39;development.localhost&#39;</code>

```text
[driver] scenario='username-flag'  cmd=uv run cwcli restore cwe2e6v14 --no-migrate --mariadb-root-username root
warning: `VIRTUAL_ENV=/tmp/no-mistakes-evidence/01KWRSZ61WS6987Z9J7H1VG8PE/isolated-home/.cache/uv/builds-v0/.tmpMIp0sT` does not match the project environment path `.venv` and will be ignored; use `--active` to target the active environment instead
Using default site: development.localhost
⠋ Scanning backups for all sites
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Scanning backups for all sites
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Scanning backups for all sites
💡 Clear cache after migrations with '--clear-cache' for a clean state

? Select a backup to restore: (Use arrow keys to navigate, Enter to select)
   
=== Backups from site: development.localhost ===
 > 2026-07-05 12:10:07  [DATABASE ONLY]
   2026-07-05 09:27:53  [DATABASE ONLY]
   
=== Remote Source ===
   Restore from remote source (via sendme)WARNING: your terminal doesn't support cursor position requests (CPR).
? Select a backup to restore: (Use arrow keys to navigate, Enter to select)
   
=== Backups from site: development.localhost ===
 > 2026-07-05 12:10:07  [DATABASE ONLY]
   2026-07-05 09:27:53  [DATABASE ONLY]
   
=== Remote Source ===
   Restore from remote source (via sendme)? Select a backup to restore: 2026-07-05 12:10:07  [DATABASE ONLY]

⠋ Checking for missing apps
💡 Use '--lines' flag to control how many log lines are shown⠋ Checking for missing apps
💡 Use '--lines' flag to control how many log lines are shown

⚠ Warning: This will replace all data in site 'development.localhost'
Backup: 20260705_121007-development_localhost-database.sql.gz
From: 2026-07-05 12:10:07
Will restore: Database

? Are you sure you want to restore? (y/N)WARNING: your terminal doesn't support cursor position requests (CPR).
? Are you sure you want to restore? (y/N)yYes? Are you sure you want to restore? Yes
? MariaDB root password:WARNING: your terminal doesn't support cursor position requests (CPR).
? MariaDB root password:123***? MariaDB root password: ***

⠋ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠹ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠸ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠼ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠴ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠦ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠧ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠇ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠏ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠋ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠹ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠸ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠼ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠴ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠦ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠧ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠇ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠏ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠋ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠹ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠸ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠼ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠴ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠦ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠧ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠇ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠏ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠋ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠹ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠸ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠼ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠴ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠦ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠧ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠇ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠏ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠋ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠙ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠹ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠸ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠼ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠴ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠦ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠧ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠇ Restoring site 'development.localhost'
💡 Clear cache after migrations with '--clear-cache' for a clean state⠏ Restoring site 'development.localhost'
💡 Check auto-inspect status with 'cwcli config auto-inspect status'⠋ Restoring site 'development.localhost'
💡 Check auto-inspect status with 'cwcli config auto-inspect status'⠙ Restoring site 'development.localhost'
💡 Check auto-inspect status with 'cwcli config auto-inspect status'⠹ Restoring site 'development.localhost'
💡 Check auto-inspect status with 'cwcli config auto-inspect status'

✓ Successfully restored site 'development.localhost'
From backup: 20260705_121007-development_localhost-database.sql.gz

[driver] outcome index=0 -> RESTORED
[OK] password prompt collected input; restore succeeded (auto_enter=False fix holds)
```
</details>
<details>
<summary>Evidence: Interactive restore on real v14 — default flow + migrate + restart (fixes #2 interactive, #6)</summary>

<code>? Are you sure you want to restore? Yes&#10;? MariaDB root username: root # prompt now APPEARS (was skipped)&#10;? MariaDB root password: *** # input collected&#10;✓ Successfully restored site &#39;development.localhost&#39;&#10;✓ Migrated site &#39;development.localhost&#39;&#10;Restarting instance...&#10;✓ Instance restarted (logs: /tmp/bench-cwe2e6v14.log)</code>

```text
[driver] scenario='default'  cmd=uv run cwcli restore cwe2e6v14
Using default site: development.localhost
 > 2026-07-05 12:10:07  [DATABASE ONLY]
   2026-07-05 09:27:53  [DATABASE ONLY]
   Restore from remote source (via sendme)? Select a backup to restore: 2026-07-05 12:10:07  [DATABASE ONLY]
? Are you sure you want to restore? (y/N)WARNING: your terminal doesn't support cursor position requests (CPR).
? Are you sure you want to restore? (y/N)yYes? Are you sure you want to restore? Yes
? MariaDB root username: rootWARNING: your terminal doesn't support cursor position requests (CPR).
? MariaDB root username: root? MariaDB root username: root
? MariaDB root password:WARNING: your terminal doesn't support cursor position requests (CPR).
? MariaDB root password:123***? MariaDB root password: ***
✓ Successfully restored site 'development.localhost'
From backup: 20260705_121007-development_localhost-database.sql.gz
✓ Migrated site 'development.localhost'
Restarting instance...
✓ Instance restarted (logs: /tmp/bench-cwe2e6v14.log)
[driver] outcome index=0 -> RESTORED
[OK] password prompt collected input; restore succeeded (auto_enter=False fix holds)
```
</details>
<details>
<summary>Evidence: Fix #1 — receive full DB path on real Frappe v14 (bare filename vs full path)</summary>

<code>### BUGGY: bench restore &lt;bare-filename&gt;, cwd=private/backups (what receive mode used to build):&#10;Invalid path 20260705_121007-development_localhost-database.sql.gz&#10;&#10;### FIXED: bench restore &lt;FULL container path&gt; (what receive mode builds now):&#10;Site development.localhost has been restored</code>

```text
############ #1: Frappe v14 - bare filename (the receive-mode bug) vs full path (the fix) ############

### BUGGY: bench restore <bare-filename> with cwd = private/backups (what receive mode used to build):
Invalid path 20260705_121007-development_localhost-database.sql.gz

### FIXED: bench restore <FULL container path> with cwd = private/backups (what receive mode builds now):
Warning: MariaDB version ['11.8', '8'] is more than 10.8 which is not yet tested with Frappe Framework.
Restoring Database file...
App frappe already installed
*** Scheduler is disabled ***
Site development.localhost has been restored
```
</details>
<details>
<summary>Evidence: Fix #5 — missing-apps reads the BACKUP&#39;s own dump (real v15 data)</summary>

<code>apps in BACKUP : [&#39;frappe&#39;, &#39;widgets&#39;] # read from the dump, not per-site apps.json&#10;missing vs REAL bench (has frappe+widgets): [] -&gt; no false positive&#10;missing vs bench WITHOUT widgets : [&#39;widgets&#39;] -&gt; warning fires&#10;[verdict] missing-apps reads backup dump &amp; fires only when the bench lacks an app: True</code>

```text
backup dump      : /workspace/frappe-bench/sites/development.localhost/private/backups/20260705_145654-development_localhost-database.sql.gz
apps in BACKUP   : ['frappe', 'widgets']
missing vs REAL bench (has frappe+widgets): []   -> expect []
missing vs bench WITHOUT widgets           : ['widgets']   -> expect ['widgets']

[verdict] missing-apps reads backup dump & fires only when the bench lacks an app: True
```
</details>
<details>
<summary>Evidence: cwcli inspect on real Frappe v15 (fixes #3/#4)</summary>

```text
Project cwe2e6
└── Bench [0] at /workspace/frappe-bench
    ├── Available Apps (2)
    │   ├── frappe
    │   └── widgets
    └── Sites (1)
        └── development.localhost (default)
            └── Installed Apps (2)
                ├── frappe  15.113.4 version-15
                └── widgets 0.0.1    UNVERSIONED
```
</details>
<details>
<summary>Evidence: pty restore driver script (pexpect)</summary>

```text
#!/usr/bin/env python3
"""Drive `cwcli restore` through a real pty (pexpect), the way a human types.

Proves the auto_enter=False credential root fix: after the destructive-restore
confirm (driven `y` THEN Enter, as a human habitually types), the immediately
following MariaDB password prompt STILL collects input instead of receiving the
confirm's leaked trailing Enter as an empty submit.

Usage: pty_restore.py <scenario>
  scenario = "username-flag"  -> pass --mariadb-root-username root (username prompt
             SKIPPED). This is the exact case that FAILED before auto_enter=False,
             because there was no username prompt to absorb the stray Enter.
  scenario = "default"        -> no flags; the username prompt appears too.
"""
import os
import sys
import pexpect

RAW_MARKER = "\x1b[?2004h"  # prompt_toolkit raw-mode readiness marker

scenario = sys.argv[1] if len(sys.argv) > 1 else "username-flag"
project = os.environ.get("E2E_PROJECT", "cwe2e6v14")
password = os.environ.get("E2E_DB_PW", "123")

cmd = ["uv", "run", "cwcli", "restore", project]
if os.environ.get("E2E_MIGRATE") != "1":
    cmd += ["--no-migrate"]
if scenario == "username-flag":
    cmd += ["--mariadb-root-username", "root"]

print(f"[driver] scenario={scenario!r}  cmd={' '.join(cmd)}")

child = pexpect.spawn(cmd[0], cmd[1:], encoding="utf-8", timeout=300, echo=False,
                      dimensions=(40, 120))
child.logfile = sys.stdout

# 1) Backup selection menu (questionary.select). Wait for raw-mode, pick highlighted.
child.expect("Select a backup to restore")
child.expect_exact(RAW_MARKER)
child.send("\r")  # accept the highlighted (newest) backup

# 2) If the default scenario, the username prompt appears BEFORE... no: creds are
#    prompted AFTER the confirm. First handle the destructive-restore confirm.
child.expect("Are you sure you want to restore")
child.expect_exact(RAW_MARKER)
# Drive it the way a human does: press 'y' THEN Enter. With auto_enter=True (the
# old bug) the 'y' submits and this Enter leaks into the next prompt.
child.send("y")
child.send("\r")

# 3) In the default scenario the username prompt runs; accept the default (root).
if scenario == "default":
    child.expect("MariaDB root username")
    child.expect_exact(RAW_MARKER)
    child.send("\r")  # keep default 'root'

# 4) The MariaDB password prompt - THE prompt the leaked Enter used to empty.
child.expect("MariaDB root password")
child.expect_exact(RAW_MARKER)
child.send(password)
child.send("\r")

# 5) Outcome. The bug printed "Password cannot be empty."; the fix runs the restore.
idx = child.expect([
    "Migrated site|Successfully restored",
    "Password cannot be empty",
    "Restore process failed",
    pexpect.EOF,
    pexpect.TIMEOUT,
])
child.expect(pexpect.EOF)
outcome = ["RESTORED", "EMPTY_PASSWORD_BUG", "RESTORE_FAILED", "EOF", "TIMEOUT"][idx]
print(f"\n[driver] outcome index={idx} -> {outcome}")
if outcome == "RESTORED":
    print("[OK] password prompt collected input; restore succeeded (auto_enter=False fix holds)")
    sys.exit(0)
elif outcome == "EMPTY_PASSWORD_BUG":
    print("[FAIL] password prompt received an empty submit - the leaked-Enter bug is present")
    sys.exit(2)
else:
    print(f"[FAIL] unexpected outcome: {outcome}")
    sys.exit(3)
```
</details>
<details>
<summary>Evidence: auto_enter counterfactual harness script</summary>

```text
#!/usr/bin/env python3
"""Isolate the exact prompt_toolkit mechanism the AGENTS.md sharp edge describes.

Runs a tiny two-prompt program (a questionary.confirm followed by a
questionary.password, exactly the restore shape) through a real pty, driving the
confirm the way a human habitually types: the 'y' answer key immediately followed
by Enter. It does this twice - once with auto_enter=True (the OLD behavior) and
once with auto_enter=False (the FIX) - and reports whether the password prompt
received the leaked Enter as an empty submit.

This touches no cwcli source; it demonstrates why auto_enter=False is load-bearing.
"""
import io
import re
import sys
import pexpect

RAW_MARKER = "\x1b[?2004h"

CHILD = r'''
import sys, questionary
mode = sys.argv[1] == "True"
c = questionary.confirm("Are you sure you want to restore?", default=False, auto_enter=mode).ask()
p = questionary.password("MariaDB root password:").ask()
print(f"RESULT confirm={c!r} password={p!r}")
'''


def run(auto_enter: bool) -> str:
    cap = io.StringIO()
    child = pexpect.spawn(
        sys.executable, ["-c", CHILD, str(auto_enter)],
        encoding="utf-8", timeout=30, echo=False, dimensions=(40, 120),
    )
    child.logfile_read = cap
    child.expect("Are you sure you want to restore")
    child.expect_exact(RAW_MARKER)
    # Human habit: press the answer key 'y' THEN Enter.
    child.send("y")
    child.send("\r")
    # Try to type the password IF the prompt is still waiting. With auto_enter=True
    # the confirm already submitted on 'y' and the '\r' leaked into the password
    # prompt as an empty submit, so the child may have already exited (EOF) - that
    # empty submit is exactly the bug, and it is already in the captured output.
    try:
        child.expect_exact(RAW_MARKER, timeout=5)
        child.send("123")
        child.send("\r")
    except (pexpect.TIMEOUT, pexpect.EOF):
        pass
    try:
        child.expect(pexpect.EOF)
    except pexpect.TIMEOUT:
        child.terminate(force=True)
    m = re.search(r"RESULT confirm=\S+ password=\S*", cap.getvalue())
    return m.group(0) if m else "(no RESULT line captured)"


print("=== auto_enter=True  (OLD behavior - the confirm submits on 'y', Enter leaks) ===")
old = run(True)
print(old)
print()
print("=== auto_enter=False (THE FIX - the confirm consumes its own Enter) ===")
new = run(False)
print(new)
print()

old_empty = "password=''" in old
new_ok = "password='123'" in new
print(f"[verdict] auto_enter=True  -> password empty (leaked-Enter bug present): {old_empty}")
print(f"[verdict] auto_enter=False -> password collected '123' (fix holds):      {new_ok}")
sys.exit(0 if (old_empty and new_ok) else 1)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `src/caffeinated_whale_cli/commands/restore.py:113` - `_prompt_mariadb_credentials` (restore.py:113) documents that it returns a non-empty username, but a whitespace-only `--mariadb-root-username` flag value (e.g. &#34;   &#34;) is truthy, so it skips the prompt/default and returns the whitespace as-is. The normal path&#39;s old `if not mariadb_root_username.strip():` empty-check was dropped in this refactor, and the `invalid_chars` check does not include spaces, so a whitespace username is shlex-quoted and passed to `bench restore`, producing a confusing MariaDB auth failure (&#39;Failed to restore ... Incorrect MariaDB root password&#39;) instead of a clean &#39;username cannot be empty&#39; error. Suggest `.strip()`-normalizing the flag value and erroring on empty inside the helper (fixes both paths).
- ℹ️ `src/caffeinated_whale_cli/commands/restore.py:175` - Restore now, by default, runs `bench migrate` and force-restarts the bench dev server (`_start_project` kills and relaunches `bench start`) after a successful restore (restore.py:175, invoked at 1398 and 1954). This is a deliberate, documented new default (skippable with `--no-migrate`), but it is a notable user-facing behavior change: a restore that previously only touched data will now start/restart the dev server even if the user had it stopped, and a failed migrate exits non-zero despite a successful restore. Noting the tradeoff for awareness; no action needed as it is intentional and documented in README/AGENTS.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run --extra dev pytest -q` (284 passed)</code>
- <code>`uv run --extra dev pytest tests/test_restore_inspect_fixes.py tests/test_restore_safety.py tests/test_inspect_partial_refresh.py tests/test_yes_flag.py` (61 passed)</code>
- <code>Verified docs-only commit vs code: `grep -n auto_enter src/.../restore.py` (4 confirms) and `grep -rn tcflush|termios|FIONREAD src/` (none)</code>
- <code>`cwcli inspect cwe2e6v14` and `cwcli inspect cwe2e6` — Sites(1), development.localhost marked (default) with no default_site key (fixes #3/#4)</code>
- <code>pty (pexpect) `cwcli restore cwe2e6v14 --mariadb-root-username root --no-migrate`, confirm driven y THEN Enter — username prompt skipped, password collected, restore succeeded (fix #2 flag path / auto_enter=False)</code>
- <code>pty `cwcli restore cwe2e6v14` default flow with migrate — username prompt shown, password collected, `Migrated site` + `Restarting instance` + `Instance restarted` (fixes #2 interactive, #6)</code>
- <code>Direct v14 repro: `bench restore &lt;bare-filename&gt;` → `Invalid path` vs `bench restore &lt;full-path&gt;` → `Site ... has been restored` (fix #1)</code>
- <code>Real-data missing-apps: called `check_missing_apps`/`_read_backup_installed_apps` on the v15 backup dump — `[&#39;frappe&#39;,&#39;widgets&#39;]`, `[]` vs real bench, `[&#39;widgets&#39;]` vs bench lacking widgets (fix #5)</code>
- `Counterfactual pty harness: questionary.confirm+password driven y THEN Enter — auto_enter=True → password='' (bug), auto_enter=False → password='123' (fix)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved default-site resolution across inspect/backup/restore/unlock using `common_site_config.json`’s `default_site` or `sites/currentsite.txt` fallback.
  * Added `restore --no-migrate` to skip post-restore migrate + restart.
* **Bug Fixes**
  * `restore --receive` now uses the full backup DB dump path and fixes restore argument ordering.
  * More consistent interactive vs non-interactive MariaDB root credential prompting, with safer validation.
  * Restore warns about missing apps based on backup dump contents; `inspect` no longer treats `currentsite.txt` as a site.
* **Documentation**
  * Updated README and command help text; added restore+inspect E2E evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->