### PR TITLE
feat(init): default Frappe to version-16 and add --version alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Use **instance** as the top-level term throughout.
 
 Each entry is the contract; the linked source file is authoritative and the Sharp edges appendix holds the root-cause detail.
 
-- **`init` version gating** (`commands/init.py`) - `bench new-site` MariaDB flag, Python/Node versions, and `setuptools` pin depend on the Frappe branch.
+- **`init` version gating** (`commands/init.py`) - default branch `version-16`; `--version <N|X.Y.Z>` alias resolves to a `version-N` branch or `vX.Y.Z` tag (`--frappe-branch` still takes a raw ref; the two are mutually exclusive). `bench new-site` MariaDB flag, Python/Node versions, and `setuptools` pin gate on the major version parsed from the ref.
   Existing-bench decline continues on a fresh name instead of dead-ending.
   See Sharp edges: `init`.
 - **`inspect` 3-tier freshness** (`commands/inspect.py`) - cache-backed with a read-only drift check; escalates to a full re-cache only on real drift.
@@ -108,12 +108,17 @@ Keep the root-cause "why" so a later change does not silently re-break the fix.
 
 ### `init` command: Frappe/bench version gating
 
-`bench new-site` MariaDB flag depends on the Frappe branch (see `_select_mariadb_flag` in `commands/init.py`):
+The default Frappe branch is `version-16` (`DEFAULT_FRAPPE_BRANCH` in `commands/init.py`; `--erpnext-branch` defaults to `version-16` to match). Two mutually-exclusive flags pick the ref, resolved BEFORE any port/Docker work so a bad value fails fast:
 
-- `version-13` and `version-14` -> `--no-mariadb-socket`
-- `version-15`+ -> `--mariadb-user-host-login-scope=%` (this flag only exists in bench/Frappe 15+; passing it to bench 14 makes `bench new-site` fail)
+- `--frappe-branch <ref>` - a raw git branch/tag (e.g. `version-16`, `v16.26.3`, `develop`), passed to `bench init` unchanged.
+- `--version <value>` - a shape-resolving alias (`resolve_frappe_ref`): a bare integer `N` -> branch `version-N`; a full SemVer 2.0.0 `X.Y.Z` (`_SEMVER_RE`) -> tag `vX.Y.Z`; anything else (e.g. `16.26`, `latest`) raises `ValueError` -> `Exit(1)`. `_resolve_frappe_branch` rejects passing both flags (`Exit(1)`) and defaults to `DEFAULT_FRAPPE_BRANCH` when neither is given.
 
-Other per-branch settings nearby in `init.py`: Python version (`branch_python`: 15->3.12, 14->3.10, 13->3.9), Node major (`branch_node`: 14->16, 13->14), and `setuptools<82` is pinned only for `version-13`.
+Version gating keys on the MAJOR version parsed from the resolved ref via `_frappe_major_version` (handles BOTH `version-16`->16 and the `v16.26.3`->16 tag form; `develop`->`None`), NOT exact branch strings - so a SemVer tag is gated the same as its branch equivalent:
+
+- `bench new-site` MariaDB flag (`_select_mariadb_flag`): major `<= 14` (or a `v14.x.x`/`v13.x.x` tag) -> `--no-mariadb-socket`; else -> `--mariadb-user-host-login-scope=%` (this flag only exists in bench/Frappe 15+; passing it to bench 14 makes `bench new-site` fail). `develop`/unknown -> the 15+ flag.
+- Python version (`branch_python`, keyed by int: 15->3.12, 14->3.10, 13->3.9), Node major (`branch_node`, keyed by int: 14->16, 13->14), and `setuptools<82` pinned only when major == 13. version-16 uses the container-default Python/Node (no dict entry).
+
+Regression coverage: `tests/test_init_frappe_version.py` (resolver shapes, mutual exclusion, default, major extraction, and an end-to-end capture that the resolved ref reaches the real `bench init` command) and the tag-form cases in `tests/test_init_mariadb_flag.py`.
 
 #### `init` existing-bench flow: decline must continue, not dead-end
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ cwcli init [OPTIONS] [PROJECT_NAME]
 | `-b`, `--bench TEXT` | Bench directory name inside the container (default: frappe-bench) |
 | `-s`, `--site TEXT` | Primary site name, must end with .localhost (default: development.localhost) |
 | `--bench-parent TEXT` | Directory inside container where bench is created (default: /workspace) |
-| `--frappe-branch TEXT` | Frappe branch for bench init (default: version-15) |
+| `--frappe-branch TEXT` | Frappe branch or tag for bench init, e.g. `version-16` or `v16.26.3` (default: version-16). Mutually exclusive with `--version` |
+| `--version TEXT` | Frappe version for bench init, resolved by shape: a bare major (`16` → `version-16` branch) or a full semantic version (`16.26.3` → `v16.26.3` tag). Malformed values are rejected with a non-zero exit. Mutually exclusive with `--frappe-branch` |
 | `--db-root-password TEXT` | MariaDB root password (default: 123) |
 | `--admin-password TEXT` | Administrator password for the site (default: admin) |
 | `--install-erpnext` | Install ERPNext application after initialization |
-| `--erpnext-branch TEXT` | ERPNext branch to use (default: version-15) |
+| `--erpnext-branch TEXT` | ERPNext branch to use (default: version-16) |
 | `--auto-start` | Automatically start containers if not running |
 | `--reuse-bench` / `--no-reuse-bench` | Pre-answer the existing-bench question non-interactively: `--reuse-bench` reuses the bench and skips `bench init`; `--no-reuse-bench` requires a fresh `--bench` name and errors if it already exists. Default: ask interactively (a non-TTY without either flag refuses). Distinct from `--auto-start`, which controls container startup |
 | `-v`, `--verbose` | Show verbose output with streaming command execution |
@@ -117,16 +118,21 @@ cwcli init [OPTIONS] [PROJECT_NAME]
 
 | Branch | Python | Node.js | Bench Image |
 |--------|--------|---------|-------------|
+| `version-16` (default) | Default | Default | Latest stable from Docker Hub |
 | `version-15` | 3.12.x (via pyenv) | Default | Latest stable from Docker Hub |
 | `version-14` | 3.10.x (via pyenv) | 16 (via nvm) + yarn | Latest stable from Docker Hub |
 | `version-13` | 3.9.x (via pyenv) | 14 (via nvm) + yarn | Latest stable from Docker Hub |
 | Other | Default | Default | Latest stable from Docker Hub |
 
+Version gating keys on the major version parsed from the ref, so a semantic-version tag
+(e.g. `v14.80.0` from `--version 14.80.0`) is gated the same way its branch equivalent
+(`version-14`) is.
+
 Missing Python or Node.js versions are automatically installed inside the container.
 `version-13` also pins `setuptools<82` in the bench virtualenv after init.
 
-Site creation picks the MariaDB flag per branch: `version-13` and `version-14` use `--no-mariadb-socket`,
-while `version-15` and newer use `--mariadb-user-host-login-scope=%` (a flag that only exists in bench/Frappe 15+).
+Site creation picks the MariaDB flag per major version: `14` and older use `--no-mariadb-socket`,
+while `15` and newer use `--mariadb-user-host-login-scope=%` (a flag that only exists in bench/Frappe 15+).
 
 **Examples:**
 
@@ -143,14 +149,20 @@ cwcli init my-project --port 10000
 # Initialize with ERPNext
 cwcli init my-project --install-erpnext
 
+# Pick a Frappe version by shape: a bare major -> version-N branch
+cwcli init my-project --version 16
+
+# ...or a full semantic version -> vX.Y.Z tag
+cwcli init my-project --version 16.26.3
+
 # Full customization
 cwcli init my-project \
   --port 12000 \
   --bench custom-bench \
   --site myapp.localhost \
-  --frappe-branch version-15 \
+  --frappe-branch version-16 \
   --install-erpnext \
-  --erpnext-branch version-15 \
+  --erpnext-branch version-16 \
   --admin-password secretpass
 
 # Verbose mode for debugging

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -35,6 +35,7 @@ Example:
     # Initializes bench and site
 """
 
+import re
 import shlex
 import subprocess
 import sys
@@ -429,13 +430,85 @@ def _build_cd_command(path: str, command: str) -> str:
     return f"cd {shlex.quote(path)} && {command}"
 
 
+DEFAULT_FRAPPE_BRANCH = "version-16"
+
+# Official SemVer 2.0.0 grammar (https://semver.org): MAJOR.MINOR.PATCH with an
+# optional pre-release and build metadata. A full match resolves to a git tag;
+# a bare integer major resolves to a version-N branch instead.
+_SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+    r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?"
+    r"(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
+
+
+def resolve_frappe_ref(version: str) -> str:
+    """Resolve a ``--version`` value to a git ref for ``bench init``.
+
+    - a bare integer ``N`` -> branch ``version-N`` (e.g. ``16`` -> ``version-16``)
+    - a semantic version ``X.Y.Z`` -> tag ``vX.Y.Z`` (e.g. ``16.26.3`` -> ``v16.26.3``)
+
+    The value must satisfy the SemVer 2.0.0 grammar to resolve to a tag; a
+    malformed value (e.g. ``16.26`` or ``latest``) raises ``ValueError``.
+    """
+    value = version.strip()
+    if re.fullmatch(r"\d+", value):
+        return f"version-{value}"
+    if _SEMVER_RE.match(value):
+        return f"v{value}"
+    raise ValueError(
+        f"Invalid --version value {version!r}: expected a bare major version "
+        f"(e.g. 16 -> version-16) or a full semantic version "
+        f"(e.g. 16.26.3 -> v16.26.3)."
+    )
+
+
+def _resolve_frappe_branch(frappe_branch: str | None, version: str | None) -> str:
+    """Resolve the effective Frappe git ref from the mutually-exclusive
+    ``--frappe-branch`` / ``--version`` flags.
+
+    Defaults to :data:`DEFAULT_FRAPPE_BRANCH` when neither is given. A malformed
+    ``--version`` or passing both flags prints an error and exits non-zero.
+    """
+    if frappe_branch is not None and version is not None:
+        stderr_console.print(
+            "[bold red]Error:[/bold red] --frappe-branch and --version are "
+            "mutually exclusive; pass only one."
+        )
+        raise typer.Exit(code=1)
+    if version is not None:
+        try:
+            return resolve_frappe_ref(version)
+        except ValueError as exc:
+            stderr_console.print(f"[bold red]Error:[/bold red] {exc}")
+            raise typer.Exit(code=1) from None
+    if frappe_branch is not None:
+        return frappe_branch
+    return DEFAULT_FRAPPE_BRANCH
+
+
+def _frappe_major_version(ref: str) -> int | None:
+    """Extract the major Frappe version from a resolved git ref.
+
+    Handles both the branch form (``version-16`` -> 16) and the tag form
+    (``v16.26.3`` -> 16). Returns ``None`` for refs with no leading numeric
+    major (e.g. ``develop``), so version gating falls through to the modern
+    defaults.
+    """
+    m = re.match(r"^(?:version-|v)(\d+)", ref)
+    return int(m.group(1)) if m else None
+
+
 def _select_mariadb_flag(frappe_branch: str) -> str:
-    """Select the ``bench new-site`` MariaDB flag for the given Frappe branch.
+    """Select the ``bench new-site`` MariaDB flag for the given Frappe ref.
 
     ``--mariadb-user-host-login-scope`` only exists in bench/Frappe 15+, so
-    versions 13 and 14 must fall back to ``--no-mariadb-socket``.
+    versions 14 and older must fall back to ``--no-mariadb-socket``. Works for
+    both branch refs (``version-14``) and tag refs (``v14.80.0``).
     """
-    if frappe_branch in ("version-13", "version-14"):
+    major = _frappe_major_version(frappe_branch)
+    if major is not None and major <= 14:
         return "--no-mariadb-socket"
     return "--mariadb-user-host-login-scope=%"
 
@@ -678,10 +751,22 @@ def init(
         "--bench-parent",
         help="Directory inside the container where the bench will be created.",
     ),
-    frappe_branch: str = typer.Option(
-        "version-15",
+    frappe_branch: str | None = typer.Option(
+        None,
         "--frappe-branch",
-        help="Frappe branch to use for bench init.",
+        help=(
+            "Frappe branch or tag for bench init (e.g. version-16 or v16.26.3). "
+            "Mutually exclusive with --version. Default: version-16."
+        ),
+    ),
+    version: str | None = typer.Option(
+        None,
+        "--version",
+        help=(
+            "Frappe version for bench init, resolved by shape: a bare major "
+            "(16 -> version-16 branch) or a full semantic version "
+            "(16.26.3 -> v16.26.3 tag). Mutually exclusive with --frappe-branch."
+        ),
     ),
     db_root_password: str = typer.Option(
         "123",
@@ -720,7 +805,7 @@ def init(
         help="Install the ERPNext application onto the created site after initialization.",
     ),
     erpnext_branch: str = typer.Option(
-        "version-15",
+        "version-16",
         "--erpnext-branch",
         help="ERPNext branch to use when fetching the app (used with --install-erpnext).",
     ),
@@ -737,9 +822,14 @@ def init(
         cwcli init
         cwcli init my-project
         cwcli init my-project --bench my-bench --site mysite.localhost
-        cwcli init my-project --frappe-branch version-15 --install-erpnext
-        cwcli init my-project --db-root-password mypass --admin-password admin123
+        cwcli init my-project --version 16 --install-erpnext
+        cwcli init my-project --version 16.26.3
+        cwcli init my-project --frappe-branch version-16 --db-root-password mypass
     """
+    # Resolve the Frappe git ref first so a malformed --version fails fast,
+    # before any project dir / container work.
+    frappe_branch = _resolve_frappe_branch(frappe_branch, version)
+
     start_time = time.time()
 
     # Prompt for project name if not provided
@@ -836,10 +926,11 @@ def init(
         # Determine Python and Node.js requirements per branch
         env_prefix = ""
         nvm_prefix = ""
-        branch_python = {"version-15": "3.12", "version-14": "3.10", "version-13": "3.9"}
-        branch_node = {"version-14": "16", "version-13": "14"}
+        branch_python = {15: "3.12", 14: "3.10", 13: "3.9"}
+        branch_node = {14: "16", 13: "14"}
+        frappe_major = _frappe_major_version(frappe_branch)
 
-        python_prefix = branch_python.get(frappe_branch)
+        python_prefix = branch_python.get(frappe_major) if frappe_major is not None else None
         if python_prefix:
             py_version = _get_pyenv_python_version(frappe_container, python_prefix, verbose=verbose)
             if not py_version:
@@ -855,7 +946,7 @@ def init(
                         f"[dim]Using PYENV_VERSION={py_version} for {frappe_branch}[/dim]"
                     )
 
-        node_major = branch_node.get(frappe_branch)
+        node_major = branch_node.get(frappe_major) if frappe_major is not None else None
         if node_major:
             node_version = _get_nvm_node_version(frappe_container, node_major, verbose=verbose)
             if not node_version:
@@ -930,7 +1021,7 @@ def init(
                 )
 
     # Pin setuptools<82 for version-13 to retain pkg_resources
-    if frappe_branch == "version-13":
+    if _frappe_major_version(frappe_branch) == 13:
         pin_cmd = _build_cd_command(bench_full_path, "./env/bin/pip install 'setuptools<82'")
         if verbose:
             stderr_console.print("[dim]Pinning setuptools<82 for version-13...[/dim]")

--- a/tests/test_init_frappe_version.py
+++ b/tests/test_init_frappe_version.py
@@ -1,0 +1,185 @@
+"""Tests for ``--version`` / ``--frappe-branch`` resolution in ``init``.
+
+``--version`` resolves by input shape: a bare integer ``N`` becomes the branch
+``version-N``, a full semantic version ``X.Y.Z`` becomes the tag ``vX.Y.Z``, and
+anything malformed is rejected with a non-zero exit. ``--frappe-branch`` keeps
+working as a raw ref, and the two flags are mutually exclusive.
+"""
+
+import pytest
+import typer
+
+import caffeinated_whale_cli.commands.init as init_mod
+from caffeinated_whale_cli.commands.init import (
+    DEFAULT_FRAPPE_BRANCH,
+    _frappe_major_version,
+    _resolve_frappe_branch,
+    resolve_frappe_ref,
+)
+
+
+class TestResolveFrappeRef:
+    """The pure shape-based resolver."""
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("16", "version-16"),
+            ("15", "version-15"),
+            ("14", "version-14"),
+            (" 16 ", "version-16"),  # surrounding whitespace tolerated
+        ],
+    )
+    def test_bare_integer_resolves_to_branch(self, value, expected):
+        assert resolve_frappe_ref(value) == expected
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("16.26.3", "v16.26.3"),
+            ("15.40.0", "v15.40.0"),
+            ("16.0.0-beta.1", "v16.0.0-beta.1"),  # pre-release is valid semver
+            ("16.0.0+build.7", "v16.0.0+build.7"),  # build metadata is valid semver
+        ],
+    )
+    def test_semver_resolves_to_tag(self, value, expected):
+        assert resolve_frappe_ref(value) == expected
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "16.26",  # only two components is not semver
+            "v16.26.3",  # already has the v prefix -> not a bare int or bare semver
+            "latest",
+            "version-16",
+            "16.26.3.4",
+            "16.x",
+            "",
+        ],
+    )
+    def test_malformed_raises(self, value):
+        with pytest.raises(ValueError):
+            resolve_frappe_ref(value)
+
+
+class TestResolveFrappeBranch:
+    """The command-level composition of the two mutually-exclusive flags."""
+
+    def test_default_when_neither_given(self):
+        assert _resolve_frappe_branch(None, None) == DEFAULT_FRAPPE_BRANCH
+        assert DEFAULT_FRAPPE_BRANCH == "version-16"
+
+    def test_frappe_branch_passthrough(self):
+        assert _resolve_frappe_branch("version-15", None) == "version-15"
+        assert _resolve_frappe_branch("develop", None) == "develop"
+
+    def test_version_int_resolves(self):
+        assert _resolve_frappe_branch(None, "16") == "version-16"
+
+    def test_version_semver_resolves(self):
+        assert _resolve_frappe_branch(None, "16.26.3") == "v16.26.3"
+
+    def test_malformed_version_exits_nonzero(self):
+        with pytest.raises(typer.Exit) as exc:
+            _resolve_frappe_branch(None, "not-a-version")
+        assert exc.value.exit_code == 1
+
+    def test_both_flags_exits_nonzero(self):
+        with pytest.raises(typer.Exit) as exc:
+            _resolve_frappe_branch("version-16", "16")
+        assert exc.value.exit_code == 1
+
+
+class _StopAfterBenchInit(Exception):
+    """Sentinel to stop init once the bench init command is captured."""
+
+
+def _drive_init_to_bench_init(monkeypatch, tmp_path, **overrides):
+    """Run the real ``init`` command body (verbose path) far enough to capture
+    the ``bench init`` command string, stubbing every Docker/host boundary.
+
+    Returns the captured command string.
+    """
+    captured = {}
+
+    class _FakeContainer:
+        def exec_run(self, *a, **k):  # pragma: no cover - not reached for v16
+            return 0, b""
+
+    def recording_exec(container, command, **kwargs):
+        captured["command"] = command
+        raise _StopAfterBenchInit
+
+    monkeypatch.setattr(init_mod, "check_ports_in_use", lambda ports: dict.fromkeys(ports, False))
+    monkeypatch.setattr(init_mod.config_utils, "get_show_tips", lambda: False)
+    monkeypatch.setattr(init_mod, "_setup_project_directory", lambda *a, **k: tmp_path)
+    monkeypatch.setattr(init_mod, "_customize_compose_ports", lambda *a, **k: None)
+    monkeypatch.setattr(init_mod, "_pull_compose_images", lambda *a, **k: None)
+    monkeypatch.setattr(init_mod, "_start_compose_project", lambda *a, **k: None)
+    monkeypatch.setattr(init_mod, "_wait_for_containers_running", lambda *a, **k: True)
+    monkeypatch.setattr(init_mod, "get_frappe_container", lambda *a, **k: _FakeContainer())
+    monkeypatch.setattr(init_mod, "_ensure_directory", lambda *a, **k: None)
+    monkeypatch.setattr(
+        init_mod,
+        "_resolve_bench_target",
+        lambda *a, **k: ("frappe-bench", "/workspace/frappe-bench", False),
+    )
+    monkeypatch.setattr(init_mod, "_exec_in_container", recording_exec)
+
+    params = dict(
+        project_name="proj",
+        port=18500,
+        bench_name="frappe-bench",
+        site_name="development.localhost",
+        bench_parent="/workspace",
+        frappe_branch=None,
+        version=None,
+        db_root_password="123",
+        admin_password="admin",
+        auto_start=False,
+        reuse_bench=None,
+        verbose=True,
+        install_erpnext=False,
+        erpnext_branch="version-16",
+    )
+    params.update(overrides)
+
+    with pytest.raises(_StopAfterBenchInit):
+        init_mod.init.__wrapped__(**params)
+    return captured["command"]
+
+
+class TestBenchInitRefEndToEnd:
+    """The resolved ref reaches the actual ``bench init`` command."""
+
+    def test_default_uses_version_16(self, monkeypatch, tmp_path):
+        cmd = _drive_init_to_bench_init(monkeypatch, tmp_path)
+        assert "--frappe-branch version-16" in cmd
+
+    def test_version_int_reaches_bench_init(self, monkeypatch, tmp_path):
+        cmd = _drive_init_to_bench_init(monkeypatch, tmp_path, version="16")
+        assert "--frappe-branch version-16" in cmd
+
+    def test_version_semver_tag_reaches_bench_init(self, monkeypatch, tmp_path):
+        cmd = _drive_init_to_bench_init(monkeypatch, tmp_path, version="16.26.3")
+        assert "--frappe-branch v16.26.3" in cmd
+
+    def test_frappe_branch_passthrough_reaches_bench_init(self, monkeypatch, tmp_path):
+        cmd = _drive_init_to_bench_init(monkeypatch, tmp_path, frappe_branch="develop")
+        assert "--frappe-branch develop" in cmd
+
+
+class TestFrappeMajorVersion:
+    @pytest.mark.parametrize(
+        "ref,expected",
+        [
+            ("version-16", 16),
+            ("version-14", 14),
+            ("v16.26.3", 16),
+            ("v14.80.0", 14),
+            ("develop", None),
+            ("staging", None),
+        ],
+    )
+    def test_major_extraction(self, ref, expected):
+        assert _frappe_major_version(ref) == expected

--- a/tests/test_init_frappe_version.py
+++ b/tests/test_init_frappe_version.py
@@ -90,7 +90,7 @@ class TestResolveFrappeBranch:
         assert exc.value.exit_code == 1
 
 
-class _StopAfterBenchInit(Exception):
+class _StopAfterBenchInitError(Exception):
     """Sentinel to stop init once the bench init command is captured."""
 
 
@@ -108,7 +108,7 @@ def _drive_init_to_bench_init(monkeypatch, tmp_path, **overrides):
 
     def recording_exec(container, command, **kwargs):
         captured["command"] = command
-        raise _StopAfterBenchInit
+        raise _StopAfterBenchInitError
 
     monkeypatch.setattr(init_mod, "check_ports_in_use", lambda ports: dict.fromkeys(ports, False))
     monkeypatch.setattr(init_mod.config_utils, "get_show_tips", lambda: False)
@@ -144,7 +144,7 @@ def _drive_init_to_bench_init(monkeypatch, tmp_path, **overrides):
     )
     params.update(overrides)
 
-    with pytest.raises(_StopAfterBenchInit):
+    with pytest.raises(_StopAfterBenchInitError):
         init_mod.init.__wrapped__(**params)
     return captured["command"]
 

--- a/tests/test_init_mariadb_flag.py
+++ b/tests/test_init_mariadb_flag.py
@@ -21,6 +21,20 @@ class TestSelectMariadbFlag:
         # --mariadb-user-host-login-scope, so it must use --no-mariadb-socket.
         assert _select_mariadb_flag("version-14") == "--no-mariadb-socket"
 
-    @pytest.mark.parametrize("branch", ["version-15", "develop"])
+    @pytest.mark.parametrize("branch", ["version-15", "version-16", "develop"])
     def test_version_15_plus_uses_host_login_scope(self, branch):
         assert _select_mariadb_flag(branch) == "--mariadb-user-host-login-scope=%"
+
+    @pytest.mark.parametrize(
+        "ref,expected",
+        [
+            ("v14.80.0", "--no-mariadb-socket"),
+            ("v13.60.0", "--no-mariadb-socket"),
+            ("v15.40.0", "--mariadb-user-host-login-scope=%"),
+            ("v16.26.3", "--mariadb-user-host-login-scope=%"),
+        ],
+    )
+    def test_tag_refs_gate_on_major_version(self, ref, expected):
+        # Regression: a semver tag (from --version X.Y.Z) must gate the same
+        # way its branch equivalent does, not silently fall to the 15+ default.
+        assert _select_mariadb_flag(ref) == expected

--- a/tests/test_init_reuse_bench.py
+++ b/tests/test_init_reuse_bench.py
@@ -297,6 +297,7 @@ class TestInitContainerReadiness:
                 site_name="development.localhost",
                 bench_parent="/workspace",
                 frappe_branch="version-15",
+                version=None,
                 db_root_password="123",
                 admin_password="admin",
                 auto_start=False,


### PR DESCRIPTION
## Intent

Default the Frappe branch to version-16 in the init command, and add a --version alias for Frappe branch/version selection that resolves by input shape: a bare integer N (e.g. --version 16) resolves to branch version-N; a semantic-version value X.Y.Z (e.g. --version 16.26.3) resolves to tag vX.Y.Z. The value must meet the SemVer 2.0.0 standard to resolve to a tag; a bare integer just prepends 'version-'. Malformed values (e.g. 16.26, latest, 16.x) are rejected with an honest error and a non-zero exit.

Decisions made: --version is an alias that composes with the existing --frappe-branch (kept working as a raw branch/tag ref); the two are mutually exclusive and passing both exits non-zero. Default when neither is given is DEFAULT_FRAPPE_BRANCH=version-16. --erpnext-branch default was also bumped to version-16 so --install-erpnext stays a coherent Frappe+ERPNext pair. Resolution runs as the first statement in init() so a malformed --version fails fast before any port/Docker work. Used the official SemVer 2.0.0 regex (accepts optional pre-release/build metadata) because the task explicitly requires meeting the semantic-versioning standard.

Root-cause extra: because tag refs are now resolvable, the per-version gating (bench new-site MariaDB flag via _select_mariadb_flag, Python/Node versions, setuptools<82 pin) was changed to key on the MAJOR version parsed from the ref via _frappe_major_version (handles both version-16->16 and v16.26.3->16; develop->None), instead of exact branch strings. This keeps a v14.x.x tag gated the same as version-14 rather than silently using the 15+ defaults. Existing _select_mariadb_flag tests stay green.

These init flags do not prompt, so 'both modes' means identical behavior under TTY and non-TTY; validated the malformed rejection exits 1 with an honest error in both a real pty and a piped non-TTY, and captured that the resolved ref reaches the actual bench init command for the int and semver paths. README and AGENTS.md/CLAUDE.md updated; the .egg-info/PKG-INFO change is an auto-generated build artifact and was not hand-edited.

## What Changed

- `init` now defaults `--frappe-branch` (and `--erpnext-branch`) to `version-16` instead of the prior default, and adds a `--version` alias that resolves by input shape: a bare integer `N` resolves to branch `version-N`, a full SemVer 2.0.0 `X.Y.Z` resolves to tag `vX.Y.Z`. `--version` and `--frappe-branch` are mutually exclusive; a malformed value or passing both exits non-zero with an honest error, resolved before any port/Docker work so it fails fast.
- Version-gated behavior (the `bench new-site` MariaDB flag, Python/Node version selection, and the `setuptools<82` pin) now keys off the major version parsed from the resolved ref (via `_frappe_major_version`, handling both `version-16` and `v16.26.3` tag forms) instead of matching exact branch strings, so a SemVer tag gates the same as its branch equivalent.
- Adds `tests/test_init_frappe_version.py` and extends `tests/test_init_mariadb_flag.py`/`tests/test_init_reuse_bench.py` to cover the resolver shapes, mutual exclusion, default behavior, and major-version extraction; updates `README.md` and `AGENTS.md` for the new flag and default.

## Risk Assessment

✅ Low: The change is a narrow, well-scoped feature addition (default branch bump + --version alias) with a fast-fail resolver, mutually-exclusive-flag validation, and major-version gating that generalizes cleanly over the prior exact-string matching; it has thorough new/updated test coverage (resolver shapes, malformed inputs, mutual exclusion, end-to-end capture of the resolved ref reaching bench init, and mariadb-flag gating on tag refs) and no unintended side effects were found elsewhere in the codebase or docs.

## Testing

Ran the full pytest suite (394 passed) plus the feature-specific tests that drive the real init() function up to the captured bench-init command string, then independently confirmed via the actual installed CLI (non-mocked, real process) that malformed --version values and the --frappe-branch/--version conflict both fail fast with a non-zero exit and an honest error message before touching Docker, exactly matching the stated intent; no code issues found and the worktree was left clean.

<details>
<summary>Evidence: Real CLI transcript: malformed --version and mutual-exclusion rejections</summary>

```text
=== malformed --version (16.26, two components) ===
$ uv run cwcli init demo-mal --version 16.26
Error: Invalid --version value '16.26': expected a bare major version (e.g. 16 
-> version-16) or a full semantic version (e.g. 16.26.3 -> v16.26.3).
[exit code: 1]

=== malformed --version (latest) ===
$ uv run cwcli init demo-mal --version latest
Error: Invalid --version value 'latest': expected a bare major version (e.g. 16 
-> version-16) or a full semantic version (e.g. 16.26.3 -> v16.26.3).
[exit code: 1]

=== malformed --version (16.x) ===
$ uv run cwcli init demo-mal --version 16.x
Error: Invalid --version value '16.x': expected a bare major version (e.g. 16 ->
version-16) or a full semantic version (e.g. 16.26.3 -> v16.26.3).
[exit code: 1]

=== both flags mutually exclusive ===
$ uv run cwcli init demo-both --frappe-branch version-15 --version 16
Error: --frappe-branch and --version are mutually exclusive; pass only one.
[exit code: 1]
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `src/caffeinated_whale_cli/commands/init.py:933` - `branch_python.get(frappe_major) if frappe_major is not None else None` (and the identical pattern for node_major on line 949) is redundant: dict.get() on a dict keyed by int already returns None when the key is None or otherwise absent, since None is never a key in branch_python/branch_node. Simplifies to `branch_python.get(frappe_major)` / `branch_node.get(frappe_major)` with no behavior change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_init_frappe_version.py tests/test_init_mariadb_flag.py tests/test_init_reuse_bench.py -q` (69 passed)</code>
- <code>`uv run pytest -q` full suite (394 passed)</code>
- <code>`uv run cwcli init --help` - confirms --version and --frappe-branch are documented, mutually exclusive, defaulting to version-16</code>
- <code>`uv run cwcli init demo-mal --version 16.26` (real CLI, non-TTY) - exits 1 with honest error, no Docker calls</code>
- <code>`uv run cwcli init demo-mal --version latest` - exits 1 with honest error</code>
- <code>`uv run cwcli init demo-mal --version 16.x` - exits 1 with honest error</code>
- <code>`uv run cwcli init demo-both --frappe-branch version-15 --version 16` - exits 1, mutual-exclusion error</code>
- `Reviewed README.md/AGENTS.md doc diffs for consistency with the new default and flag behavior`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
