### PR TITLE
build(packaging): make cwcli install/run/upgrade cleanly through uv tooling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,10 @@ The canonical worked examples are `docs/e2e/restore-inspect-e2e-r6.md` and `docs
 
 - **Tooling.** Use `uv` (`uv sync --frozen --all-extras`, `uv run ...`).
   Format with black and lint with ruff, both at line-length 100 and scoped to `src/` (`uv run black --check src/`, `uv run ruff check src/`).
+  `black` is a **dev-only** dependency (in the `dev` extra, NOT runtime `dependencies`): it is a formatter, never imported or subprocessed by `src/`, so keeping it out of runtime deps keeps the `uv tool install`/`uvx` environment lean - do not move it back.
+- **Distribution.** cwcli is distributed as a uv tool: `uv tool install caffeinated-whale-cli` (unpinned, so `uv tool upgrade` works) or `uvx --from caffeinated-whale-cli cwcli ...`.
+  Both `cwcli` and `caffeinated-whale-cli` console scripts point at `caffeinated_whale_cli.main:cli`; the `--from` is needed because the command name differs from the package name.
+  Install/run/upgrade docs live in `README.md`; the isolated E2E evidence is `docs/e2e/uv-tool-distribution.md`.
 - **Types.** Keep `uv run mypy src/` at zero errors; it is a blocking gate.
   Prefer accurate annotations over `# type: ignore` (there are none in `src/`), and add the matching `types-*` stub (`types-requests`, `types-toml` are dev deps) rather than ignoring an untyped import.
   Do not loosen `[tool.mypy]` to hide errors.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,34 @@ A command-line interface (CLI) for managing Frappe/ERPNext Docker instances duri
 
 ## Installation
 
-Ensure you have Python 3.10+ and `pip` installed.
+`cwcli` requires Python 3.10+.
+
+### With uv (recommended)
+
+[uv](https://docs.astral.sh/uv/) installs `cwcli` into an isolated environment and puts the `cwcli` command on your `PATH`, without touching your system or project Python.
+
+```bash
+# Install (adds the `cwcli` command to your PATH)
+uv tool install caffeinated-whale-cli
+
+# Upgrade to the latest release
+uv tool upgrade caffeinated-whale-cli
+
+# Uninstall
+uv tool uninstall caffeinated-whale-cli
+```
+
+If this is your first `uv tool install`, uv may print a note about adding its tool-bin directory to your `PATH`; run `uv tool update-shell` (then restart your terminal) to do so.
+
+To run a one-off command without installing, use `uvx`.
+Because the command name (`cwcli`) differs from the package name, pass it via `--from`:
+
+```bash
+uvx --from caffeinated-whale-cli cwcli --version
+uvx --from caffeinated-whale-cli cwcli ls
+```
+
+### With pip
 
 ```bash
 pip install caffeinated-whale-cli
@@ -34,8 +61,8 @@ After installation, if you see an error like `'cwcli' is not recognized...`, the
 
 To fix this:
 
-1. **Find the script's location:** Run `pip show -f caffeinated-whale-cli` and look for the location of `cwcli.exe` (or `cwcli` on macOS/Linux). It's typically in a `Scripts` or `bin` folder within your Python installation directory.
-2. **Add to PATH:** Follow your operating system's instructions to add this directory to your `PATH` environment variable.
+1. **uv:** Run `uv tool update-shell` and restart your terminal.
+2. **pip:** Run `pip show -f caffeinated-whale-cli` and look for the location of `cwcli.exe` (or `cwcli` on macOS/Linux) - typically a `Scripts` or `bin` folder within your Python installation - then add that directory to your `PATH`.
 3. **Restart your terminal:** Close and reopen your terminal for changes to take effect.
 
 ## Quick Start

--- a/docs/e2e/uv-tool-distribution.md
+++ b/docs/e2e/uv-tool-distribution.md
@@ -1,0 +1,111 @@
+# E2E evidence: uv distribution (`uv tool install` / `uvx` / `uv tool upgrade`)
+
+Real end-to-end validation that a fresh user can install, run, and upgrade `cwcli`
+entirely through uv tooling, on a **fully isolated** environment.
+The captain's real `~/.cwcli` and real uv tools were never touched.
+
+## Isolation
+
+Every command below ran with a throwaway `HOME` and dedicated uv directories so
+nothing leaked into the real environment:
+
+```
+HOME            = $SANDBOX/home            # so ~/.cwcli was a fresh, empty dir
+UV_TOOL_DIR     = $SANDBOX/tooldir         # uv tool venvs
+UV_TOOL_BIN_DIR = $SANDBOX/toolbin         # the installed `cwcli` symlink
+UV_CACHE_DIR    = $SANDBOX/cache
+XDG_DATA_HOME / XDG_CONFIG_HOME = $SANDBOX/...
+```
+
+Post-run isolation check confirmed:
+
+- The captain's real `~/.cwcli` had no entries newer than the session (newest was
+  `cache` at `2026-07-07`, predating the run).
+- The captain's real uv tools directory contained **no** `caffeinated-whale-cli`.
+
+## What it proves
+
+### 1. `uv tool install` (persistent install → working `cwcli` on PATH)
+
+Installed this branch's locally built wheel (`caffeinated_whale_cli-0.36.0-py3-none-any.whl`):
+
+```
+$ uv tool install <local wheel>
+Installed 2 executables: caffeinated-whale-cli, cwcli
+$ which cwcli
+$SANDBOX/toolbin/cwcli
+$ cwcli --version
+Caffeinated Whale CLI Version: 0.36.0
+```
+
+The tool environment resolved **19 packages** and the runtime dependency set was
+lean - `black` is **absent** (it moved to the `dev` extra in this change, since it
+is only a formatter and is never imported or subprocessed at runtime):
+
+```
+docker  peewee  questionary  rich  toml  typer   # (+ their transitive deps) — no black
+```
+
+### 2. Read-only command run
+
+```
+$ cwcli --version        # exercises the full Typer app import chain
+Caffeinated Whale CLI Version: 0.36.0
+$ cwcli ls               # read-only docker scan, wrote only to the isolated HOME's cache
+             Caffeinated Whale Instances
+  Project Name   Status    Ports
+  ...            ...       ...
+```
+
+`cwcli ls` is non-destructive (it only lists) and, with the isolated `HOME`, wrote
+no cache to the captain's real `~/.cwcli`.
+
+### 3. `uv tool upgrade` (genuine version advance)
+
+To show the documented upgrade command actually advancing a version, `cwcli` was
+installed **unpinned** from a local wheelhouse holding only `0.36.0`, then a
+"new release" (`0.36.1`) was dropped in and the upgrade command run:
+
+```
+$ uv tool install caffeinated-whale-cli --find-links <wheelhouse>   # unpinned
+$ cwcli --version
+Caffeinated Whale CLI Version: 0.36.0
+
+# ... 0.36.1 wheel added to the wheelhouse ...
+
+$ uv tool upgrade caffeinated-whale-cli --find-links <wheelhouse>
+Updated caffeinated-whale-cli v0.36.0 -> v0.36.1
+ - caffeinated-whale-cli==0.36.0
+ + caffeinated-whale-cli==0.36.1
+$ cwcli --version
+Caffeinated Whale CLI Version: 0.36.1
+```
+
+> Note on pins: installing with an exact version (`uv tool install caffeinated-whale-cli==0.34.0`)
+> records a pin, and `uv tool upgrade` then reports "Nothing to upgrade" (verified
+> against real PyPI releases 0.34.0 → 0.35.0). The README therefore documents the
+> unpinned `uv tool install caffeinated-whale-cli` as the install command, so
+> `uv tool upgrade` works as expected.
+
+### 4. `uvx` ephemeral run (no persistent install)
+
+Because the command name (`cwcli`) differs from the package name
+(`caffeinated-whale-cli`), `uvx` needs `--from`:
+
+```
+$ uvx --from caffeinated-whale-cli cwcli --version
+Caffeinated Whale CLI Version: 0.36.1
+$ uvx --from caffeinated-whale-cli cwcli --help
+ Usage: cwcli [OPTIONS] COMMAND [ARGS]...
+ A command-line tool to help you create, manage, and back up your Frappe and ...
+```
+
+## Reproducing
+
+The runtime/packaging pieces this relies on:
+
+- Build backend: `setuptools.build_meta` with src-layout auto-discovery (unchanged).
+- `[project.scripts]` exposes both `cwcli` and `caffeinated-whale-cli` →
+  `caffeinated_whale_cli.main:cli`, so `uv tool install` puts `cwcli` on PATH and
+  `uvx --from caffeinated-whale-cli cwcli` runs the same entry point.
+- `black` lives in the `dev` optional-dependency group, not runtime `dependencies`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,11 +30,11 @@ dependencies = [
     "questionary>=2.1.0",
     "toml>=0.10.2",
     "peewee>=3.17.0",
-    "black>=25.1.0",
 ]
 
 [project.optional-dependencies]
 dev = [
+    "black>=25.1.0",
     "ruff>=0.8.0",
     "mypy>=1.13.0",
     "pytest>=8.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,6 @@ name = "caffeinated-whale-cli"
 version = "0.36.0"
 source = { editable = "." }
 dependencies = [
-    { name = "black" },
     { name = "docker" },
     { name = "peewee" },
     { name = "questionary" },
@@ -52,6 +51,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "black" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -62,7 +62,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "black", specifier = ">=25.1.0" },
+    { name = "black", marker = "extra == 'dev'", specifier = ">=25.1.0" },
     { name = "docker", specifier = ">=7.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "peewee", specifier = ">=3.17.0" },


### PR DESCRIPTION
## Intent

Make cwcli easy to install and run through uv tooling (uv/uvx adoption is growing). This is a packaging-and-docs change only; cwcli command behavior must NOT change.

Audit conclusion: the package already builds via PEP 517 (setuptools.build_meta, src-layout auto-discovery) and already exposes two console scripts (cwcli and caffeinated-whale-cli, both -> caffeinated_whale_cli.main:cli), so uv tool install and uvx already worked. Two deliberate improvements were made:

1. Moved black from runtime [project.dependencies] to the [project.optional-dependencies].dev extra, and regenerated uv.lock. Rationale: black is only the CI formatter - it is never imported or subprocessed anywhere in src/ (verified by grep) - so shipping it as a RUNTIME dependency needlessly bloated every 'uv tool install' / 'uvx' environment with black's whole dependency tree. CI still gets black via 'uv sync --frozen --all-extras' (used by lint.yml/test.yml), so 'uv run black --check src/' still works. This is intentional and should not be flagged as 'removing a dependency' - it was reclassified, not dropped.

2. README Installation section now leads with uv: 'uv tool install caffeinated-whale-cli' (documented UNPINNED on purpose, so 'uv tool upgrade' actually advances versions - an exact-version pin makes uv report 'Nothing to upgrade'), plus 'uv tool upgrade', 'uv tool uninstall', and 'uvx --from caffeinated-whale-cli cwcli' (the --from is required because the command name differs from the package name). pip kept as an alternative; PATH troubleshooting refreshed for both uv and pip.

Also added docs/e2e/uv-tool-distribution.md capturing an isolated end-to-end validation (throwaway HOME + isolated UV_TOOL_DIR/BIN/CACHE so the captain's real ~/.cwcli and uv tools were untouched): uv tool install of the local wheel, read-only 'cwcli --version'/'cwcli ls', a genuine 0.36.0 -> 0.36.1 'uv tool upgrade', and a 'uvx --from' ephemeral run. Added a short durable note to AGENTS.md (black is dev-only; uv distribution flow). Chose NOT to switch the build backend (setuptools already works with uv and changing it risks the existing trusted-publishing release flow). All gates green locally: black, ruff, mypy (0 errors), 358 tests pass. Version stays 0.36.0 (no release cut).

## What Changed

- Moved `black` from runtime `[project.dependencies]` to the `dev` extra in `pyproject.toml` (and regenerated `uv.lock`), since it is only the CI/local formatter and is never imported or subprocessed from `src/`, keeping `uv tool install`/`uvx` environments lean.
- Rewrote the README Installation section to lead with `uv tool install caffeinated-whale-cli` (left unpinned so `uv tool upgrade` works), plus `uv tool upgrade`, `uv tool uninstall`, and `uvx --from caffeinated-whale-cli cwcli` usage, keeping pip as an alternative and refreshing PATH troubleshooting for both.
- Added `docs/e2e/uv-tool-distribution.md` capturing an isolated end-to-end validation (isolated HOME/UV_TOOL_DIR/UV_TOOL_BIN_DIR/UV_CACHE_DIR) of wheel install, `uv tool upgrade`, and `uvx --from` ephemeral runs, and added a short note to `AGENTS.md` documenting the dev-only `black` placement and the uv distribution flow.

## Risk Assessment

✅ Low: The change touches only packaging metadata (moving black to the dev extra) and documentation (README, AGENTS.md, a new E2E evidence doc); no files under src/ changed, black is verifiably unused at runtime, and uv.lock/pyproject.toml are internally consistent.

## Testing

<code>Verified `git diff` between base and target touches only pyproject.toml, uv.lock, README.md, AGENTS.md, and a new docs/e2e file (no src/ or tests/ changes). Confirmed `uv lock --check` reports no drift and grepped src/ to confirm black is never imported/subprocessed there. Independently reproduced the author&#39;s E2E claim from scratch in a throwaway sandbox (isolated HOME/UV_TOOL_DIR/UV_TOOL_BIN_DIR/UV_CACHE_DIR): built the branch&#39;s wheel, ran `uv tool install`, verified both `cwcli`/`caffeinated-whale-cli` executables and `cwcli --help`&#39;s full command list work identically, ran a read-only `cwcli ls`, confirmed black is absent from the 19 resolved packages and the installed venv, tested `uvx --from &lt;wheel&gt; cwcli --version` as an ephemeral run leaving no persistent install, and confirmed the real host `~/.cwcli` timestamps and `uv tool list` were unchanged before/after. Also ran the full pytest suite (358 passed) as supplementary proof of no command-behavior regression. All transient sandbox/build artifacts were removed and the worktree is clean.</code>

<details>
<summary>Evidence: Independent isolated uv tool install / uvx E2E transcript</summary>

```text
# Independent re-verification: uv tool install / uvx distribution (branch fm/cwcli-uv-tool-dist-u7)

Reproduced the packaging change end-to-end in a fully isolated sandbox
(`HOME`, `UV_TOOL_DIR`, `UV_TOOL_BIN_DIR`, `UV_CACHE_DIR`, `XDG_DATA_HOME`,
`XDG_CONFIG_HOME` all under a throwaway `/tmp/cwcli-uv-e2e-test`, cleaned up
afterward), independent of the author's own `docs/e2e/uv-tool-distribution.md`.

## 1. Built the branch's wheel

`` `
$ uv build --wheel -o /tmp/cwcli-uv-e2e-test/dist
Successfully built /tmp/cwcli-uv-e2e-test/dist/caffeinated_whale_cli-0.36.0-py3-none-any.whl
`` `

## 2. `uv tool install` into the isolated sandbox

`` `
$ uv tool install /tmp/cwcli-uv-e2e-test/dist/caffeinated_whale_cli-0.36.0-py3-none-any.whl
Resolved 19 packages in 1.48s
Installed 19 packages in 22ms
 + annotated-doc==0.0.4
 + caffeinated-whale-cli==0.36.0 (from file:///tmp/cwcli-uv-e2e-test/dist/...)
 + certifi==2026.6.17
 + charset-normalizer==3.4.9
 + docker==7.2.0
 + idna==3.18
 + markdown-it-py==4.2.0
 + mdurl==0.1.2
 + peewee==4.1.2
 + prompt-toolkit==3.0.52
 + pygments==2.20.0
 + questionary==2.1.1
 + requests==2.34.2
 + rich==15.0.0
 + shellingham==1.5.4
 + toml==0.10.2
 + typer==0.26.8
 + urllib3==2.7.0
 + wcwidth==0.8.2
Installed 2 executables: caffeinated-whale-cli, cwcli
`` `

`black` is absent from the resolved runtime dependency set (19 packages, none
named black/click/pathspec/mypy-extensions - black's transitive deps).
`find /tmp/cwcli-uv-e2e-test/tooldir -iname "black*"` returned nothing.

## 3. Both console scripts run correctly

`` `
$ which cwcli
/tmp/cwcli-uv-e2e-test/toolbin/cwcli
$ cwcli --version
Caffeinated Whale CLI Version: 0.36.0
$ caffeinated-whale-cli --version
Caffeinated Whale CLI Version: 0.36.0
$ cwcli --help
  ... full command list unchanged: init, inspect, label, where, run, update,
  status, open, logs, unlock, restore, backup, ls, start, stop, restart,
  rm, config, apps ...
`` `

## 4. Read-only `cwcli ls` against the isolated HOME

`` `
$ cwcli ls
             Caffeinated Whale Instances
  Project Name   Status    Ports
  ...
`` `

Ran cleanly; `~/.cwcli/cache` was created fresh only under the sandbox
`HOME` (`/tmp/cwcli-uv-e2e-test/home/.cwcli/cache`), confirming isolation.

## 5. `uvx --from <local wheel>` ephemeral run

`` `
$ uv tool uninstall caffeinated-whale-cli
Uninstalled 2 executables: caffeinated-whale-cli, cwcli
$ uvx --from /tmp/cwcli-uv-e2e-test/dist/caffeinated_whale_cli-0.36.0-py3-none-any.whl cwcli --version
Installed 19 packages in 13ms
Caffeinated Whale CLI Version: 0.36.0
`` `

`toolbin` remained empty after the `uvx` run, confirming no persistent
install was left behind (ephemeral, as documented).

## 6. Real host state untouched

- Real `~/.cwcli/{archive,cache,config,projects}` mtimes were identical
  before and after the run (baseline: `archive` 2026-06-26 23:29, `cache`
  2026-07-07 09:59, `config` 2026-06-26 05:42, `projects` 2026-06-26 23:29 -
  unchanged after).
- Real `uv tool list` shows no `caffeinated-whale-cli` entry.

## 7. Lockfile / dependency classification checks

`` `
$ uv lock --check
Resolved 38 packages in 1ms
`` `

No drift between `pyproject.toml` and `uv.lock`.

`` `
$ grep -rn "black" src/
(only unrelated comment hits for the word "whitelist"/"blacklist" - no
import or subprocess usage of black anywhere in src/)
`` `

## 8. Full unit suite (supplementary - proves no command-behavior regression)

`` `
$ uv sync --frozen --all-extras
$ uv run pytest -q
358 passed in 8.79s
`` `

## Cleanup

Removed the sandbox (`/tmp/cwcli-uv-e2e-test`) and the transient
`build/`/`dist/` artifacts created by `uv build` inside the worktree
(both already gitignored); `git status` is clean.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 9ad8beb..cb7c81b --stat (confirms packaging/docs-only scope)`
- `grep -rn "black" src/ (confirms black never imported/subprocessed at runtime)`
- <code>`uv lock --check` (confirms uv.lock matches pyproject.toml after the black extras move)</code>
- <code>`uv build --wheel` then `uv tool install &lt;wheel&gt;` in an isolated sandbox (HOME/UV_TOOL_DIR/UV_TOOL_BIN_DIR/UV_CACHE_DIR/XDG_*), verifying 19 resolved packages with black absent</code>
- <code>`cwcli --version`, `caffeinated-whale-cli --version`, `cwcli --help`, `cwcli ls` run against the isolated install</code>
- <code>`uv tool uninstall caffeinated-whale-cli` then `uvx --from &lt;local wheel&gt; cwcli --version` (ephemeral run, no persistent toolbin entry left)</code>
- <code>Compared real host `~/.cwcli` subdirectory mtimes and `uv tool list` output before/after the sandboxed run to confirm no leakage</code>
- <code>`uv sync --frozen --all-extras &amp;&amp; uv run pytest -q` (358 passed, confirms no command-behavior regression)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added installation and upgrade guidance using `uv`, including one-off execution with `uvx`.
  * Clarified Python 3.10+ requirements and troubleshooting steps for `uv` and `pip` installations.
  * Documented development-only tooling and CLI distribution details.
  * Added end-to-end evidence for isolated installation, execution, and upgrade workflows.

* **Chores**
  * Corrected the development dependency configuration to ensure all development tools are included properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->