### PR TITLE
docs: correct stale claims across docs/ to match shipped code

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -24,12 +24,17 @@ docs/
 │   └── ci-cd.md           # GitHub Actions & releases
 │
 ├── testing/               # Testing documentation
-│   ├── guide.md          # Complete testing guide
-│   ├── coverage-summary.md       # Current coverage status
-│   └── implementation-checklist.md   # Test tracking
+│   ├── README.md          # Testing directory index
+│   └── guide.md           # Complete testing guide
 │
-└── technical/             # Technical documentation & API reference
-    └── bench.md           # Bench management deep-dive
+├── technical/              # Technical documentation & API reference
+│   ├── README.md           # Technical directory index
+│   ├── bench.md            # Bench management deep-dive
+│   ├── frappe-backup-restore.md  # Frappe backup/restore mechanics
+│   ├── iroh-blobs-and-sendme.md  # Iroh/sendme protocol background
+│   └── sendme-doc.md       # sendme CLI reference
+│
+└── e2e/                    # Captured real-instance E2E evidence (historical, not living docs)
 ```
 
 ## Contributing
@@ -86,8 +91,7 @@ Everything related to writing and running tests.
 | Guide | Purpose | When to Read |
 |-------|---------|--------------|
 | **[Testing Guide](./testing/guide.md)** | How to write tests | When writing new tests |
-| **[Coverage Summary](./testing/coverage-summary.md)** | Current test status | To see what's tested |
-| **[Implementation Checklist](./testing/implementation-checklist.md)** | Test tracking | To see progress |
+| **[Testing Directory Index](./testing/README.md)** | Current coverage status and suite inventory | To see what's tested |
 
 ### Quick Reference
 
@@ -107,9 +111,8 @@ uv run pytest --cov --cov-report=html
 
 ### Current Status
 
-- **completion_utils.py**: 92% coverage (27 tests) ✅
-- **Overall project**: 7.46% coverage
-- **Target**: Expand to port utilities, Docker utils, commands
+- **Overall project**: ~41% coverage at 0.34.0 (321 tests across 18 test files; see the [Testing Directory](./testing/) for the per-module breakdown).
+- **Target**: Expand coverage on the modules that still have none (`port_utils.py`, `sendme_utils.py`, `vscode_utils.py`).
 
 See [Testing Directory](./testing/) for complete documentation.
 
@@ -121,7 +124,11 @@ Deep-dives into architecture, API, and implementation details.
 
 | Document | Topics Covered |
 |----------|----------------|
+| **[Technical Directory Index](./technical/README.md)** | Architecture overview, core systems, API reference |
 | **[Bench Management](./technical/bench.md)** | Bench instances, sites, apps, cache system |
+| **[Frappe Backup & Restore](./technical/frappe-backup-restore.md)** | Frappe's `bench backup`/`bench restore` mechanics and what cwcli provides today |
+| **[iroh-blobs and sendme](./technical/iroh-blobs-and-sendme.md)** | Protocol background for the P2P transfer used by `cwcli restore --send`/`--receive` |
+| **[sendme CLI Reference](./technical/sendme-doc.md)** | The underlying `sendme` binary's CLI reference |
 
 ### Architecture Overview
 
@@ -163,10 +170,10 @@ ports                # Port conflict detection
 
 ### Test Coverage
 
-- **Modules Tested**: 1 (completion_utils.py)
-- **Test Files**: 1 (test_completion_utils.py)
-- **Total Tests**: 27
-- **Coverage**: 92% for tested module
+- **Test Files**: 18
+- **Total Tests**: 321
+- **Overall Coverage**: ~41% at 0.34.0
+- See the [Testing Directory](./testing/) for the per-module breakdown.
 
 ## Common Tasks
 

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -7,6 +7,9 @@ This directory contains technical documentation, API references, and deep-dives 
 | Document | Purpose | Topics Covered |
 |----------|---------|----------------|
 | **[Bench Management](./bench.md)** | Bench system deep-dive | Bench instances, sites, apps, cache system |
+| **[Frappe Backup & Restore](./frappe-backup-restore.md)** | Frappe's `bench backup`/`bench restore` mechanics | Backup file naming, restore process, what cwcli provides today |
+| **[iroh-blobs and sendme](./iroh-blobs-and-sendme.md)** | P2P transfer protocol background | Iroh blobs, BLAKE3 verification, the sendme protocol |
+| **[sendme CLI Reference](./sendme-doc.md)** | The underlying `sendme` binary | `sendme send`/`sendme receive` flags and output |
 
 ## Overview
 
@@ -137,7 +140,7 @@ def my_command():
 
 ### Cache System
 
-**Location:** `~/caffeinated-whale-cli/cache/cwc-cache.db`
+**Location:** `~/.cwcli/cache/cwc-cache.db`
 
 **Schema:**
 ```sql
@@ -155,7 +158,7 @@ Project
 
 ### Configuration
 
-**Location:** `~/caffeinated-whale-cli/config/`
+**Location:** `~/.cwcli/config/`
 
 **Customization:**
 - Custom bench search paths
@@ -300,6 +303,8 @@ See [Testing Documentation](../testing/) for comprehensive testing guides.
 
 ## Future Architecture Plans
 
+Verified as still unshipped as of 0.34.0 (2026-07-08); re-check this list for staleness the next time this doc is substantially edited.
+
 ### Planned Enhancements
 
 1. **Plugin System** - Allow custom commands
@@ -331,7 +336,7 @@ cwcli inspect frappe-one -v
 
 ```bash
 # View cache database
-sqlite3 ~/caffeinated-whale-cli/cache/cwc-cache.db
+sqlite3 ~/.cwcli/cache/cwc-cache.db
 
 # List cached projects
 .tables
@@ -364,6 +369,8 @@ python -c "import docker; docker.from_env().ping()"
 | Tab completion | <200ms | 2s TTL cache |
 
 ### Optimization Opportunities
+
+Also unverified/unshipped as of 0.34.0 (2026-07-08).
 
 1. **Parallel container operations** - Start/stop multiple at once
 2. **Batch Docker queries** - Reduce API calls

--- a/docs/technical/frappe-backup-restore.md
+++ b/docs/technical/frappe-backup-restore.md
@@ -765,82 +765,66 @@ sites/*/private/backups/
 
 ## Integration with cwcli
 
-### Potential Commands
+### What cwcli Actually Provides Today
 
-Based on Frappe's backup/restore capabilities, cwcli could implement:
+Backup and restore shipped as `cwcli backup` and `cwcli restore` (flags verified against the Typer signatures in `src/caffeinated_whale_cli/commands/backup.py` and `restore.py` at 0.34.0), not as the `cwcli backup list`/`restore`/`cleanup` subcommand family sketched in an earlier draft of this doc.
 
-#### `cwcli backup`
+#### `cwcli backup` - create a backup
 
 ```bash
-# Backup project's default site
+# Backup the default site (resolved from common_site_config.json or currentsite.txt)
 cwcli backup my-project
 
-# Backup with files
-cwcli backup my-project --with-files --compress
+# Backup a specific site, with public and private files
+cwcli backup my-project --site example.com --with-files
 
-# Backup to external location
-cwcli backup my-project --path /mnt/backups
-
-# Database-only backup (fast)
-cwcli backup my-project --database-only
-
-# Exclude log tables
-cwcli backup my-project --exclude 'Error Log,Access Log'
+# Target a specific bench in a multi-bench project, auto-starting stopped containers
+cwcli backup my-project --bench 1 --yes
 ```
 
-#### `cwcli backup list`
+There is no `list`/`cleanup`/`--database-only`/`--exclude` subcommand or flag; `cwcli backup` runs `bench backup` for one site per invocation.
+
+#### `cwcli restore` - restore a site from a local backup
 
 ```bash
-# List available backups
-cwcli backup list my-project
+# Interactive backup-selection menu
+cwcli restore my-project
 
-# Output:
-┌─────────────────────┬──────────────┬──────────┬─────────┐
-│ Timestamp           │ Type         │ Site     │ Size    │
-├─────────────────────┼──────────────┼──────────┼─────────┤
-│ 2025-11-09 22:59:46 │ database     │ default  │ 45.2 MB │
-│ 2025-11-09 22:59:10 │ full (tar)   │ default  │ 2.1 GB  │
-│ 2025-11-09 22:57:26 │ full (tgz)   │ default  │892 MB   │
-└─────────────────────┴──────────────┴──────────┴─────────┘
+# Non-interactive: pick the newest backup for the target site
+cwcli restore my-project --latest --yes
 
-# Show grouped by backup set
-cwcli backup list my-project --grouped
+# Non-interactive: pick a specific backup file
+cwcli restore my-project --backup-file 20251109_225726-my_project-database.sql.gz --yes
 ```
 
-#### `cwcli backup restore`
+`--latest` and `--backup-file` are mutually exclusive selectors that replace the interactive menu; both require `--yes` (or an interactive TTY) to pass the destructive-restore confirmation.
+`--no-recache` is a **deprecated no-op** flag kept only for backward compatibility - the missing-apps check has read app availability live from the bench since the fixes in `docs/e2e/restore-inspect-e2e-r6.md`, so this flag no longer does anything.
+
+#### `cwcli restore --send` / `--receive` - P2P backup transfer
 
 ```bash
-# Restore latest backup
-cwcli backup restore my-project
+# On the source machine: share a backup via sendme
+cwcli restore my-project --send
 
-# Restore specific backup
-cwcli backup restore my-project --timestamp 20251109_225726
-
-# Restore with files
-cwcli backup restore my-project --with-files --timestamp 20251109_225726
-
-# Restore to different site
-cwcli backup restore my-project --to-site new-site.example.com
+# On the destination machine: receive and restore it
+cwcli restore my-project --receive --yes
 ```
 
-#### `cwcli backup cleanup`
+This is the "peer-to-peer restore" capability once sketched here as `cwcli backup send`/`backup receive`/`restore --from-peer`; see [sendme-doc.md](./sendme-doc.md#shipped-implementation) and the root [README's P2P Backup Transfer section](../../README.md#command-reference) for the full flag reference.
 
-```bash
-# Remove backups older than 30 days
-cwcli backup cleanup my-project --older-than 30
+#### `rm`'s backup-before-delete gate
 
-# Keep only last N backups
-cwcli backup cleanup my-project --keep 10
-
-# Dry run (show what would be deleted)
-cwcli backup cleanup my-project --older-than 30 --dry-run
-```
+`cwcli rm` is not a backup command, but it backs up every site before deleting a project's volumes: a failed or unverifiable `bench backup` aborts the removal before any container is touched.
+See the "Data-safety gates" section of the project's `AGENTS.md`/`CLAUDE.md` for the exact contract.
+`--no-backup` opts out.
 
 ### Implementation Considerations
 
+The sections below describe how the shipped commands are implemented, kept for background on the container-exec and security-validation approach (the code samples are illustrative, not verbatim - read the actual command modules for the current implementation).
+
 #### 1. Container Execution
 
-Since cwcli manages Docker containers, backup commands would execute inside the Frappe container:
+Since cwcli manages Docker containers, backup commands execute inside the Frappe container:
 
 ```python
 def backup_site(project_name: str, site: str = None, with_files: bool = False):
@@ -906,22 +890,6 @@ invalid_chars = [";", "&", "|", "$", "`", "(", ")", "<", ">", "\n", "\r", "\\"]
 if any(char in site for char in invalid_chars):
     raise ValueError("Invalid site name: shell metacharacters not allowed")
 ```
-
-### Future Roadmap
-
-**Phase 1: Read-Only Operations**
-- `cwcli backup list` - View existing backups
-- `cwcli backup info` - Show backup details
-- `cwcli backup verify` - Check backup integrity
-
-**Phase 2: Backup Creation**
-- `cwcli backup create` - Create new backups
-- `cwcli backup schedule` - Setup cron jobs
-- `cwcli backup cleanup` - Manage retention
-
-**Phase 3: Restore Operations**
-- `cwcli backup restore` - Restore from backups (with safety checks)
-- `cwcli backup test` - Test restore in temporary site
 
 ---
 

--- a/docs/technical/sendme-doc.md
+++ b/docs/technical/sendme-doc.md
@@ -808,11 +808,10 @@ sendme send -v myfile.txt
 
 ## Integration with cwcli
 
-### Planned Features
+### Shipped Implementation
 
 The cwcli project integrates sendme for peer-to-peer Frappe backup sharing.
-
-#### Current Implementation (v0.16.0)
+This shipped as `cwcli restore --send` / `cwcli restore --receive`, not as separate `backup send`/`backup receive` commands or a `restore --from-peer` flag - see the root [README's P2P Backup Transfer section](../../README.md#command-reference) for the full flag reference and example output.
 
 **Module:** `src/caffeinated_whale_cli/utils/sendme_utils.py`
 
@@ -822,28 +821,19 @@ The cwcli project integrates sendme for peer-to-peer Frappe backup sharing.
 - PATH setup for Unix and Windows
 - Clipboard integration
 
-#### Future cwcli Commands
-
-**Send backup to peer:**
+**Send a backup:**
 ```bash
-cwcli backup send my-project
+cwcli restore my-project --send
 # Internally: sendme send <backup-file> -c
 ```
 
-**Receive backup from peer:**
+**Receive and restore a backup:**
 ```bash
-cwcli backup receive iroh-blob:...
-# Internally: sendme receive <ticket>
-# Then: cwcli restore my-project --from-received
+cwcli restore my-project --receive
+# Internally: sendme receive <ticket>, then bench restore on the downloaded file
 ```
 
-**Interactive restore from remote:**
-```bash
-cwcli restore my-project --from-peer
-# Prompts for ticket
-# Downloads via sendme
-# Restores backup automatically
-```
+`-y`/`--yes` skips the destructive-restore and missing-apps confirmations on the receive path for scripted use; without a TTY and without `--yes`, cwcli refuses and exits non-zero rather than overwriting the site silently.
 
 ### Why sendme for Frappe Backups?
 
@@ -864,14 +854,14 @@ cwcli restore my-project --from-peer
 
 ```bash
 # Production server
-cwcli backup send production-site
+cwcli restore production-site --send
 # Output: Ticket copied to clipboard
 
 # Developer shares ticket via Slack
 
 # Developer laptop
-cwcli restore dev-site --receive-ticket iroh-blob:...
-# Downloads backup, verifies hash, restores automatically
+cwcli restore dev-site --receive
+# Prompts for the ticket, downloads, verifies hash, restores automatically
 ```
 
 ---

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -20,25 +20,32 @@ uv run pytest tests/test_completion_utils.py
 | Guide | Purpose | When to Read |
 |-------|---------|--------------|
 | **[Testing Guide](./guide.md)** | Complete testing documentation | When writing tests |
-| **[Coverage Summary](./coverage-summary.md)** | Current test coverage status | To see what's tested |
-| **[Implementation Checklist](./implementation-checklist.md)** | Test implementation tracking | To see completed work |
 
 ## Current Status
 
 ### Test Coverage
 
-- **completion_utils.py**: 92% (27 tests) ✅
-- **Overall project**: 7.46%
-- **Target**: Expand coverage to port utilities, Docker utils, commands
+Measured with `uv run pytest --cov` at 0.34.0: 321 tests across 18 test files, ~41% overall coverage.
+Per-area breakdown (highest-coverage module in each area; see the module list in each test file for what else it exercises):
+
+- **rm safety** (`test_rm_safety`, `test_rm_truth`, `test_rm_stopped`) - `commands/rm.py` ~76%
+- **restore safety** (`test_restore_safety`, `test_restore_inspect_fixes`) - `commands/restore.py` ~43%
+- **inspect freshness** (`test_inspect_partial_refresh`, `test_inspect_label_recovery`) - `commands/inspect.py` ~62%
+- **bench labels/selectors** (`test_bench_labels`, `test_bench_selector`, `test_bench_label_db_and_command`) - `utils/bench_labels.py` ~94%
+- **yes-flag contract** (`test_yes_flag`) - covers the `confirm_or_exit`/`ensure_containers_running` non-interactive contract across `start`, `config`, `logs`
+- **db security** (`test_db_security`) - `utils/db_utils.py` ~68%
+- **init reuse** (`test_init_reuse_bench`, `test_init_mariadb_flag`) - `commands/init.py` ~18% (only the reuse-bench and MariaDB-flag branches are covered)
+- **completion** (`test_completion_utils`) - `utils/completion_utils.py` ~92%
+- **tips** (`test_tips`) - `utils/tips.py` ~91%
+- **config validation** (`test_config_validation`) - config validation helpers in `utils/db_utils.py`
+- **exit codes** (`test_exit_codes`) - cross-command honest-exit-code contract
+
+**No dedicated suite** (only incidental coverage from other tests' mocking): `utils/port_utils.py` (~9%), `utils/docker_utils.py` (~37%), `utils/sendme_utils.py` (~9%), `utils/vscode_utils.py` (~16%).
+**Target**: add dedicated suites for those four modules next.
 
 ### Test Files
 
-```
-tests/
-├── __init__.py
-├── README.md
-└── test_completion_utils.py    # 27 tests, 92% coverage
-```
+Run `ls tests/` for the authoritative, current list; as of 0.34.0 it holds 18 `test_*.py` suites plus `bench_fakes.py` (shared fakes) and `README.md`.
 
 ## Testing Framework
 
@@ -208,16 +215,8 @@ uv run pytest --cov --cov-report=xml
 
 ### By Module
 
-```
-tests/
-├── test_completion_utils.py      # Completion utilities
-├── test_port_utils.py             # Port utilities (future)
-├── test_docker_utils.py           # Docker utilities (future)
-└── test_commands/                 # Command tests (future)
-    ├── test_start.py
-    ├── test_inspect.py
-    └── test_update.py
-```
+Tests are flat files in `tests/` named after the area they cover (e.g. `test_rm_safety.py`, `test_bench_labels.py`), not a mirrored `test_commands/`/`test_utils/` package tree.
+Run `ls tests/` for the current, authoritative list.
 
 ### By Type
 
@@ -280,36 +279,21 @@ The `Pytest` job is the intended required gate. See the [CI/CD Workflows guide](
 
 ## Future Test Priorities
 
-Based on code complexity and criticality:
+Status as of 0.34.0 (based on `ls tests/` and the coverage run above):
 
-### High Priority
-1. **Port Conflict Detection** (`commands/start.py`)
-   - Complex multi-stage logic
-   - Interactive prompts
-   - Critical UX feature
+### Done
+1. **Project Inspection** (`commands/inspect.py`) - covered by `test_inspect_partial_refresh`, `test_inspect_label_recovery` (~62%).
+2. **Database Operations** (`utils/db_utils.py`) - covered by `test_db_security`, `test_config_validation` (~68%).
 
-2. **Project Inspection** (`commands/inspect.py`)
-   - Core functionality
-   - Cache integration
-   - Complex data gathering
+### Partial
+3. **Port Conflict Detection** (`commands/start.py`) - `test_yes_flag` covers the non-interactive/`--yes` contract, but the port-scanning and interactive-resolution logic itself has no dedicated suite (~59%).
 
-3. **Docker Utilities** (`utils/docker_utils.py`)
-   - Foundation for all commands
-   - Error handling critical
-
-### Medium Priority
-4. **Database Operations** (`utils/db_utils.py`)
-   - Cache consistency
-   - Data integrity
-
-5. **Port Utilities** (`utils/port_utils.py`)
-   - Cross-platform behavior
-   - Process detection
-
-### Lower Priority
-6. **VS Code Integration** (`utils/vscode_utils.py`)
-7. **Configuration Management** (`utils/config_utils.py`)
-8. Other command modules
+### Still needed
+4. **Docker Utilities** (`utils/docker_utils.py`) - foundation for all commands; error handling untested by a dedicated suite (~37%, all incidental).
+5. **Port Utilities** (`utils/port_utils.py`) - cross-platform process detection (~9%).
+6. **VS Code Integration** (`utils/vscode_utils.py`) - container attachment fallback logic (~16%).
+7. **Configuration Management** (`utils/config_utils.py`) - distinct from `db_utils`'s config validation, which `test_config_validation` already covers (~37%).
+8. Other command modules at or near 0%: `backup.py`, `list.py`, `run.py`, `status.py`, `unlock.py`, `where.py`.
 
 ## Common Issues
 

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -56,13 +56,9 @@ uv run pytest -x
 
 ### Current Test Coverage
 
-- **`test_completion_utils.py`** - Tab completion utilities (92% coverage)
-  - Project name completion
-  - App name completion
-  - Site name completion
-  - Bench name completion
-  - Cache functionality
-  - Docker client management
+`tests/` holds 18 `test_*.py` suites totaling 321 tests at ~41% overall coverage (measured with `uv run pytest --cov` at 0.34.0).
+See the [Testing Directory Index](./README.md#current-status) for the full per-area breakdown.
+`test_completion_utils.py` remains the most complete single-module suite (tab completion, ~92% coverage): project name completion, app name completion, site name completion, bench name completion, cache functionality, Docker client management.
 
 ### Test Organization
 
@@ -201,7 +197,7 @@ def temp_cache():
 
 - **Minimum**: 80% coverage for new code
 - **Target**: 90%+ coverage for critical paths
-- **Current**: 92% for completion utilities
+- **Current**: ~41% overall at 0.34.0; `completion_utils.py` is the highest-covered module at ~92% (see the [Testing Directory Index](./README.md#current-status) for the rest)
 
 ### Checking Coverage
 
@@ -320,13 +316,13 @@ uv run pytest -l  # Show local variables
 
 ## Future Test Coverage
 
-Areas that need test coverage:
+Status as of 0.34.0 (see the [Testing Directory Index](./README.md#future-test-priorities) for the full list):
 
-- [ ] `commands/inspect.py` - Project inspection logic
-- [ ] `commands/start.py` - Port conflict detection
+- [x] `commands/inspect.py` - Project inspection logic (`test_inspect_partial_refresh`, `test_inspect_label_recovery`)
+- [x] `utils/db_utils.py` - Cache database operations (`test_db_security`, `test_config_validation`)
+- [~] `commands/start.py` - Port conflict detection; `test_yes_flag` covers the non-interactive contract, but the port-scanning logic itself has no dedicated suite
 - [ ] `utils/port_utils.py` - Port management
 - [ ] `utils/docker_utils.py` - Docker interactions
-- [ ] `utils/db_utils.py` - Cache database operations
 - [ ] Integration tests for full command flows
 
 ## Resources

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -58,7 +58,7 @@ uv run pytest -x
 
 `tests/` holds 18 `test_*.py` suites totaling 321 tests at ~41% overall coverage (measured with `uv run pytest --cov` at 0.34.0).
 See the [Testing Directory Index](./README.md#current-status) for the full per-area breakdown.
-`test_completion_utils.py` remains the most complete single-module suite (tab completion, ~92% coverage): project name completion, app name completion, site name completion, bench name completion, cache functionality, Docker client management.
+`test_completion_utils.py` remains the most complete single-module suite (tab completion, ~92% coverage): project name completion, app name completion, site name completion, cache functionality, Docker client management.
 
 ### Test Organization
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,6 +32,11 @@ uv run pytest --pdb
 
 ## Test Files
 
+As of 0.34.0, `tests/` holds 18 `test_*.py` suites totaling 321 tests at ~41%
+overall coverage (measured with `uv run pytest --cov`). Run `ls tests/` for the
+authoritative current list; see [../docs/testing/README.md](../docs/testing/README.md)
+for the per-area breakdown.
+
 ### `test_completion_utils.py`
 Tests for tab completion functionality.
 
@@ -41,7 +46,6 @@ Tests for tab completion functionality.
 - Project name completion from Docker
 - App name completion from cache
 - Site name completion from cache
-- Bench name completion from cache
 - Cache TTL behavior
 - Docker client reuse
 - Error handling
@@ -50,24 +54,28 @@ Tests for tab completion functionality.
 - `TestCompleteProjectNames` - 7 tests
 - `TestCompleteAppNames` - 6 tests
 - `TestCompleteSiteNames` - 4 tests
-- `TestCompleteBenchNames` - 3 tests
 - `TestCacheHelpers` - 4 tests
 - `TestGetDockerClient` - 3 tests
 
 ## Test Coverage
 
-Current overall coverage: **7.46%** (only completion_utils tested)
+Current overall coverage: **~41%** at 0.34.0 (321 tests across 18 test files).
 
 ### Covered Modules
-- ✅ `utils/completion_utils.py` - 92% (9 missing lines)
-- ⚠️ `utils/db_utils.py` - 48% (partial coverage from mocking)
+- ✅ `utils/completion_utils.py` - 92% (7 missing lines)
+- ✅ `utils/bench_labels.py` - ~94% (`test_bench_labels`, `test_bench_selector`, `test_bench_label_db_and_command`)
+- ✅ `utils/db_utils.py` - ~68% (`test_db_security`, `test_config_validation`)
+- ✅ `commands/inspect.py` - ~62% (`test_inspect_partial_refresh`, `test_inspect_label_recovery`)
+- ✅ `commands/restore.py` - ~43% (`test_restore_safety`, `test_restore_inspect_fixes`)
+- ✅ `commands/rm.py` - ~76% (`test_rm_safety`, `test_rm_truth`, `test_rm_stopped`)
 
-### Modules Needing Tests
-- ❌ All command modules (0% coverage)
-- ❌ `utils/port_utils.py` (0% coverage)
-- ❌ `utils/docker_utils.py` (0% coverage)
-- ❌ `utils/vscode_utils.py` (0% coverage)
-- ❌ `utils/config_utils.py` (0% coverage)
+### Modules Needing Dedicated Suites
+- ⚠️ `utils/port_utils.py` (~9%, only incidental coverage)
+- ⚠️ `utils/docker_utils.py` (~37%, only incidental coverage)
+- ⚠️ `utils/sendme_utils.py` (~9%, only incidental coverage)
+- ⚠️ `utils/vscode_utils.py` (~16%, only incidental coverage)
+- ⚠️ `utils/config_utils.py` (~37%, distinct from `db_utils`'s config validation)
+- ⚠️ Command modules at or near 0% dedicated coverage: `backup.py`, `list.py`, `run.py`, `status.py`, `unlock.py`, `where.py`
 
 ## Writing New Tests
 
@@ -178,26 +186,22 @@ This can happen if pytest finds tests in multiple locations. Use `testpaths` in 
 
 ## Future Test Priorities
 
-1. **Port conflict detection** (`commands/start.py`)
-   - Most complex logic in codebase
-   - Critical for user experience
-   - High risk of regression
+Status as of 0.34.0 (see [../docs/testing/README.md](../docs/testing/README.md) for the full list):
 
-2. **Project inspection** (`commands/inspect.py`)
-   - Core functionality
-   - Cache system testing
+### Done
+1. **Project inspection** (`commands/inspect.py`) - covered by `test_inspect_partial_refresh`, `test_inspect_label_recovery` (~62%).
+2. **Database operations** (`utils/db_utils.py`) - covered by `test_db_security`, `test_config_validation` (~68%).
 
-3. **Docker utilities** (`utils/docker_utils.py`)
-   - Foundation for all commands
-   - Error handling critical
+### Partial
+3. **Port conflict detection** (`commands/start.py`) - `test_yes_flag` covers the non-interactive/`--yes` contract, but the port-scanning and interactive-resolution logic has no dedicated suite (~59%).
 
-4. **Database operations** (`utils/db_utils.py`)
-   - Data integrity
-   - Cache consistency
-
-5. **Integration tests**
-   - Full command workflows
-   - End-to-end scenarios
+### Still needed
+4. **Docker utilities** (`utils/docker_utils.py`) - foundation for all commands; error handling only incidentally covered (~37%).
+5. **Port utilities** (`utils/port_utils.py`) - cross-platform process detection (~9%).
+6. **VS Code integration** (`utils/vscode_utils.py`) - container attachment fallback (~16%).
+7. **Configuration management** (`utils/config_utils.py`) - distinct from `db_utils`'s config validation (~37%).
+8. **Integration tests** - full command workflows, end-to-end scenarios.
+9. Other command modules at or near 0%: `backup.py`, `list.py`, `run.py`, `status.py`, `unlock.py`, `where.py`.
 
 ## Resources
 


### PR DESCRIPTION
## Intent

Fix every stale doc claim in docs/ (plus the root README where verified false) so an agent or human reading the docs reaches true conclusions about the shipped code, per GitHub issue #43. This is documentation-only, zero runtime code changes. Specifically: removed dead links to docs/testing/coverage-summary.md and implementation-checklist.md (files that were never created - removed the references rather than creating placeholder files, since a static coverage doc goes stale immediately); corrected the cache and config paths from the wrong ~/caffeinated-whale-cli/{cache,config} to the real ~/.cwcli/{cache,config} (verified against src/caffeinated_whale_cli/utils/db_utils.py and config_utils.py); rewrote docs/technical/sendme-doc.md and docs/technical/frappe-backup-restore.md, which proposed future commands like 'cwcli backup send/receive' and 'restore --from-peer' that were never built - replaced with the actual shipped 'cwcli restore --send/--receive' flags (verified against the Typer signatures in src/caffeinated_whale_cli/commands/restore.py and backup.py), keeping two clearly-marked historical mentions of the old proposed names for context; replaced testing docs that claimed 7.46% coverage and 27 tests (only test_completion_utils.py) with the real measured numbers from running 'uv run pytest --cov': 321 tests across 18 test files, ~41% overall coverage at version 0.34.0, plus an honest per-area suite inventory grouped by feature area, and marked start.py's test coverage as 'partial' rather than done or missing since it only has incidental coverage via test_yes_flag; fixed docs/README.md's documentation index so it lists the real docs/technical/ directory contents (5 files, was showing only 1); date-stamped the 'Future Architecture Plans' section as still-unshipped as of 0.34.0. Deliberately left docs/e2e/ and CHANGELOG.md untouched since those are historical evidence, not living docs. Kept restore's --no-recache flag documented as a deprecated no-op (real flag, kept for backward compatibility) rather than deleting it or describing it as functional. Every relative link in edited files was verified to resolve, and the mypy zero-error gate documentation was left unweakened. Full test suite, mypy, black, and ruff all pass with a docs-only diff.

## What Changed

- Fixed stale or wrong paths and links throughout `docs/` and `tests/README.md`: corrected cache/config paths from `~/caffeinated-whale-cli/{cache,config}` to the real `~/.cwcli/{cache,config}`, removed dead links to never-created `coverage-summary.md` / `implementation-checklist.md`, and refreshed the `docs/README.md` index to list the real 5-file `docs/technical/` tree.
- Rewrote `docs/technical/sendme-doc.md` and `docs/technical/frappe-backup-restore.md` to describe the shipped `cwcli restore --send/--receive` flags instead of proposed-but-unbuilt `backup send/receive` and `restore --from-peer`, keeping two clearly-marked historical mentions of the old proposed names for context.
- Replaced stale testing-coverage claims (7.46% / 27 tests) with the measured 321 tests across 18 files at ~41% overall coverage on 0.34.0, added an honest per-area suite inventory, marked `start.py` coverage as partial, and date-stamped the still-unshipped "Future Architecture Plans" section. No runtime code changed.

## Risk Assessment

✅ Low: Documentation-only diff with no runtime code changes; all factual claims (paths, CLI flags, test counts, cross-doc links) verified against the shipped source and resolve correctly.

## Testing

Verified the docs-only change against shipped code and by running the real test suite. All factual claims now hold: cache/config paths (~/.cwcli/cache, ~/.cwcli/config) match APP_NAME=".cwcli" in db_utils.py/config_utils.py; dead links to coverage-summary.md/implementation-checklist.md are fully removed; restore --send/--receive/--latest/--backup-file/--no-recache/--yes/--no-migrate/--site/--bench and backup --site/--with-files/--bench/--yes (with no list/cleanup/--database-only/--exclude) match the Typer signatures in restore.py/backup.py; --no-recache is correctly documented as a deprecated no-op. Ran `uv run --extra dev pytest --cov` and got exactly the numbers the docs state: 321 tests passed, 41.34% overall coverage, 18 test files, with every per-area coverage figure in docs/testing/README.md matching the measured run. docs/technical/ has 5 files as the docs/README.md tree now shows, and all new relative links and anchors (sendme-doc.md#shipped-implementation, README.md#command-reference, technical/README.md, testing/README.md) resolve to real targets. Root README already used the correct paths/flags. No stale claims remain; the few "backup send/receive/--from-peer" mentions are the author's deliberately-marked historical context.

<details>
<summary>Evidence: pytest --cov summary (full run)</summary>

<code>==== tests coverage ====&#10;_______________ coverage: platform linux, python 3.13.14-final-0 _______________&#10;&#10;TOTAL 5540 3250 41.34%&#10;= 321 passed in 4.97s ==&#10;&#10;Per-module (selected, matches docs/testing/README.md claims):&#10;commands/rm.py 76.45% (doc: ~76%)&#10;commands/restore.py 42.84% (doc: ~43%)&#10;commands/inspect.py 62.29% (doc: ~62%)&#10;utils/bench_labels.py 94.19% (doc: ~94%)&#10;utils/db_utils.py 67.86% (doc: ~68%)&#10;commands/init.py 17.79% (doc: ~18%)&#10;utils/completion_utils.py 92.22% (doc: ~92%)&#10;utils/tips.py 91.30% (doc: ~91%)&#10;utils/port_utils.py 9.38% (doc: ~9%)&#10;utils/docker_utils.py 37.29% (doc: ~37%)&#10;utils/sendme_utils.py 9.00% (doc: ~9%)&#10;utils/vscode_utils.py 16.42% (doc: ~16%)&#10;commands/start.py 58.80% (doc: ~59%)&#10;utils/config_utils.py 36.90% (doc: ~37%)</code>

```text
tests/test_restore_safety.py ........................                    [ 62%]
tests/test_rm_safety.py ................................................ [ 77%]
....                                                                     [ 78%]
tests/test_rm_stopped.py ..........                                      [ 81%]
tests/test_rm_truth.py ..................                                [ 87%]
tests/test_tips.py ........................                              [ 95%]
tests/test_yes_flag.py ................                                  [100%]

================================ tests coverage ================================
_______________ coverage: platform linux, python 3.13.14-final-0 _______________

Name                                                  Stmts   Miss   Cover   Missing
------------------------------------------------------------------------------------
src/caffeinated_whale_cli/commands/backup.py            111    111   0.00%   1-224
src/caffeinated_whale_cli/commands/config.py            271    188  30.63%   26, 36-39, 49-52, 85-88, 103, 111-123, 151-167, 172-174, 182-192, 209-244, 259-263, 271-304, 314-319, 334-341, 344-346, 354-378, 390-422, 433-455, 469-470, 485-491, 499-516
src/caffeinated_whale_cli/commands/init.py              416    342  17.79%   65-84, 88-102, 111-127, 143-192, 197-198, 203-209, 287-302, 311-347, 352-368, 373-392, 396, 418-428, 437-462, 467-473, 478-481, 492-493, 513-532, 552-584, 669-1030
src/caffeinated_whale_cli/commands/inspect.py           297    112  62.29%   31, 36-37, 60, 71, 80, 102, 134, 138-149, 168, 172-177, 180, 191, 202, 225-227, 239, 288, 329, 334, 391, 403, 409, 452, 459-474, 477, 481, 505-506, 513-516, 539, 545-546, 557-612, 624-666
src/caffeinated_whale_cli/commands/label.py              63      6  90.48%   62-66, 84-87, 137-141
src/caffeinated_whale_cli/commands/list.py               91     91   0.00%   1-174
src/caffeinated_whale_cli/commands/logs.py               43     30  30.23%   53-116
src/caffeinated_whale_cli/commands/open.py              142     84  40.85%   73-76, 95-96, 104-107, 110, 125, 131-180, 189-192, 203-207, 232-234, 237-240, 253, 260-265, 267-272, 274-279, 286-351, 354, 362
src/caffeinated_whale_cli/commands/restart.py            57     20  64.91%   29-46, 76, 82-83, 86-89, 110-115
src/caffeinated_whale_cli/commands/restore.py           922    527  42.84%   46, 53-54, 117-119, 121-122, 132-134, 167, 171, 199, 245, 262-323, 340-370, 385-407, 440, 443, 446-447, 501-505, 515, 563, 569, 575, 603-618, 622-638, 678, 698-925, 966-967, 974-977, 981-1035, 1041-1066, 1079-1080, 1087-1088, 1104, 1111-1126, 1135-1136, 1141-1142, 1148-1149, 1152-1154, 1172-1173, 1176-1179, 1191-1199, 1206, 1221-1225, 1282-1294, 1331-1333, 1357-1358, 1371, 1384-1390, 1400-1446, 1453-1470, 1581-1584, 1597-1601, 1611-1619, 1637-1638, 1645-1648, 1652, 1656-1710, 1716-1741, 1745-1746, 1750-1754, 1758-1762, 1769-1772, 1779-1780, 1828-1835, 1899-1901, 1918, 1920, 1941-1943, 1961-1965, 1972-1973, 1979-1980, 1995-1996, 2000-2001, 2004-2005, 2009, 2020-2023, 2030, 2034-2093, 2100-2116
src/caffeinated_whale_cli/commands/rm.py                501    118  76.45%   57-58, 78, 155, 158, 173, 205-209, 213, 224, 233, 240, 251-255, 286, 297-298, 304, 322-328, 361, 375-382, 385, 399-408, 413-414, 431-437, 478, 485, 487, 497, 552, 563, 579, 587, 625, 632, 648, 729, 763-765, 773, 782, 831, 838, 840, 847, 849, 860, 868, 904, 914, 934, 1081-1082, 1085-1088, 1125-1142, 1148-1187, 1193, 1233-1239, 1249, 1270
src/caffeinated_whale_cli/commands/run.py                29     29   0.00%   1-78
src/caffeinated_whale_cli/commands/start.py             233     96  58.80%   44-48, 51, 60-62, 65, 75-80, 106-110, 144-150, 155, 163-195, 198-229, 273-278, 286-289, 310, 316, 335-339, 348, 352, 368-369, 371, 377, 400, 407-412, 461, 463, 465-467, 469, 476-477, 480-483, 501-506, 529-530
src/caffeinated_whale_cli/commands/status.py             44     44   0.00%   1-76
src/caffeinated_whale_cli/commands/stop.py               56     11  80.36%   30, 35-40, 44, 79, 85-86, 89-92
src/caffeinated_whale_cli/commands/unlock.py             87     87   0.00%   1-192
src/caffeinated_whale_cli/commands/update.py            424    290  31.60%   24-64, 71-77, 126-179, 204-205, 212-215, 226-265, 278-284, 313-315, 328-330, 337-343, 352, 361, 365-369, 406-407, 418, 422-446, 452-469, 475-493, 518-755, 775, 782-798, 821-823, 826-830, 833-837, 840-844, 847-851, 935-940
src/caffeinated_whale_cli/commands/utils.py             108     30  72.22%   57, 67, 75, 84, 113-115, 118, 129, 188, 199, 253-255, 280-308
src/caffeinated_whale_cli/commands/where.py             100    100   0.00%   7-274
src/caffeinated_whale_cli/main.py                        49     49   0.00%   1-84
src/caffeinated_whale_cli/utils/auto_inspect.py         154    131  14.94%   27, 32-48, 53-60, 65-74, 79-94, 99-118, 123-140, 145-225, 250-252, 257-264, 269-271, 276-307, 312-317
src/caffeinated_whale_cli/utils/bench_labels.py          86      5  94.19%   152, 155, 161, 198-199
src/caffeinated_whale_cli/utils/bench_sites.py           36      6  83.33%   49-51, 79-81, 105-106
src/caffeinated_whale_cli/utils/cache.py                  9      1  88.89%   51
src/caffeinated_whale_cli/utils/completion_utils.py      90      7  92.22%   112-114, 136, 184, 198, 211-212
src/caffeinated_whale_cli/utils/config_utils.py          84     53  36.90%   55-56, 66, 68, 70, 76, 78, 80, 82-83, 92-94, 99-104, 109-114, 119-123, 128-133, 138-145, 150-155, 165-167, 177-182
src/caffeinated_whale_cli/utils/console.py                3      0 100.00%
src/caffeinated_whale_cli/utils/db_utils.py             280     90  67.86%   26-29, 180, 222-225, 240, 259, 285-286, 324-325, 331-334, 367-370, 376, 393-395, 402-409, 433, 439-451, 470, 479-480, 493-494, 506-507, 532-533, 541-543, 563-593, 607-630, 650-654
src/caffeinated_whale_cli/utils/docker_utils.py          59     37  37.29%   25-27, 33-43, 63-73, 91-101, 117-134, 160-166
src/caffeinated_whale_cli/utils/port_utils.py           160    145   9.38%   34, 42-62, 75-106, 122-165, 179-188, 206-218, 236-318, 334-345
src/caffeinated_whale_cli/utils/sendme_utils.py         211    192   9.00%   33-62, 67, 72-75, 81-86, 91-106, 120-145, 158-264, 275-363, 378-408, 419-428
src/caffeinated_whale_cli/utils/startup.py              121    100  17.36%   20, 26-38, 43-52, 57-66, 71-80, 90, 95, 100-138, 143-154, 164, 169, 174-224, 229-250, 260-268, 273-296, 301-309
src/caffeinated_whale_cli/utils/tips.py                  69      6  91.30%   164-172
src/caffeinated_whale_cli/utils/vscode_utils.py         134    112  16.42%   21, 26, 31, 42-72, 77-90, 95-108, 115-141, 146, 153, 160, 175-253
------------------------------------------------------------------------------------
TOTAL                                                  5540   3250  41.34%
============================= 321 passed in 4.97s ==============================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 667928ac..d393b64 --name-only` - confirmed docs-only (6 files under docs/, no src/test changes)</code>
- <code>`grep -rn &#39;coverage-summary|implementation-checklist&#39; docs/` - confirmed dead links fully removed</code>
- <code>`grep -rn &#39;caffeinated-whale-cli/(cache|config)&#39; docs/` - confirmed wrong paths fully removed</code>
- <code>`grep APP_NAME / CACHE_DIR / CONFIG_DIR src/.../utils/{db_utils,config_utils}.py` - verified ~/.cwcli/cache and ~/.cwcli/config paths</code>
- <code>`grep -nE &#39;--send|--receive|--latest|--backup-file|--no-recache|--yes|--no-migrate|--site|--bench&#39; src/.../commands/restore.py` - verified restore flag signatures</code>
- <code>`grep -nE &#39;--site|--with-files|--bench|--yes|--database-only|--exclude&#39; src/.../commands/backup.py` - verified backup flags and absence of list/cleanup/--database-only/--exclude</code>
- <code>`uv run --extra dev pytest --cov=src/caffeinated_whale_cli` - 321 passed, 41.34% total, 18 files (matches docs)</code>
- `checked each per-area coverage % in docs/testing/README.md against the coverage run output (all match)`
- <code>`ls docs/technical/` and `ls docs/testing/` - verified 5 technical files / 2 testing files match the docs/README.md tree</code>
- `verified new relative links/anchors resolve: ./sendme-doc.md#shipped-implementation (heading line 811), ../../README.md#command-reference (root README line 65), ./technical/README.md, ./testing/README.md`
- <code>`grep -nE &#39;backup send|--from-peer|--database-only&#39; README.md` - confirmed root README has no stale claims (already correct)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the docs to match the current structure, with clearer sections for testing and technical topics.
  * Added and expanded guides for backup/restore, P2P transfer, and the sendme CLI reference.
  * Refreshed testing information with the latest suite count, coverage figures, and module-by-module status.
  * Clarified current supported backup/restore workflows and updated examples to reflect what is available today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->