### PR TITLE
feat(init): make existing-bench flow non-interactive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,13 +116,26 @@ Other per-branch settings nearby in `init.py`: Python version (`branch_python`: 
 #### `init` existing-bench flow: decline must continue, not dead-end
 
 The devcontainer image ships a `/workspace/frappe-bench`, so a fresh `cwcli init` usually finds an already-existing bench at the default `bench_parent/bench_name`.
-`_resolve_bench_target(frappe_container, bench_parent_path, bench_name)` in `init.py` owns this branch and returns `(bench_name, bench_full_path, bench_exists)`.
-When the bench exists it asks "Reuse the existing bench ...?": Yes reuses it (returns `bench_exists=True` so `bench init` is skipped); No now prompts for a different bench name and loops, so site setup continues on a fresh bench (returns `bench_exists=False`).
-A blank replacement name or a cancelled prompt (`.ask()` returns `None`) exits cleanly with code 0 and "No changes made.".
+`_resolve_bench_target(frappe_container, bench_parent_path, bench_name, reuse_bench=None)` in `init.py` owns this branch and returns `(bench_name, bench_full_path, bench_exists)`.
+
+The tri-state `reuse_bench: bool | None` flag (`init`'s `--reuse-bench/--no-reuse-bench`, default `None`) pre-answers the existing-bench question so the command is fully agent-drivable (issue #41).
+When the bench exists, the resolver short-circuits BEFORE the interactive `while bench_exists` loop:
+- `reuse_bench is True` (`--reuse-bench`): reuse with no prompt, return `bench_exists=True` (`bench init` skipped), exactly like an interactive Yes.
+- `reuse_bench is False` (`--no-reuse-bench`): refuse to reuse; print an error naming the path and advising a different `--bench`, then `raise typer.Exit(1)`. It must NEVER enter the rename loop (a non-interactive loop would spin forever).
+- `reuse_bench is None` and `sys.stdin.isatty()`: the unchanged interactive issue #20 loop below.
+- `reuse_bench is None` and NOT a TTY: refuse with an honest `Exit(1)` naming both flags, BEFORE touching questionary. This replaces the old non-TTY hang (idle pipe) / `EOFError` crash (closed stdin); `.ask()` only catches `KeyboardInterrupt`, so the guard must be `sys.stdin.isatty()` checked up front.
+When the bench does NOT exist the flag is irrelevant (returns `bench_exists=False`); `--no-reuse-bench` with a fresh name is a useful no-op that just asserts freshness ("create a NEW bench or fail").
+
+Interactive loop (only reached when `reuse_bench is None` AND a TTY): "Reuse the existing bench ...?": Yes reuses it (`bench_exists=True`, `bench init` skipped); No prompts for a different bench name and loops, so site setup continues on a fresh bench (`bench_exists=False`).
+A blank replacement name or a cancelled prompt (`.ask()` returns `None`) exits cleanly with code 0 and "No changes made." - this exit-0 interactive-cancel is the DELIBERATE issue #20 behavior; only the NON-TTY path (where "no changes" is a failure to do the requested job) exits 1.
 This replaced the old behavior where declining reuse just `raise typer.Exit(0)` and aborted the whole command (issue #20).
 The resolver runs after the setup spinner has exited, so its prompts own the terminal; keep it out of any `console.status`/`TipSpinner` block.
 `inputs.bench_name` is reassigned from the resolver's return (so `bench init` and the site paths use the chosen name), which is valid because `InitInputs` is a plain mutable `@dataclass`.
-Regression coverage is in `tests/test_init_reuse_bench.py`.
+
+Spinner-race fix (issue #41): `ensure_containers_running` used to be called INSIDE init's `TipSpinner` with `prompt=True`, so a slow container start with no `--auto-start` could paint a questionary confirm under the live spinner (the repo's known deadlock pattern).
+Now `_wait_for_containers_running(project, ...)` runs a bounded SILENT poll (`ensure_containers_running(..., prompt=False, auto_start=False)`, ~10 x 0.5s) INSIDE the spinner - safe because it never prompts and absorbs normal startup latency (a container is often ~200ms from ready right after `compose up -d`, so a single check mis-reads it as down).
+Only if that returns `False` does init call `ensure_containers_running(..., auto_start=auto_start)` (which prompts on a TTY or refuses on a non-TTY) OUTSIDE the spinner, then fetches the frappe container. `--reuse-bench` and `--auto-start` are separate axes (bench reuse vs container start); do not merge them.
+Regression coverage is in `tests/test_init_reuse_bench.py` (flag/non-TTY resolver cases in `TestReuseBenchFlag`, poll behavior in `TestWaitForContainersRunning`).
 
 ### `inspect` command: 3-tier freshness model (cache / partial / full)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ The source of truth for the user-facing feature set is `README.md`.
 
 - `src/caffeinated_whale_cli/commands/` - one module per CLI command (`init`, `inspect`, `rm`, `restore`, `start`, `run`, `label`, `config`, ...) plus `utils.py` (shared resolver, confirm, container-running helpers).
 - `src/caffeinated_whale_cli/utils/` - cross-command building blocks: `db_utils.py` (SQLite cache + migrations + secret redaction), `bench_labels.py` (label model + marker I/O), `bench_sites.py` (site detection), `docker_utils.py`, `cache.py`, `sendme_utils.py`.
-- `tests/` - pytest suites (18 `test_*.py` files, ~321 tests); `bench_fakes.py` holds the container fakes. See `tests/README.md` for the coverage map.
+- `tests/` - pytest suites (18 `test_*.py` files, ~329 tests); `bench_fakes.py` holds the container fakes. See `tests/README.md` for the coverage map.
 - `docs/e2e/` - worked real-instance E2E evidence (the canonical examples for the recipe below); `docs/technical/`, `docs/testing/`, `docs/contributing/` hold design, test, and workflow docs.
 - Version-bump touches exactly four files: `pyproject.toml` (`version`), `src/caffeinated_whale_cli/__init__.py` (`__version__`), `uv.lock` (regenerate with `uv lock`), and `CHANGELOG.md`.
 - `.github/workflows/` - `lint.yml`, `test.yml`, `build.yml`, `release.yml`.

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ cwcli init [OPTIONS] [PROJECT_NAME]
 | `--install-erpnext` | Install ERPNext application after initialization |
 | `--erpnext-branch TEXT` | ERPNext branch to use (default: version-15) |
 | `--auto-start` | Automatically start containers if not running |
+| `--reuse-bench` / `--no-reuse-bench` | Pre-answer the existing-bench question non-interactively: `--reuse-bench` reuses the bench and skips `bench init`; `--no-reuse-bench` requires a fresh `--bench` name and errors if it already exists. Default: ask interactively (a non-TTY without either flag refuses). Distinct from `--auto-start`, which controls container startup |
 | `-v`, `--verbose` | Show verbose output with streaming command execution |
 
 **What It Does:**
@@ -195,6 +196,19 @@ Leaving the name blank (or cancelling either prompt) makes no changes and exits 
 ```
 No changes made.
 ```
+
+**Non-interactive (agents/automation):** pass a flag so `init` never prompts.
+Re-running `init` against the devcontainer's shipped bench, pass `--reuse-bench`:
+
+```bash
+# Reuse the existing bench and run site setup with zero prompts (skips bench init)
+cwcli init my-project --reuse-bench --auto-start
+
+# Require a brand-new bench; error out if the name already exists
+cwcli init my-project --bench fresh-bench --no-reuse-bench
+```
+
+Without a reuse flag, a non-interactive session (non-TTY) where the bench already exists refuses honestly with exit 1 instead of hanging, and names `--reuse-bench`/`--no-reuse-bench`.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,7 @@ uv run pytest --cov --cov-report=html
 
 ### Current Status
 
-- **Overall project**: ~41% coverage at 0.34.0 (321 tests across 18 test files; see the [Testing Directory](./testing/) for the per-module breakdown).
+- **Overall project**: ~42% coverage at 0.34.0 (329 tests across 18 test files; see the [Testing Directory](./testing/) for the per-module breakdown).
 - **Target**: Expand coverage on the modules that still have none (`port_utils.py`, `sendme_utils.py`, `vscode_utils.py`).
 
 See [Testing Directory](./testing/) for complete documentation.
@@ -171,8 +171,8 @@ ports                # Port conflict detection
 ### Test Coverage
 
 - **Test Files**: 18
-- **Total Tests**: 321
-- **Overall Coverage**: ~41% at 0.34.0
+- **Total Tests**: 329
+- **Overall Coverage**: ~42% at 0.34.0
 - See the [Testing Directory](./testing/) for the per-module breakdown.
 
 ## Common Tasks

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -25,7 +25,7 @@ uv run pytest tests/test_completion_utils.py
 
 ### Test Coverage
 
-Measured with `uv run pytest --cov` at 0.34.0: 321 tests across 18 test files, ~41% overall coverage.
+Measured with `uv run pytest --cov` at 0.34.0: 329 tests across 18 test files, ~42% overall coverage.
 Per-area breakdown (highest-coverage module in each area; see the module list in each test file for what else it exercises):
 
 - **rm safety** (`test_rm_safety`, `test_rm_truth`, `test_rm_stopped`) - `commands/rm.py` ~76%
@@ -34,7 +34,7 @@ Per-area breakdown (highest-coverage module in each area; see the module list in
 - **bench labels/selectors** (`test_bench_labels`, `test_bench_selector`, `test_bench_label_db_and_command`) - `utils/bench_labels.py` ~94%
 - **yes-flag contract** (`test_yes_flag`) - covers the `confirm_or_exit`/`ensure_containers_running` non-interactive contract across `start`, `config`, `logs`
 - **db security** (`test_db_security`) - `utils/db_utils.py` ~68%
-- **init reuse** (`test_init_reuse_bench`, `test_init_mariadb_flag`) - `commands/init.py` ~18% (only the reuse-bench and MariaDB-flag branches are covered)
+- **init reuse** (`test_init_reuse_bench`, `test_init_mariadb_flag`) - `commands/init.py` ~31% (the reuse-bench resolver, the container-readiness poll, and the MariaDB-flag branches are covered)
 - **completion** (`test_completion_utils`) - `utils/completion_utils.py` ~92%
 - **tips** (`test_tips`) - `utils/tips.py` ~91%
 - **config validation** (`test_config_validation`) - config validation helpers in `utils/db_utils.py`

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -56,7 +56,7 @@ uv run pytest -x
 
 ### Current Test Coverage
 
-`tests/` holds 18 `test_*.py` suites totaling 321 tests at ~41% overall coverage (measured with `uv run pytest --cov` at 0.34.0).
+`tests/` holds 18 `test_*.py` suites totaling 329 tests at ~42% overall coverage (measured with `uv run pytest --cov` at 0.34.0).
 See the [Testing Directory Index](./README.md#current-status) for the full per-area breakdown.
 `test_completion_utils.py` remains the most complete single-module suite (tab completion, ~92% coverage): project name completion, app name completion, site name completion, cache functionality, Docker client management.
 
@@ -197,7 +197,7 @@ def temp_cache():
 
 - **Minimum**: 80% coverage for new code
 - **Target**: 90%+ coverage for critical paths
-- **Current**: ~41% overall at 0.34.0; `completion_utils.py` is the highest-covered module at ~92% (see the [Testing Directory Index](./README.md#current-status) for the rest)
+- **Current**: ~42% overall at 0.34.0; `completion_utils.py` is the highest-covered module at ~92% (see the [Testing Directory Index](./README.md#current-status) for the rest)
 
 ### Checking Coverage
 

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -37,6 +37,8 @@ Example:
 
 import shlex
 import subprocess
+import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -154,8 +156,6 @@ def _exec_in_container(
 
     try:
         if stream_output:
-            import sys
-
             for stdout, stderr in container.client.api.exec_start(exec_id, stream=True, demux=True):
                 if stdout:
                     # Use raw sys.stdout.write to preserve carriage returns for progress bars
@@ -234,20 +234,53 @@ def _resolve_bench_target(
     frappe_container,
     bench_parent_path: str,
     bench_name: str,
+    reuse_bench: bool | None = None,
 ) -> tuple[str, str, bool]:
     """Resolve which bench to set up inside the container.
 
     Returns ``(bench_name, bench_full_path, bench_exists)``.
 
-    When the chosen bench already exists, the user is asked whether to reuse it.
-    Declining no longer aborts the command: the user is prompted for a different
-    bench name so site setup can continue on a fresh bench (issue #20). A blank
-    name or a cancelled prompt exits cleanly without making changes.
+    ``reuse_bench`` pre-answers the existing-bench question so the command is
+    drivable non-interactively (issue #41):
+
+    - ``True`` (``--reuse-bench``): reuse the existing bench with no prompt
+      (``bench init`` is skipped downstream, exactly like an interactive Yes).
+    - ``False`` (``--no-reuse-bench``): refuse to reuse; error and exit 1 so the
+      caller must pass a fresh ``--bench`` name (never enters the rename loop).
+    - ``None`` (default): ask interactively on a TTY (the issue #20 loop below);
+      on a non-TTY, refuse with an honest exit 1 instead of hanging on an idle
+      pipe or crashing with ``EOFError`` inside questionary.
+
+    When ``reuse_bench is None`` and the terminal is interactive, declining reuse
+    does NOT abort: the user is prompted for a different bench name so site setup
+    can continue on a fresh bench (issue #20). A blank name or a cancelled prompt
+    exits cleanly (code 0, "No changes made.") without making changes.
     ``bench_exists`` is True when an existing bench will be reused (so
     ``bench init`` is skipped) and False when a fresh bench must be initialized.
     """
     bench_full_path = f"{bench_parent_path}/{bench_name}"
     bench_exists = _directory_exists(frappe_container, bench_full_path)
+
+    # Non-interactive pre-answers for the existing-bench case. Each branch either
+    # returns or exits, so the interactive loop below is only reached when
+    # reuse_bench is None AND stdin is a TTY.
+    if bench_exists:
+        if reuse_bench is True:
+            add_path(bench_full_path)
+            return bench_name, bench_full_path, True
+        if reuse_bench is False:
+            stderr_console.print(
+                f"[bold red]Error:[/bold red] Bench '{bench_full_path}' already exists and "
+                "--no-reuse-bench was given. Pass a different --bench name to create a new bench."
+            )
+            raise typer.Exit(code=1)
+        if not sys.stdin.isatty():
+            stderr_console.print(
+                f"[bold red]Error:[/bold red] Bench '{bench_full_path}' already exists and this is "
+                "a non-interactive session. Pass --reuse-bench to reuse it, or --no-reuse-bench "
+                "with a different --bench name to create a fresh bench."
+            )
+            raise typer.Exit(code=1)
 
     while bench_exists:
         console.print(f"[yellow]Bench '{bench_name}' already exists at {bench_full_path}.[/yellow]")
@@ -584,6 +617,37 @@ def _customize_compose_ports(
     compose_path.write_text(content)
 
 
+def _wait_for_containers_running(
+    project_name: str,
+    *,
+    verbose: bool = False,
+    attempts: int = 10,
+    delay: float = 0.5,
+) -> bool:
+    """Poll for the frappe container to reach 'running' after ``compose up -d``.
+
+    Right after ``docker compose up -d`` a container briefly reports
+    ``created``/``starting``; a single status check therefore mis-reads a normal
+    slow start as "not running". This bounded, silent poll (``prompt=False``,
+    ``auto_start=False`` so it never prompts and never starts anything) re-checks
+    status a few times over ``attempts * delay`` seconds. It is safe to call
+    under a live spinner precisely because it never prompts; the caller runs the
+    interactive prompt/refusal OUTSIDE the spinner only if this returns False.
+    """
+    for attempt in range(attempts):
+        if ensure_containers_running(
+            project_name,
+            require_running=True,
+            auto_start=False,
+            prompt=False,
+            verbose=verbose,
+        ):
+            return True
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return False
+
+
 @handle_docker_errors
 def init(
     project_name: str | None = typer.Argument(
@@ -634,6 +698,16 @@ def init(
         "--auto-start",
         help="Automatically start containers if they are not running.",
     ),
+    reuse_bench: bool | None = typer.Option(
+        None,
+        "--reuse-bench/--no-reuse-bench",
+        help=(
+            "When the target bench directory already exists: --reuse-bench reuses it "
+            "(skips bench init), --no-reuse-bench requires a fresh --bench name and errors "
+            "if it exists. Default: ask interactively (refuse on a non-TTY). Distinct from "
+            "--auto-start, which controls container startup."
+        ),
+    ),
     verbose: bool = typer.Option(
         False,
         "--verbose",
@@ -666,8 +740,6 @@ def init(
         cwcli init my-project --frappe-branch version-15 --install-erpnext
         cwcli init my-project --db-root-password mypass --admin-password admin123
     """
-    import time
-
     start_time = time.time()
 
     # Prompt for project name if not provided
@@ -703,7 +775,12 @@ def init(
         stderr_console.print("[dim]Pulling Docker images...[/dim]")
         _pull_compose_images(inputs.project_name, conf_dir, verbose=verbose)
         _start_compose_project(inputs.project_name, conf_dir, verbose=verbose)
-        ensure_containers_running(inputs.project_name, require_running=True, auto_start=auto_start)
+        # Bounded silent poll first (a container is often 200ms from ready right
+        # after 'compose up -d'); only prompt/refuse if it is genuinely not up.
+        if not _wait_for_containers_running(inputs.project_name, verbose=verbose):
+            ensure_containers_running(
+                inputs.project_name, require_running=True, auto_start=auto_start
+            )
         frappe_container = get_frappe_container(inputs.project_name)
     else:
         # Non-verbose mode: use spinners for user feedback
@@ -726,13 +803,19 @@ def init(
             _start_compose_project(inputs.project_name, conf_dir, verbose=verbose)
 
             spinner.update("Waiting for containers to be ready")
+            # Silent bounded poll (prompt=False) is safe under the spinner; the
+            # interactive prompt/refusal below runs only AFTER the spinner exits,
+            # so a slow container start never paints a confirm under the spinner
+            # (the repo's known deadlock pattern).
+            containers_running = _wait_for_containers_running(inputs.project_name, verbose=verbose)
+
+        # Spinner has exited. If the containers are still not up, prompt/refuse
+        # OUTSIDE the spinner, then fetch the frappe container.
+        if not containers_running:
             ensure_containers_running(
                 inputs.project_name, require_running=True, auto_start=auto_start
             )
-
-            # Get the frappe container
-            spinner.update("Getting frappe container")
-            frappe_container = get_frappe_container(inputs.project_name)
+        frappe_container = get_frappe_container(inputs.project_name)
 
     # Prepare bench paths inside the container
     bench_parent_path = bench_parent.rstrip("/") or "/workspace"
@@ -745,7 +828,7 @@ def init(
     # asked whether to reuse it; declining lets them pick a different bench name
     # and continue site setup instead of aborting (issue #20).
     inputs.bench_name, bench_full_path, bench_exists = _resolve_bench_target(
-        frappe_container, bench_parent_path, inputs.bench_name
+        frappe_container, bench_parent_path, inputs.bench_name, reuse_bench=reuse_bench
     )
 
     # Initialize bench if it doesn't exist

--- a/tests/README.md
+++ b/tests/README.md
@@ -32,7 +32,7 @@ uv run pytest --pdb
 
 ## Test Files
 
-As of 0.34.0, `tests/` holds 18 `test_*.py` suites totaling 321 tests at ~41%
+As of 0.34.0, `tests/` holds 18 `test_*.py` suites totaling 329 tests at ~42%
 overall coverage (measured with `uv run pytest --cov`). Run `ls tests/` for the
 authoritative current list; see [../docs/testing/README.md](../docs/testing/README.md)
 for the per-area breakdown.
@@ -59,7 +59,7 @@ Tests for tab completion functionality.
 
 ## Test Coverage
 
-Current overall coverage: **~41%** at 0.34.0 (321 tests across 18 test files).
+Current overall coverage: **~42%** at 0.34.0 (329 tests across 18 test files).
 
 ### Covered Modules
 - ✅ `utils/completion_utils.py` - 92% (7 missing lines)

--- a/tests/test_init_reuse_bench.py
+++ b/tests/test_init_reuse_bench.py
@@ -40,7 +40,7 @@ def _container():
     return MagicMock(name="frappe_container")
 
 
-class _StopInit(Exception):
+class _StopInitError(Exception):
     """Stop a command-level init test after the container readiness check."""
 
 
@@ -274,7 +274,7 @@ class TestInitContainerReadiness:
             return kwargs.get("prompt") is not False
 
         def stop_after_readiness(_project_name):
-            raise _StopInit
+            raise _StopInitError
 
         monkeypatch.setattr(init_mod, "TipSpinner", RecordingSpinner)
         monkeypatch.setattr(init_mod.config_utils, "get_show_tips", lambda: False)
@@ -289,7 +289,7 @@ class TestInitContainerReadiness:
         monkeypatch.setattr(init_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(init_mod, "get_frappe_container", stop_after_readiness)
 
-        with pytest.raises(_StopInit):
+        with pytest.raises(_StopInitError):
             init_mod.init.__wrapped__(
                 project_name="proj",
                 port=18000,

--- a/tests/test_init_reuse_bench.py
+++ b/tests/test_init_reuse_bench.py
@@ -11,7 +11,11 @@ import pytest
 import typer
 
 from caffeinated_whale_cli.commands import init as init_mod
-from caffeinated_whale_cli.commands.init import _bench_name_validation, _resolve_bench_target
+from caffeinated_whale_cli.commands.init import (
+    _bench_name_validation,
+    _resolve_bench_target,
+    _wait_for_containers_running,
+)
 
 
 @pytest.fixture
@@ -19,18 +23,25 @@ def patched(monkeypatch):
     """Patch questionary, add_path, and _directory_exists used by the resolver.
 
     Returns ``(questionary_mock, directory_exists_mock)`` so each test can wire
-    up prompt answers and bench-existence results.
+    up prompt answers and bench-existence results. Defaults ``sys.stdin.isatty``
+    to True so the interactive resolver loop runs; non-TTY refusal is exercised
+    explicitly where needed.
     """
     questionary_mock = MagicMock()
     directory_exists_mock = MagicMock()
     monkeypatch.setattr(init_mod, "questionary", questionary_mock)
     monkeypatch.setattr(init_mod, "add_path", MagicMock())
     monkeypatch.setattr(init_mod, "_directory_exists", directory_exists_mock)
+    monkeypatch.setattr(init_mod.sys.stdin, "isatty", lambda: True)
     return questionary_mock, directory_exists_mock
 
 
 def _container():
     return MagicMock(name="frappe_container")
+
+
+class _StopInit(Exception):
+    """Stop a command-level init test after the container readiness check."""
 
 
 class TestResolveBenchTarget:
@@ -118,6 +129,191 @@ class TestResolveBenchTarget:
 
         assert (name, path, exists) == ("primis-bench", "/workspace/primis-bench", False)
         init_mod.add_path.assert_called_once_with("/workspace/primis-bench")
+
+
+class TestReuseBenchFlag:
+    """Non-interactive existing-bench handling via --reuse-bench/--no-reuse-bench (issue #41)."""
+
+    def test_reuse_bench_true_reuses_without_prompting(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+
+        name, path, exists = _resolve_bench_target(
+            _container(), "/workspace", "frappe-bench", reuse_bench=True
+        )
+
+        assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", True)
+        questionary_mock.confirm.assert_not_called()
+        questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_called_once_with("/workspace/frappe-bench")
+
+    def test_no_reuse_bench_on_existing_exits_1_without_prompting(self, patched):
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_bench_target(_container(), "/workspace", "frappe-bench", reuse_bench=False)
+
+        assert excinfo.value.exit_code == 1
+        questionary_mock.confirm.assert_not_called()
+        questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_not_called()
+
+    def test_no_flag_non_tty_on_existing_refuses_without_prompting(self, patched, monkeypatch):
+        # The reported bug: a non-TTY run used to hang or crash (EOFError) inside
+        # questionary. It must now refuse honestly with exit 1 and never prompt.
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = True
+        monkeypatch.setattr(init_mod.sys.stdin, "isatty", lambda: False)
+
+        with pytest.raises(typer.Exit) as excinfo:
+            _resolve_bench_target(_container(), "/workspace", "frappe-bench", reuse_bench=None)
+
+        assert excinfo.value.exit_code == 1
+        questionary_mock.confirm.assert_not_called()
+        questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_not_called()
+
+    def test_fresh_bench_with_no_reuse_bench_proceeds(self, patched):
+        # --no-reuse-bench against a fresh name just asserts freshness; it must
+        # NOT block creation.
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = False
+
+        name, path, exists = _resolve_bench_target(
+            _container(), "/workspace", "frappe-bench", reuse_bench=False
+        )
+
+        assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", False)
+        questionary_mock.confirm.assert_not_called()
+        questionary_mock.text.assert_not_called()
+        init_mod.add_path.assert_called_once_with("/workspace/frappe-bench")
+
+    def test_fresh_bench_non_tty_no_flag_proceeds(self, patched, monkeypatch):
+        # A non-TTY refusal only applies when the bench already exists; a fresh
+        # bench must be created without any prompt or refusal.
+        questionary_mock, directory_exists_mock = patched
+        directory_exists_mock.return_value = False
+        monkeypatch.setattr(init_mod.sys.stdin, "isatty", lambda: False)
+
+        name, path, exists = _resolve_bench_target(
+            _container(), "/workspace", "frappe-bench", reuse_bench=None
+        )
+
+        assert (name, path, exists) == ("frappe-bench", "/workspace/frappe-bench", False)
+        questionary_mock.confirm.assert_not_called()
+        init_mod.add_path.assert_called_once_with("/workspace/frappe-bench")
+
+
+class TestWaitForContainersRunning:
+    """The spinner-race fix: the poll never prompts, so it is safe under a spinner."""
+
+    def test_returns_true_immediately_when_running(self, monkeypatch):
+        calls = []
+
+        def fake_ensure(project, **kwargs):
+            calls.append(kwargs)
+            return True
+
+        monkeypatch.setattr(init_mod, "ensure_containers_running", fake_ensure)
+
+        assert _wait_for_containers_running("proj") is True
+        assert len(calls) == 1
+        # Never prompts (safe under a spinner) and never auto-starts during the poll.
+        assert calls[0]["prompt"] is False
+        assert calls[0]["auto_start"] is False
+
+    def test_polls_then_gives_up_without_prompting(self, monkeypatch):
+        monkeypatch.setattr(init_mod.time, "sleep", lambda _s: None)
+        calls = []
+
+        def fake_ensure(project, **kwargs):
+            calls.append(kwargs)
+            return False
+
+        monkeypatch.setattr(init_mod, "ensure_containers_running", fake_ensure)
+
+        assert _wait_for_containers_running("proj", attempts=3, delay=0.01) is False
+        assert len(calls) == 3
+        assert all(c["prompt"] is False for c in calls)
+
+
+class TestInitContainerReadiness:
+    """Command-level coverage for moving the promptable check outside TipSpinner."""
+
+    def test_non_verbose_init_prompts_only_after_spinner_exits(self, monkeypatch, tmp_path):
+        calls = []
+
+        class RecordingSpinner:
+            active = False
+
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def __enter__(self):
+                type(self).active = True
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                type(self).active = False
+                return False
+
+            def update(self, _message):
+                pass
+
+        def fake_ensure(project_name, **kwargs):
+            calls.append(
+                {
+                    "project_name": project_name,
+                    "inside_spinner": RecordingSpinner.active,
+                    "kwargs": kwargs,
+                }
+            )
+            # The quiet poll under the spinner should give up, which drives the
+            # promptable fallback after the spinner has exited.
+            return kwargs.get("prompt") is not False
+
+        def stop_after_readiness(_project_name):
+            raise _StopInit
+
+        monkeypatch.setattr(init_mod, "TipSpinner", RecordingSpinner)
+        monkeypatch.setattr(init_mod.config_utils, "get_show_tips", lambda: False)
+        monkeypatch.setattr(
+            init_mod, "check_ports_in_use", lambda ports: dict.fromkeys(ports, False)
+        )
+        monkeypatch.setattr(init_mod, "_setup_project_directory", lambda *a, **k: tmp_path)
+        monkeypatch.setattr(init_mod, "_customize_compose_ports", lambda *a, **k: None)
+        monkeypatch.setattr(init_mod, "_pull_compose_images", lambda *a, **k: None)
+        monkeypatch.setattr(init_mod, "_start_compose_project", lambda *a, **k: None)
+        monkeypatch.setattr(init_mod, "ensure_containers_running", fake_ensure)
+        monkeypatch.setattr(init_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(init_mod, "get_frappe_container", stop_after_readiness)
+
+        with pytest.raises(_StopInit):
+            init_mod.init.__wrapped__(
+                project_name="proj",
+                port=18000,
+                bench_name="frappe-bench",
+                site_name="development.localhost",
+                bench_parent="/workspace",
+                frappe_branch="version-15",
+                db_root_password="123",
+                admin_password="admin",
+                auto_start=False,
+                reuse_bench=None,
+                verbose=False,
+                install_erpnext=False,
+                erpnext_branch="version-15",
+            )
+
+        spinner_calls = [call for call in calls if call["inside_spinner"]]
+        fallback_calls = [call for call in calls if not call["inside_spinner"]]
+        assert spinner_calls
+        assert all(call["kwargs"]["prompt"] is False for call in spinner_calls)
+        assert all(call["kwargs"]["auto_start"] is False for call in spinner_calls)
+        assert len(fallback_calls) == 1
+        assert "prompt" not in fallback_calls[0]["kwargs"]
+        assert fallback_calls[0]["kwargs"]["auto_start"] is False
 
 
 class TestBenchNameValidation:


### PR DESCRIPTION
## Intent

Make cwcli init fully non-interactive for the existing-bench flow and fix the spinner-race prompt (GitHub issue #41).

Goal: cwcli init must be fully agent-drivable. The devcontainer image ships a /workspace/frappe-bench, so a fresh init usually finds an already-existing bench and hits an interactive questionary prompt (Reuse the existing bench?), which hangs or crashes (EOFError) under a non-TTY. This makes init unusable for automation.

What was implemented:
1. A tri-state --reuse-bench/--no-reuse-bench flag (default None) on init that pre-answers the existing-bench question. Handled in _resolve_bench_target(frappe_container, bench_parent_path, bench_name, reuse_bench) in commands/init.py, which returns (bench_name, bench_full_path, bench_exists) and short-circuits BEFORE the interactive 'while bench_exists' loop:
- reuse_bench is True (--reuse-bench): reuse silently, bench_exists=True (bench init skipped), like interactive Yes.
- reuse_bench is False (--no-reuse-bench): refuse to reuse; print an error naming the path and advising a different --bench, then Exit(1). Must NEVER enter the rename loop (it would spin forever non-interactively).
- reuse_bench is None AND a TTY: the unchanged interactive issue #20 loop (Yes reuses; No prompts a new name and continues on a fresh bench; blank/cancel exits 0 'No changes made').
- reuse_bench is None AND NOT a TTY: refuse up front with an honest Exit(1) naming both flags, checked via sys.stdin.isatty() BEFORE touching questionary (questionary .ask() only catches KeyboardInterrupt, so a guard is required to avoid the old non-TTY hang / EOFError crash).
When the bench does not exist the flag is irrelevant (--no-reuse-bench with a fresh name is a useful no-op asserting freshness).

2. Spinner-race fix: ensure_containers_running used to run INSIDE init's TipSpinner with prompt=True, so a slow container start with no --auto-start could paint a questionary confirm under the live spinner (the repo's known deadlock pattern). Now _wait_for_containers_running runs a bounded SILENT poll (ensure_containers_running(prompt=False, auto_start=False), ~10 x 0.5s) inside the spinner - safe because it never prompts and absorbs normal startup latency. Only if that returns False does init call ensure_containers_running(auto_start=auto_start) (which prompts on a TTY or refuses on a non-TTY) OUTSIDE the spinner, then fetches the frappe container. --reuse-bench and --auto-start are kept as separate axes (bench reuse vs container start), deliberately not merged.

Deliberate design decisions a diff-only reviewer might question:
- The interactive-cancel path exits 0 ('No changes made') on purpose - that is the pre-existing issue #20 behavior; only the NON-TTY path exits 1 (there, doing nothing is a failure to do the requested job).
- inputs.bench_name is reassigned from the resolver's return so bench init and the site paths use the chosen name; valid because InitInputs is a plain mutable @dataclass.
- The resolver runs AFTER the setup spinner exits so its prompts own the terminal - kept out of any console.status/TipSpinner block.

Regression coverage added in tests/test_init_reuse_bench.py (TestReuseBenchFlag for flag/non-TTY resolver cases, TestWaitForContainersRunning for poll behavior). Local validation (pytest, mypy, black, ruff, cwcli init --help) and a real throwaway-instance Docker E2E already passed.

## What Changed

- Added a tri-state `--reuse-bench/--no-reuse-bench` flag to `cwcli init` (default unset) that pre-answers the existing-bench question in a new `_resolve_bench_target` helper: `--reuse-bench` reuses silently, `--no-reuse-bench` refuses and exits 1 naming the path, an unset flag on a TTY keeps the interactive reuse/rename loop, and an unset flag on a non-TTY now refuses up front with an honest exit 1 (naming both flags) instead of hanging or crashing with `EOFError`.
- Fixed the spinner-race prompt: container readiness is now a bounded silent poll (`_wait_for_containers_running`, `prompt=False`/`auto_start=False`) run inside the setup spinner, and only escalates to the prompting `ensure_containers_running` outside the spinner - so a slow start can no longer paint a questionary confirm under the live spinner.
- Extended `tests/test_init_reuse_bench.py` with `TestReuseBenchFlag` and `TestWaitForContainersRunning` coverage (full suite 329 passing), and refreshed the flag docs plus stale test-count/coverage stats in `README.md`, `AGENTS.md`, and the `docs/`/`tests/` READMEs.

## Risk Assessment

✅ Low: A well-bounded, well-tested change: correct tri-state flag handling and a silent bounded poll that cleanly moves the interactive prompt outside the spinner, with no reachable bug, unbound-variable, or deadlock path.

## Testing

Baseline: synced deps with `uv sync --frozen --all-extras`, then ran the targeted `test_init_reuse_bench.py` (29 pass) and the full suite (329 pass, no regressions). Beyond unit tests, I produced a genuine CLI transcript: `cwcli init --help` shows the new tri-state flag, and an end-to-end driver runs the real Typer `init` command in a non-TTY with the Docker layer faked so the frappe container reports an already-existing bench. That transcript demonstrates the actual end-user experience for all four existing-bench cases - the reported non-TTY bug now refuses cleanly with exit 1 (no hang/EOFError), `--reuse-bench` reuses silently, `--no-reuse-bench` errors with a path-naming message, and a fresh `--no-reuse-bench` proceeds - and confirms the runtime default is `None` (tri-state intact) despite the cosmetic `[default: no-reuse-bench]` help rendering. This is a CLI-only change with no rendered UI surface, so the reviewer-visible evidence is CLI transcripts rather than screenshots. Overall result: pass.

<details>
<summary>Evidence: End-to-end CLI transcript: cwcli init non-interactive existing-bench flow (4 scenarios, real Typer command)</summary>

<code>SCENARIO: no flag, existing bench, non-TTY (the reported bug)&#10;reuse_bench value Typer passed to resolver: None&#10;exit code: 1&#10;| Error: Bench &#39;/workspace/frappe-bench&#39; already exists and this is a&#10;| non-interactive session. Pass --reuse-bench to reuse it, or --no-reuse-bench ...&#10;&#10;SCENARIO: --reuse-bench, existing bench, non-TTY&#10;reuse_bench=True | exit 0 | reuses silently (no prompt)&#10;&#10;SCENARIO: --no-reuse-bench, existing bench, non-TTY&#10;reuse_bench=False | exit 1&#10;| Error: Bench &#39;/workspace/frappe-bench&#39; already exists and --no-reuse-bench was given...&#10;&#10;SCENARIO: --no-reuse-bench, FRESH bench, non-TTY&#10;reuse_bench=False | exit 0 | proceeds (freshness asserted)</code>

```text
cwcli init - non-interactive existing-bench flow (issue #41)
Real Typer command, real resolver, Docker layer faked (bench already exists).

==============================================================================
SCENARIO: no flag, existing bench, non-TTY  (the reported bug: used to hang/EOFError)
  $ cwcli init cwe2e-proj    (non-TTY, existing bench=True)
  reuse_bench value Typer passed to resolver: None
  exit code: 1
  --- user-visible output (stdout+stderr) ---
  | Error: Bench '/workspace/frappe-bench' already exists and this is a 
  | non-interactive session. Pass --reuse-bench to reuse it, or --no-reuse-bench 
  | with a different --bench name to create a fresh bench.
  EXPECT: refuse honestly, exit 1, name both flags; reuse_bench passed as None

==============================================================================
SCENARIO: --reuse-bench, existing bench, non-TTY
  $ cwcli init cwe2e-proj --reuse-bench   (non-TTY, existing bench=True)
  reuse_bench value Typer passed to resolver: True
  exit code: 0
  --- user-visible output (stdout+stderr) ---
  | '/workspace/frappe-bench' already exists in custom search paths.
  EXPECT: reuse silently, resolver returns (no prompt); reuse_bench=True

==============================================================================
SCENARIO: --no-reuse-bench, existing bench, non-TTY
  $ cwcli init cwe2e-proj --no-reuse-bench   (non-TTY, existing bench=True)
  reuse_bench value Typer passed to resolver: False
  exit code: 1
  --- user-visible output (stdout+stderr) ---
  | Error: Bench '/workspace/frappe-bench' already exists and --no-reuse-bench was 
  | given. Pass a different --bench name to create a new bench.
  EXPECT: error naming the path + advising --bench, exit 1; reuse_bench=False

==============================================================================
SCENARIO: --no-reuse-bench, FRESH bench, non-TTY
  $ cwcli init cwe2e-proj --no-reuse-bench   (non-TTY, existing bench=False)
  reuse_bench value Typer passed to resolver: False
  exit code: 0
  --- user-visible output (stdout+stderr) ---
  | '/workspace/frappe-bench' already exists in custom search paths.
  EXPECT: freshness asserted, proceeds past resolver (reaches bench build)

==============================================================================
DONE
```
</details>
<details>
<summary>Evidence: E2E driver script (real cwcli init via CliRunner, Docker faked)</summary>

```text
"""End-to-end driver for cwcli init non-interactive existing-bench flow (issue #41).

Invokes the REAL `cwcli init` Typer command through CliRunner (a genuine non-TTY
invocation, exactly how an agent/CI drives it). Only the Docker layer is faked -
the frappe container reports that /workspace/frappe-bench already EXISTS, which is
precisely the devcontainer situation that used to hang / crash the command.

Everything else (Typer arg parsing of --reuse-bench/--no-reuse-bench, the spinner,
the readiness poll, _resolve_bench_target) is the real shipped code path.
"""

import sys
from unittest.mock import MagicMock

from typer.testing import CliRunner

from caffeinated_whale_cli.commands import init as init_mod
from caffeinated_whale_cli import main as main_mod

runner = CliRunner()

BAR = "=" * 78


def _fake_container(bench_exists: bool):
    """A frappe container whose target bench dir may or may not already exist."""
    c = MagicMock(name="frappe_container")
    # _ensure_directory (real code, runs just before the resolver) calls
    # container.exec_run and unpacks (exit_code, output).
    c.exec_run = lambda *a, **k: (0, b"")
    return c


def _install_docker_fakes(monkey_targets, *, bench_exists: bool, reuse_seen: list):
    """Patch every Docker-facing helper init calls before the resolver."""
    from pathlib import Path

    init_mod._setup_project_directory = lambda *a, **k: Path("/tmp/fake-proj")  # type: ignore
    init_mod.check_ports_in_use = lambda ports: dict.fromkeys(ports, False)  # type: ignore
    init_mod._customize_compose_ports = lambda *a, **k: None  # type: ignore
    init_mod._pull_compose_images = lambda *a, **k: None  # type: ignore
    init_mod._start_compose_project = lambda *a, **k: None  # type: ignore
    # Containers come up "running" immediately so the poll succeeds silently.
    init_mod.ensure_containers_running = lambda *a, **k: True  # type: ignore
    init_mod.get_frappe_container = lambda *a, **k: _fake_container(bench_exists)  # type: ignore
    init_mod._directory_exists = lambda container, path: bench_exists  # type: ignore
    init_mod.config_utils.get_show_tips = lambda: False  # type: ignore

    # Wrap the REAL resolver so we can capture what reuse_bench value Typer passed,
    # then hand off to the genuine implementation.
    real_resolver = init_mod._resolve_bench_target

    def spy_resolver(container, parent, name, reuse_bench=None):
        reuse_seen.append(reuse_bench)
        # Call real resolver; it may raise typer.Exit (the behavior we want to show).
        result = real_resolver(container, parent, name, reuse_bench=reuse_bench)
        # If it returned (reuse=True / fresh), stop the command here - the rest is
        # a real multi-minute bench build we deliberately do not run.
        raise SystemExit(0)

    init_mod._resolve_bench_target = spy_resolver  # type: ignore


def scenario(title, args, *, bench_exists, expect):
    reuse_seen: list = []
    _install_docker_fakes(None, bench_exists=bench_exists, reuse_seen=reuse_seen)
    result = runner.invoke(main_mod.app, ["init", "cwe2e-proj", *args], catch_exceptions=True)
    print(BAR)
    print(f"SCENARIO: {title}")
    print(f"  $ cwcli init cwe2e-proj {' '.join(args)}   (non-TTY, existing bench={bench_exists})")
    print(f"  reuse_bench value Typer passed to resolver: {reuse_seen[-1] if reuse_seen else '<never reached>'!r}")
    print(f"  exit code: {result.exit_code}")
    try:
        err = result.stderr
    except (ValueError, RuntimeError):
        err = ""
    out = (result.stdout + err).strip()
    if out:
        print("  --- user-visible output (stdout+stderr) ---")
        for line in out.splitlines():
            print(f"  | {line}")
    print(f"  EXPECT: {expect}")
    print()
    return result, reuse_seen


def main():
    print("cwcli init - non-interactive existing-bench flow (issue #41)")
    print("Real Typer command, real resolver, Docker layer faked (bench already exists).\n")

    # 1. The reported bug: plain non-TTY init on an existing bench.
    scenario(
        "no flag, existing bench, non-TTY  (the reported bug: used to hang/EOFError)",
        [],
        bench_exists=True,
        expect="refuse honestly, exit 1, name both flags; reuse_bench passed as None",
    )

    # 2. --reuse-bench: silent reuse.
    r, seen = scenario(
        "--reuse-bench, existing bench, non-TTY",
        ["--reuse-bench"],
        bench_exists=True,
        expect="reuse silently, resolver returns (no prompt); reuse_bench=True",
    )

    # 3. --no-reuse-bench: refuse with path-naming error.
    scenario(
        "--no-reuse-bench, existing bench, non-TTY",
        ["--no-reuse-bench"],
        bench_exists=True,
        expect="error naming the path + advising --bench, exit 1; reuse_bench=False",
    )

    # 4. --no-reuse-bench against a FRESH bench: useful no-op, proceeds.
    scenario(
        "--no-reuse-bench, FRESH bench, non-TTY",
        ["--no-reuse-bench"],
        bench_exists=False,
        expect="freshness asserted, proceeds past resolver (reaches bench build)",
    )

    print(BAR)
    print("DONE")


if __name__ == "__main__":
    main()
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_init_reuse_bench.py -v` (29 passed: TestReuseBenchFlag flag/non-TTY resolver cases, TestWaitForContainersRunning poll behavior, TestInitContainerReadiness spinner-race)</code>
- <code>`uv run pytest -q` (full suite, 329 passed - no regressions from the init.py change)</code>
- <code>`COLUMNS=100 uv run cwcli init --help` - confirmed `--reuse-bench/--no-reuse-bench` flag is on the real CLI surface</code>
- <code>End-to-end driver invoking the real `cwcli init` Typer command via CliRunner (non-TTY) with Docker faked and an existing bench: verified all 4 existing-bench scenarios (no-flag refuse/exit1, --reuse-bench silent reuse, --no-reuse-bench existing error/exit1, --no-reuse-bench fresh proceeds) and that the runtime default passed to the resolver is None, not False</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--reuse-bench` and `--no-reuse-bench` options for `init` so existing bench directories can be handled explicitly.
  * Added clearer non-interactive behavior for automation: runs now fail fast instead of hanging when a bench already exists and no reuse choice is provided.

* **Bug Fixes**
  * Improved bench startup handling to avoid prompt delays and spinner-related deadlocks.
  * Made readiness checks more reliable when containers are still starting up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->