### PR TITLE
fix: add missing MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Christopher McKay
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Intent

Add the missing MIT LICENSE file to cwcli. The package declares MIT everywhere (pyproject 'license = { text = "MIT" }' plus the OSI MIT classifier, README §License links to [LICENSE](LICENSE)) but shipped no license text - a dead README link and a PyPI-published package (0.35.0 live) with no bundled license. Deliverable: create a LICENSE file at repo root with canonical verbatim OSI MIT License text, copyright line exactly 'Copyright (c) 2025-2026 Christopher McKay'. This is a licensing/packaging fix only: no relicensing, no restructuring the MIT declaration, no runtime code touched. Verified via 'uv build' that setuptools>=61 auto-detects the root LICENSE, so both the sdist (LICENSE at root) and wheel (.dist-info/licenses/LICENSE + METADATA License-File header) bundle it - no pyproject edit was needed, so none was made. Only the LICENSE file was added.

## What Changed

- Added a `LICENSE` file at the repo root containing the canonical OSI MIT License text, with the copyright line `Copyright (c) 2025-2026 Christopher McKay`.
- Resolves the dead `[LICENSE](LICENSE)` link in README and closes the gap where the PyPI-published package (already declaring `license = { text = "MIT" }` and the OSI MIT classifier in `pyproject.toml`) shipped with no bundled license text.
- No changes to `pyproject.toml` or any runtime code; `setuptools>=61` auto-detects the root `LICENSE` file so both the sdist and wheel now bundle it without further configuration.

## Risk Assessment

✅ Low: Single new file (LICENSE) with standard, verbatim MIT text and no code, config, or doc changes elsewhere in the diff.

## Testing

<code>Built real sdist and wheel artifacts with `uv build` and inspected them directly: the sdist contains LICENSE at its root, the wheel contains .dist-info/licenses/LICENSE plus a License-File: LICENSE header in METADATA, and both are byte-identical to the new repo-root LICENSE file, exactly matching the author&#39;s claim that setuptools&gt;=61 auto-detects the license with no pyproject.toml changes needed; no code or tests were touched by this change so no unit tests apply, and no issues were found.</code>

- Evidence: Built sdist (tar.gz) with LICENSE at package root (local file: <code>/tmp/no-mistakes-evidence/01KX8RQZPG8DMK53TQ4NBCCEXR/build-dist/caffeinated_whale_cli-0.35.0.tar.gz</code>)
- Evidence: Built wheel with .dist-info/licenses/LICENSE and METADATA License-File header (local file: <code>/tmp/no-mistakes-evidence/01KX8RQZPG8DMK53TQ4NBCCEXR/build-dist/caffeinated_whale_cli-0.35.0-py3-none-any.whl</code>)
<details>
<summary>Evidence: LICENSE extracted from sdist (byte-identical to repo LICENSE)</summary>

```text
MIT License

Copyright (c) 2025-2026 Christopher McKay

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```
</details>
<details>
<summary>Evidence: LICENSE extracted from wheel .dist-info/licenses/LICENSE (byte-identical to repo LICENSE)</summary>

```text
MIT License

Copyright (c) 2025-2026 Christopher McKay

Permission is hereby granted, free of charge, to any person obtaining a copy
of this software and associated documentation files (the "Software"), to deal
in the Software without restriction, including without limitation the rights
to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
copies of the Software, and to permit persons to whom the Software is
furnished to do so, subject to the following conditions:

The above copyright notice and this permission notice shall be included in all
copies or substantial portions of the Software.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
SOFTWARE.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `Read LICENSE and diffed its body against the canonical OSI MIT License text and confirmed the copyright line reads exactly 'Copyright (c) 2025-2026 Christopher McKay'`
- `grep pyproject.toml and README.md to confirm the pre-existing MIT declaration (license = { text = "MIT" }, OSI MIT classifier) and README's [LICENSE](LICENSE) link are unchanged and now resolve to a real file`
- <code>`uv build --out-dir /tmp/no-mistakes-evidence/01KX8RQZPG8DMK53TQ4NBCCEXR/build-dist` — full sdist+wheel build from the actual project</code>
- <code>`tar tzf caffeinated_whale_cli-0.35.0.tar.gz | grep -i license` — confirmed LICENSE ships at the sdist root</code>
- <code>`unzip -l caffeinated_whale_cli-0.35.0-py3-none-any.whl | grep -i license` — confirmed LICENSE ships at .dist-info/licenses/LICENSE in the wheel</code>
- <code>`unzip -p ... METADATA | grep -i license` — confirmed METADATA carries License: MIT, the OSI classifier, and License-File: LICENSE</code>
- `Byte-diffed the LICENSE extracted from both the sdist and wheel against the repo's LICENSE file to confirm identical content`
- <code>`git status --short` in the worktree post-build to confirm no build artifacts leaked outside the evidence directory</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the full MIT License text, including copyright and usage terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->