### PR TITLE
test(e2e): add real-Docker E2E harness and harden CWCLI_HOME isolation rail

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,8 @@
 | Workflow | File | Triggers | Branch |
 |----------|------|----------|--------|
 | **Lint** | `lint.yml` | Push, PR | All branches |
-| **Test** | `test.yml` | Push, PR | All branches |
+| **Test** | `test.yml` | Push, PR | All branches (fast `unit` pytest tier + mypy) |
+| **E2E** | `e2e.yml` | PR, `e2e` label, Manual | PRs into `develop`/`master` (real-Docker `e2e` tier, v14/v15/v16 matrix) |
 | **Build** | `build.yml` | Push, Manual | `master` only |
 | **Release** | `release.yml` | Push, Tags, Release, Manual | `master` (push); tags fire from any branch |
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,117 @@
+name: E2E
+
+# Least-privilege default token: the E2E jobs only check out code and drive
+# Docker locally on the runner; read-only repo access is all they need.
+permissions:
+  contents: read
+
+on:
+  # Runs on PRs (see the job `if` for the actual gate) and on demand.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+
+# Cancel superseded runs on the same ref so a rapid push sequence does not queue
+# multiple multi-GB E2E matrices.
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    name: E2E (frappe v${{ matrix.frappe }})
+    # Gate: run on a manual dispatch, on a PR carrying the `e2e` label, or on a
+    # PR into a protected branch (develop / master).
+    #
+    # NOTE: develop and master have NO branch protection today, so this is not
+    # actually a *required* merge gate yet - a repo admin must enable branch
+    # protection and tick these "E2E (frappe vNN)" checks as required for them
+    # to block a merge. Until then the fast unit tier (test.yml) is the only
+    # gate that bites, and this matrix runs informationally / on the label.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      contains(github.event.pull_request.labels.*.name, 'e2e') ||
+      github.event.pull_request.base.ref == 'develop' ||
+      github.event.pull_request.base.ref == 'master'
+    # Host runner (NO `container:`) so `docker` / `docker compose` and the
+    # preinstalled daemon are reachable - the uv container image has no daemon.
+    runs-on: ubuntu-latest
+    # Provisional ceiling: a full `cwcli init` (image pull + bench init build +
+    # new-site) is the dominant cost. Generous, but well under GitHub's 6h cap so
+    # a hung `bench init` fails fast. Tune once real runtimes exist.
+    timeout-minutes: 45
+    strategy:
+      # One leg per Frappe version, each on its own runner (isolation +
+      # parallelism + per-version resource headroom). A leaky instance on one
+      # leg cannot poison another; don't cancel the others when one fails.
+      fail-fast: false
+      matrix:
+        frappe: [14, 15, 16]
+    env:
+      CWE2E_FRAPPE_MAJOR: ${{ matrix.frappe }}
+      # One prefix per leg so the always() backstop sweeps exactly this leg's
+      # cwe2e- resources.
+      CWE2E_RUN_ID: gha${{ github.run_id }}-${{ matrix.frappe }}
+      # True only when a repo admin configured Docker Hub creds; gates the login
+      # step so CI still works (anonymous pulls) when they are absent.
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+      - name: Log in to Docker Hub
+        # Authenticated pulls dodge the anonymous per-IP rate limit on the
+        # multi-GB frappe/bench image. Skipped (anonymous pull) when creds absent.
+        if: env.HAS_DOCKERHUB == 'true'
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Preflight - upstream reachability (a DISTINCT signal)
+        # cwcli init tracks latest upstream (the frappe_docker@main compose file
+        # and the latest frappe/bench tag), so it catches upstream breakage. Pull
+        # them here first: an upstream break annotates as an UPSTREAM/INFRA
+        # failure, never an ambiguous red assertion, and this warms the base
+        # image layers for the real init.
+        run: |
+          set -o pipefail
+          if ! curl -fsSL -o /tmp/cwe2e-compose.yml \
+              "https://raw.githubusercontent.com/frappe/frappe_docker/refs/heads/main/devcontainer-example/docker-compose.yml"; then
+            echo "::error title=Upstream fetch failed::frappe_docker compose file unreachable - upstream/infra issue, NOT a cwcli regression"
+            exit 78
+          fi
+          if ! docker pull frappe/bench:latest; then
+            echo "::error title=Upstream pull failed::frappe/bench image pull failed (Docker Hub rate limit or upstream) - NOT a cwcli regression"
+            exit 78
+          fi
+
+      - name: Install dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run E2E (frappe v${{ matrix.frappe }})
+        # Version-sensitive tests run on every leg; version-agnostic tests skip
+        # themselves off the non-v16 legs (see tests/e2e). Empty addopts drops
+        # the default `-m "not e2e"` and the coverage machinery - the E2E tier
+        # drives the real binary out of process, so per-line coverage is moot.
+        run: uv run pytest tests/e2e -m e2e -o addopts="" -v --tb=short
+
+      - name: Teardown backstop - sweep leaked cwe2e- resources
+        # Unconditional: even if the run above crashed before `cwcli rm` fired,
+        # remove every cwe2e- compose project's containers, volumes, networks,
+        # then reclaim the 14 GB SSD. The broad prune is safe here (the runner is
+        # ephemeral and discarded) - it deliberately does NOT live in the harness,
+        # which also runs on operators' own machines.
+        if: always()
+        run: |
+          uv run python - <<'PY'
+          from tests.e2e import harness
+          print("cwe2e- projects swept by backstop:", harness.sweep_cwe2e())
+          PY
+          docker system prune -af --volumes || true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,12 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen --all-extras
 
-      - name: Run tests with coverage
-        run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
+      # Fast tier only: the `unit` marker (auto-applied in tests/conftest.py to
+      # every non-e2e test) selects the mock-free/mock-based suite, which needs
+      # no Docker daemon and so runs inside this uv container. The real-Docker
+      # `e2e` / `e2e_p2p` tiers run on host runners in e2e.yml.
+      - name: Run unit tests with coverage
+        run: uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
 
   typecheck:
     name: Mypy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,10 @@ Each entry is the contract; the linked source file is authoritative and the Shar
 
 ## End-to-End Testing
 
-There is no runnable E2E harness and you must NOT build one.
-Real validation is pexpect driving `cwcli` against throwaway Frappe Docker benches.
-The canonical worked examples are `docs/e2e/restore-inspect-e2e-r6.md` and `docs/e2e/bench-ux-m7-multi-bench.md` (and `docs/e2e/restore-noninteractive-h2.md`); follow the procedure below and point back to them.
+There is now an automated, CI-run E2E harness in `tests/e2e/` (the `e2e` / `e2e_p2p` marker tier) that codifies the manual recipe below; it drives the real `cwcli` binary against genuine throwaway Frappe instances, on a v14/v15/v16 matrix (`.github/workflows/e2e.yml`).
+It is being filled in per command (see the open change `openspec/changes/rebuild-e2e-test-suite`); the harness contract - the `cwe2e-` name prefix, the `CWCLI_HOME` isolation seam plus temp `HOME`, the hard rails (`enforce_isolation`, name prefix) and the unconditional `sweep_cwe2e` backstop, the port allocator, real-readiness waits, and the `pexpect`/`ESC[?2004h` helper - lives in `tests/e2e/harness.py`; read `tests/README.md` before extending it.
+The manual `docs/e2e/` worked runs remain the human-precedent reference the harness was built from (canonical examples: `docs/e2e/restore-inspect-e2e-r6.md`, `docs/e2e/bench-ux-m7-multi-bench.md`, `docs/e2e/restore-noninteractive-h2.md`).
+When validating a behavior change by hand, follow the same procedure and point back to those runs.
 
 1. **Isolate everything.**
    Set `CWCLI_HOME` (preferred - relocates only cwcli's own state via `config_utils.cwcli_home()`, leaving `HOME` and HOME-derived tooling like git/ssh untouched) or a temporary `HOME` (isolates cwcli plus everything else that reads `HOME`) to a fresh throwaway directory so `~/.cwcli` is never touched, use unique docker-compose project names (for example `cwe2e-<something>`), and dedicated volumes/network.
@@ -94,10 +95,11 @@ The canonical worked examples are `docs/e2e/restore-inspect-e2e-r6.md` and `docs
 - **Types.** Keep `uv run mypy src/` at zero errors; it is a blocking gate.
   Prefer accurate annotations over `# type: ignore` (there are none in `src/`), and add the matching `types-*` stub (`types-requests`, `types-toml` are dev deps) rather than ignoring an untyped import.
   Do not loosen `[tool.mypy]` to hide errors.
-- **Tests.** `uv run pytest` (with `pytest-cov`).
-  Typer commands keep their `typer.Option(...)` default objects when a param is omitted, so tests must pass every param explicitly (see the `inspect`/`restore` notes in Sharp edges).
-- **CI gates.** `lint.yml` runs black + ruff; `test.yml` runs the `Pytest` and `Mypy` jobs on pushes and PRs to all branches (default branch is `develop`).
-  Both jobs are the intended required gates, but `develop` has no branch protection, so a repo admin must still tick `Pytest` and `Mypy` as required status checks for them to block merges.
+- **Tests.** Two tiers, split by marker (registered in `pyproject.toml`; `tests/conftest.py` auto-applies `unit` to anything not marked `e2e`/`e2e_p2p`).
+  A bare `uv run pytest` runs only the fast `unit` tier (no Docker; the default `-m "not e2e and not e2e_p2p"`); the real-Docker tier is `uv run pytest tests/e2e -m e2e` (set `CWE2E_FRAPPE_MAJOR` for the version leg).
+  Unit-tier Typer commands keep their `typer.Option(...)` default objects when a param is omitted, so tests must pass every param explicitly (see the `inspect`/`restore` notes in Sharp edges); the E2E tier instead drives the real `cwcli` binary, exercising Typer parsing.
+- **CI gates.** `lint.yml` runs black + ruff (scoped to `src/`); `test.yml` runs the `Pytest` (now `-m unit`, the fast tier) and `Mypy` jobs on pushes and PRs to all branches; `e2e.yml` runs the real-Docker `e2e` matrix (v14/v15/v16) on PRs into `develop`/`master` and on-demand via the `e2e` PR label.
+  `develop` has no branch protection, so a repo admin must still tick `Pytest`/`Mypy` (and the `E2E (frappe vNN)` checks, to make E2E a required gate) as required status checks for them to block merges.
 - **Release.** See "Cutting a release" in Sharp edges: release.
 - **Commits.** Author commits as `karotkriss <mckay.christopher73@outlook.com>` only.
   Never add an agent name as a co-author.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **Test suite** - Reorganized into two tiers selected by pytest marker: a fast `unit` tier (the default; needs no Docker) and a real-Docker `e2e`/`e2e_p2p` tier under `tests/e2e/` that drives the real `cwcli` binary against genuine throwaway Frappe instances. A bare `pytest` runs only the fast tier; `pytest -m e2e` runs the real-Docker tier (add `pexpect` via the new `e2e` extra: `uv sync --all-extras`). The E2E harness isolates every run under a temporary `HOME` + `CWCLI_HOME` with `cwe2e-`-prefixed names, hard safety rails, and an unconditional leaked-resource backstop, and CI runs it on a v14/v15/v16 matrix on GitHub-hosted runners
+
 ## [0.37.0] - 2026-07-12
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,7 +283,7 @@ class TestMyFunction:
 ### Running Tests
 
 ```bash
-# All tests
+# Fast unit tier (default; no Docker needed)
 uv run pytest
 
 # Specific test file
@@ -294,6 +294,9 @@ uv run pytest --cov
 
 # Verbose output
 uv run pytest -v
+
+# Real-Docker E2E tier (needs a Docker daemon)
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 ```
 
 See [Testing Guide](./docs/testing/guide.md) for comprehensive testing documentation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ Everything related to writing and running tests.
 ### Quick Reference
 
 ```bash
-# Run all tests
+# Run the fast unit tier (default; no Docker needed)
 uv run pytest
 
 # Run with coverage
@@ -107,6 +107,9 @@ uv run pytest tests/test_completion_utils.py
 
 # Generate HTML coverage report
 uv run pytest --cov --cov-report=html
+
+# Run the real-Docker E2E tier (needs a Docker daemon)
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 ```
 
 ### Current Status

--- a/docs/contributing/ci-cd.md
+++ b/docs/contributing/ci-cd.md
@@ -4,16 +4,17 @@ This guide covers the automated GitHub Actions workflows for caffeinated-whale-c
 
 ## Overview
 
-We use four GitHub Actions workflows:
+We use five GitHub Actions workflows:
 
 | Workflow | Triggers | Purpose |
 |----------|----------|---------|
 | **Lint** | All branches, all PRs | Code quality checks (Black, Ruff) |
-| **Test** | All branches, all PRs | Run pytest (required gate) + mypy (zero-error gate) |
+| **Test** | All branches, all PRs | Run the fast `unit` pytest tier (required gate) + mypy (zero-error gate) |
+| **E2E** | PRs into `develop`/`master`, `e2e`-labeled PRs, manual dispatch | Run the real-Docker `e2e` tier on a v14/v15/v16 Frappe matrix |
 | **Build** | Push to `master`, manual dispatch | Build package, verify version consistency |
 | **Release** | Tags `v*.*.*`, push to `master`, published releases, manual dispatch | Publish to PyPI, create GitHub release |
 
-All workflows use the `ghcr.io/astral-sh/uv:python3.12-bookworm` Docker image.
+Lint, Test, Build, and Release run inside the `ghcr.io/astral-sh/uv:python3.12-bookworm` Docker image. E2E runs directly on the `ubuntu-latest` host runner (no `container:`) so `docker`/`docker compose` can reach the runner's own daemon; it installs `uv` via `astral-sh/setup-uv` instead.
 
 ---
 
@@ -41,13 +42,30 @@ See [Code Quality Guide](./code-quality.md) for details.
 
 Runs on every push and PR. Has two jobs:
 
-- **Pytest** - runs the test suite with coverage (`uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing`). This is the intended required gate. Because `develop` has no branch protection, an admin must tick `Pytest` as a required status check in the `develop` branch-protection settings for it to actually block merges.
+- **Pytest** - runs the fast `unit` tier with coverage (`uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing`). This is the always-required gate; it needs no Docker daemon and runs inside the uv container. Because `develop` has no branch protection, an admin must tick `Pytest` as a required status check in the `develop` branch-protection settings for it to actually block merges.
 - **Mypy** - runs `uv run mypy src/` as a zero-error gate. The historical ~50 errors across ~14 files were burned down to zero and `continue-on-error` was dropped from the step, so any new type error fails the job's status check. To make it *required to merge*, an admin must also tick `Mypy` as a required status check in the `develop` branch-protection settings (same outstanding step as `Pytest`).
 
 **Run locally:**
 ```bash
-uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
+uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
 uv run mypy src/
+```
+
+---
+
+### E2E (`.github/workflows/e2e.yml`)
+
+Runs the real-Docker `e2e` tier (`tests/e2e/`) against genuine throwaway Frappe instances, driving the real `cwcli` binary. See [tests/README.md](../../tests/README.md#e2e-harness-real-docker) for the harness itself.
+
+- **Trigger gate:** a manual dispatch, a PR carrying the `e2e` label, or a PR whose base branch is `develop`/`master`. `develop`/`master` have no branch protection today, so this is not yet a *required* merge gate - an admin must enable branch protection and tick the `E2E (frappe vNN)` checks as required for that to happen. Until then it runs informationally (or on-demand via the label) and the unit tier is the only gate that blocks a merge.
+- **Runner:** `ubuntu-latest` host runner (no `container:`), one job per `strategy.matrix.frappe: [14, 15, 16]` leg, `fail-fast: false` so a leaky instance on one leg can't cancel another.
+- **Steps:** authenticate to Docker Hub when creds are configured (dodges the anonymous-pull rate limit on the multi-GB `frappe/bench` image), a preflight upstream-reachability check (annotates an upstream/infra break distinctly from a real assertion failure), `uv sync --frozen --all-extras`, `uv run pytest tests/e2e -m e2e -o addopts=""`, then an unconditional `always()` teardown step that sweeps any leaked `cwe2e-` resources and prunes the runner's Docker state.
+- **Per-job `timeout-minutes`:** ~45 (a full `cwcli init` - image pull + bench init + new-site - is the dominant cost).
+
+**Run locally** (needs a reachable Docker daemon; installs `pexpect` via the `e2e` extra):
+```bash
+uv sync --all-extras
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 ```
 
 ---

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -212,7 +212,8 @@ feat: add tab completion support
 
 1. **CI checks run automatically:**
    - Lint workflow (Black, Ruff)
-   - Test workflow (pytest, plus a zero-error mypy gate)
+   - Test workflow (the fast `unit` pytest tier, plus a zero-error mypy gate)
+   - E2E workflow (real-Docker `e2e` tier, v14/v15/v16 matrix) - required on PRs into `develop`/`master`, or on-demand via the `e2e` label
 
 2. **Address CI failures:**
    ```bash

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -144,7 +144,7 @@ See [Testing Guide](./guide.md) for detailed documentation.
 
 ## Running Tests
 
-### All Tests
+### Unit Tier (default; no Docker needed)
 
 ```bash
 uv run pytest
@@ -245,30 +245,23 @@ Run `ls tests/` for the current, authoritative list.
 
 ### By Type
 
-Use pytest markers:
+Three markers are registered in `pyproject.toml`: `unit`, `e2e`, `e2e_p2p`. `tests/conftest.py` auto-applies `unit` to any collected test not already marked `e2e`/`e2e_p2p`, so unit tests need no hand-added marker; only the real-Docker tests under `tests/e2e/` mark themselves explicitly:
 
 ```python
-@pytest.mark.unit
-def test_function():
-    """Unit test."""
-    pass
+import pytest
 
-@pytest.mark.integration
-def test_workflow():
-    """Integration test."""
-    pass
+pytestmark = pytest.mark.e2e
 
-@pytest.mark.slow
-def test_performance():
-    """Slow test."""
-    pass
+def test_real_docker_behavior(session_instance):
+    """Drives the real cwcli binary against a genuine throwaway instance."""
+    ...
 ```
 
 Run by type:
 ```bash
-pytest -m unit           # Only unit tests
-pytest -m "not slow"     # Skip slow tests
-pytest -m integration    # Only integration tests
+pytest                # Default -m "not e2e and not e2e_p2p": only the fast unit tier
+pytest -m unit         # Explicitly the unit tier
+pytest tests/e2e -m e2e  # The real-Docker tier (needs a Docker daemon)
 ```
 
 ## Debugging Tests
@@ -293,14 +286,16 @@ uv run pytest --tb=long
 
 ## CI/CD Integration
 
-Tests run in CI on every push and PR via `.github/workflows/test.yml`:
+CI is two-tiered. The fast `unit` tier runs on every push and PR via `.github/workflows/test.yml`:
 
 ```yaml
-- name: Run tests with coverage
-  run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
+- name: Run unit tests with coverage
+  run: uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
 ```
 
-The `Pytest` job is the intended required gate. See the [CI/CD Workflows guide](../contributing/ci-cd.md) for the full setup.
+The real-Docker `e2e` tier runs via `.github/workflows/e2e.yml` on a v14/v15/v16 Frappe matrix, on PRs into `develop`/`master` and on-demand via the `e2e` PR label.
+
+The `Pytest` (unit) job is the always-required gate. See the [CI/CD Workflows guide](../contributing/ci-cd.md) for the full setup.
 
 ## Future Test Priorities
 
@@ -311,6 +306,7 @@ Status as of 0.37.0 (based on `ls tests/` and the coverage run above):
 2. **Database Operations** (`utils/db_utils.py`) - covered by `test_db_security`, `test_config_validation` (~68%).
 3. **App Management** (`commands/apps.py`, `commands/update.py`) - covered by `test_apps` (~91% / ~69%).
 4. **`CWCLI_HOME` override** (`utils/config_utils.py`'s `cwcli_home()`) - covered by `test_cwcli_home`, mock-free (real env var, real filesystem, real subprocess).
+5. **Real-Docker E2E for `init` and `backup`** (`tests/e2e/test_init_e2e.py`, `tests/e2e/test_backup_e2e.py`) - genuine `bench init`/`bench backup` against throwaway Frappe instances on the v14/v15/v16 matrix, both interactive and non-interactive. The remaining commands (`rm`, `restore`, `update`/`apps`, `unlock`, `inspect`) and the P2P loopback are deferred to follow-up PRs (`openspec/changes/rebuild-e2e-test-suite`).
 
 ### Partial
 3. **Port Conflict Detection** (`commands/start.py`) - `test_yes_flag` covers the non-interactive/`--yes` contract, but the port-scanning and interactive-resolution logic itself has no dedicated suite (~59%).

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -2,14 +2,30 @@
 
 This directory contains all testing-related documentation for caffeinated-whale-cli.
 
+## Two-tier model: fast `unit` vs real-Docker `e2e`
+
+The suite is split into two tiers by pytest marker (registered in `pyproject.toml`; `tests/conftest.py` auto-applies `unit` to anything not marked `e2e`/`e2e_p2p`).
+
+- **`unit`** - fast, needs no Docker daemon, and is the default tier a bare `pytest` runs.
+  It verifies pure logic and command wiring against fakes and runs inside the uv container in CI (`test.yml`, `-m unit`, the always-required gate).
+  It stays green even with a dead Docker endpoint - that is the proof it is mock-free (`DOCKER_HOST=tcp://127.0.0.1:1 uv run pytest -m unit`).
+- **`e2e` / `e2e_p2p`** - real Docker, under `tests/e2e/`.
+  These drive the real `cwcli` binary against genuine throwaway Frappe instances (real `cwcli init` up, real side-effect assertions, `cwcli rm` down), are excluded by default, and run on GitHub-hosted `ubuntu-latest` in a v14/v15/v16 matrix (`e2e.yml`).
+
+The migration off the legacy container-mock suite is parallel-run: those tests are carried in the `unit` tier and retired per command as each command's real E2E lands (see [`../../openspec/changes/rebuild-e2e-test-suite`](../../openspec/changes/rebuild-e2e-test-suite)); the mock-free pure-logic tests are kept permanently.
+See [`../../tests/README.md`](../../tests/README.md) for the E2E harness (isolation rails, `cwe2e-` backstop, `CWCLI_HOME` seam, `pexpect`/`ESC[?2004h`).
+
 ## Quick Start
 
 ```bash
-# Run all tests
+# Fast tier only (the default; no Docker needed)
 uv run pytest
 
-# Run with coverage
-uv run pytest --cov
+# Fast tier, explicit + coverage (what CI's unit job runs)
+uv run pytest -m unit --cov=caffeinated_whale_cli
+
+# Real-Docker E2E tier (needs a daemon), one Frappe version leg
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 
 # Run specific test file
 uv run pytest tests/test_completion_utils.py
@@ -67,7 +83,14 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = ["-v", "--strict-markers", "--tb=short", "--cov-report=term-missing"]
+# The default `-m` deselects the real-Docker tiers, so a bare `pytest` is the
+# fast unit tier; `-m e2e` on the CLI overrides it (the last `-m` wins).
+addopts = ["-v", "--strict-markers", "--tb=short", "--cov-report=term-missing", "-m", "not e2e and not e2e_p2p"]
+markers = [
+    "unit: fast tests that need no Docker daemon (the default tier)",
+    "e2e: real-Docker end-to-end tests driving the real cwcli binary",
+    "e2e_p2p: real-Docker P2P (sendme loopback) end-to-end tests",
+]
 ```
 
 ## Writing Tests

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -4,12 +4,20 @@
 
 This project uses pytest for testing. All tests are located in the `tests/` directory.
 
+The suite is split into two tiers by pytest marker (see [Testing Directory Index](./README.md#two-tier-model-fast-unit-vs-real-docker-e2e) for the full model): a fast `unit` tier (no Docker daemon needed) and a real-Docker `e2e`/`e2e_p2p` tier under `tests/e2e/`. This guide covers writing `unit`-tier tests; see [tests/README.md](../../tests/README.md#e2e-harness-real-docker) for the E2E harness.
+
 ## Running Tests
 
-### Run All Tests
+### Run the Fast Unit Tier (default)
 
 ```bash
 uv run pytest
+```
+
+### Run the Real-Docker E2E Tier
+
+```bash
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 ```
 
 ### Run Specific Test File
@@ -284,15 +292,17 @@ def test_handles_exception_gracefully(self, mock_source):
 
 ## Continuous Integration
 
-Tests run in CI on every push and PR via `.github/workflows/test.yml`:
+CI is two-tiered. The fast `unit` tier runs on every push and PR via `.github/workflows/test.yml`:
 
 ```yaml
 # .github/workflows/test.yml
-- name: Run tests with coverage
-  run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
+- name: Run unit tests with coverage
+  run: uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
 ```
 
-The `Pytest` job is the intended required gate; a second `Mypy` job runs `uv run mypy src/` as a zero-error gate (it fails on any type error). See the [CI/CD Workflows guide](../contributing/ci-cd.md) for details.
+The real-Docker `e2e` tier runs via `.github/workflows/e2e.yml` on a v14/v15/v16 Frappe matrix, on PRs into `develop`/`master` and on-demand via the `e2e` PR label.
+
+The `Pytest` (unit) job is the always-required gate; a second `Mypy` job runs `uv run mypy src/` as a zero-error gate (it fails on any type error). See the [CI/CD Workflows guide](../contributing/ci-cd.md) for details.
 
 ## Debugging Tests
 
@@ -325,7 +335,8 @@ Status as of 0.37.0 (see the [Testing Directory Index](./README.md#future-test-p
 - [~] `commands/start.py` - Port conflict detection; `test_yes_flag` covers the non-interactive contract, but the port-scanning logic itself has no dedicated suite
 - [ ] `utils/port_utils.py` - Port management
 - [ ] `utils/docker_utils.py` - Docker interactions
-- [ ] Integration tests for full command flows
+- [x] Real-Docker E2E for `init` and `backup` (`tests/e2e/test_init_e2e.py`, `tests/e2e/test_backup_e2e.py`) - genuine `bench init`/`bench backup` against throwaway Frappe instances, both interactive and non-interactive
+- [ ] Real-Docker E2E for the remaining commands (`rm`, `restore`, `update`/`apps`, `unlock`, `inspect`) and the P2P (`sendme`) loopback - tracked in `openspec/changes/rebuild-e2e-test-suite`
 
 ## Resources
 

--- a/openspec/changes/rebuild-e2e-test-suite/.openspec.yaml
+++ b/openspec/changes/rebuild-e2e-test-suite/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/rebuild-e2e-test-suite/design.md
+++ b/openspec/changes/rebuild-e2e-test-suite/design.md
@@ -32,7 +32,7 @@ Each decision below was a real fork in the recon audit (§5 D1-D6, §7). The cap
 
 ### D2. Isolation: temp HOME + explicit `CWCLI_HOME` + hard rails + label backstop (recon D2)
 **Chosen:** per-session temp `HOME` **and** a new first-class `CWCLI_HOME` source override, plus unique `cwe2e-<runid>-<n>` names, a port allocator, and two independent safety layers.
-- **Hard rail (fail-closed before any Docker work):** refuse to run if `HOME` resolves to the real home directory, or if any project name lacks the `cwe2e-` prefix.
+- **Hard rail (fail-closed before any Docker work):** refuse to run if `HOME` is (or nests under) the real home directory, if `CWCLI_HOME` is unset or does not resolve to a location inside that isolated `HOME` (validating only that it is *set* is insufficient - a `CWCLI_HOME` at/under the real home would otherwise pass while cwcli wrote real state), or if any project name lacks the `cwe2e-` prefix.
 - **Teardown backstop (unconditional):** an `always()`/session-teardown sweep of every `com.docker.compose.project` matching `cwe2e-` (`compose down -v` + `docker volume prune` by label + drop the temp `HOME`), so a crashed test cannot leak.
 
 **Why `CWCLI_HOME` and not just temp `HOME`:** repointing the whole process `HOME` is a blunt instrument - it is the isolation seam only as a side effect of an env var that many host-side tools also read. An explicit `CWCLI_HOME` redirects exactly cwcli's own footprint and nothing else, which is both cleaner for the harness and a genuinely useful user feature (redirect cwcli's state without disturbing git/ssh/etc.). The harness sets both (temp `HOME` as the belt, `CWCLI_HOME` as the precise control) and the rail checks both.

--- a/openspec/changes/rebuild-e2e-test-suite/design.md
+++ b/openspec/changes/rebuild-e2e-test-suite/design.md
@@ -1,0 +1,83 @@
+## Context
+
+The recon audit (`data/cwcli-e2e-recon-r4/report.md`) established the ground truth this design rests on; it is the authoritative input and is not re-litigated here.
+Key facts it settled, with the consequences that shape the design:
+
+- **The whole suite is mock-only.** 409 tests pass against a broken Docker endpoint in ~9s (§1). There is no "already integration-ish" layer to preserve - only three genuinely mock-free files test real string/model logic and survive untouched.
+- **The real side-effect surface is small and thin.** cwcli touches Docker four ways (§2): the docker-py SDK (discovery by `com.docker.compose.project` label, `exec_into_container`), `docker compose` via subprocess (only in `init`), `container.exec_run(...)` for every bench operation, and the `sendme` binary for P2P. Everything Frappe is a shell string exec'd in the frappe container - that `exec_run` boundary is exactly where the mocks sit and where they go behavior-blind.
+- **Isolation is a single seam: `HOME`.** All of `~/.cwcli` (config, projects, cache DB) derives from `Path.home()` (`db_utils.py:10`, `config_utils.py:5-8`). A temp `HOME` + unique `cwe2e-*` names + unique ports is the entire isolation story, and it is exactly what the manual `docs/e2e/` recipe already practices.
+- **CI cannot run Docker today.** Every job runs inside `container: ghcr.io/astral-sh/uv:python3.12-bookworm`, which has no Docker daemon (§3). A Docker-backed job must run on the host `ubuntu-latest` (Docker + compose v2 preinstalled).
+- **The dominant risk is runtime, not correctness.** A genuine `cwcli init` pulls a multi-GB `frappe/bench` image, git-clones Frappe + pip/npm build (`bench init`), then `bench new-site`. That is minutes-to-tens-of-minutes per instance; the matrix design lives or dies on how that cost is handled (§5, §6).
+- **The code's own version-gating is the version-sensitive test set** (§4): `_select_mariadb_flag` (`≤14` vs `15+`), `branch_python`/`branch_node` (v14 → pyenv 3.10 + nvm 16 + yarn; v15 → pyenv 3.12; v16 → image defaults), and the v14-only `--receive` bare-filename bug that v15's alternative-directory fallback masks.
+
+## Goals / Non-Goals
+
+**Goals**
+- Enforce the destructive-path guarantees (rm/restore/backup/update/unlock) by machine, on every PR, as **real side effects** - not shell-string matches against a fake container.
+- Automate and CI-ify the existing manual `docs/e2e/` recipe (temp HOME, `cwe2e-*` names, genuine `cwcli init` benches, pexpect for TTY, flags for non-TTY, teardown) across the Frappe versions that actually diverge.
+- Make isolation a guaranteed property (hard safety rails + a leaked-resource backstop), never a hope - the captain's real instances must never be touched.
+- Keep a fast local/PR feedback loop (the mock-free unit tier) permanently.
+
+**Non-Goals** (see the proposal's Non-Goals for the full list)
+- `testcontainers`, a pre-built base image, self-hosted runners, upstream-ref pinning, Windows/macOS Docker E2E, and Frappe v13.
+
+## Decisions
+
+Each decision below was a real fork in the recon audit (§5 D1-D6, §7). The captain locked the answers; this section records **what** was chosen and **why the rejected alternative loses**, so a future reader does not silently reopen a settled fork.
+
+### D1. Framework: pytest, two tiers, drive the real `cwcli` binary (recon D1)
+**Chosen:** stay in pytest. A fast `unit` tier (mock-free pure logic) plus a real-Docker `e2e` tier whose session-scoped fixtures `cwcli init` a real instance, yield it, and `cwcli rm` on teardown. E2E drives the **console script** (`cwcli ...` via subprocess/pexpect), not in-process Typer functions.
+**Why:** the manual recipe is already pytest-shaped; one runner keeps one CI reporting surface and lets the migration be gradual. Driving the real binary closes a genuine gap the mock suite skips - the unit suite calls Typer commands as plain functions with every param passed explicitly (an omitted param keeps its truthy `typer.Option(...)` default object and silently changes behavior), so it never exercises Typer parsing.
+**Rejected:** `testcontainers-python` (recon D1-B) - cwcli *is* the thing that runs `docker compose`; wrapping that in testcontainers is double management that fights cwcli's own compose calls. A standalone bats/shell driver (D1-C) loses pytest reporting/parametrization for no gain over the manual scripts.
+
+### D2. Isolation: temp HOME + explicit `CWCLI_HOME` + hard rails + label backstop (recon D2)
+**Chosen:** per-session temp `HOME` **and** a new first-class `CWCLI_HOME` source override, plus unique `cwe2e-<runid>-<n>` names, a port allocator, and two independent safety layers.
+- **Hard rail (fail-closed before any Docker work):** refuse to run if `HOME` resolves to the real home directory, or if any project name lacks the `cwe2e-` prefix.
+- **Teardown backstop (unconditional):** an `always()`/session-teardown sweep of every `com.docker.compose.project` matching `cwe2e-` (`compose down -v` + `docker volume prune` by label + drop the temp `HOME`), so a crashed test cannot leak.
+
+**Why `CWCLI_HOME` and not just temp `HOME`:** repointing the whole process `HOME` is a blunt instrument - it is the isolation seam only as a side effect of an env var that many host-side tools also read. An explicit `CWCLI_HOME` redirects exactly cwcli's own footprint and nothing else, which is both cleaner for the harness and a genuinely useful user feature (redirect cwcli's state without disturbing git/ssh/etc.). The harness sets both (temp `HOME` as the belt, `CWCLI_HOME` as the precise control) and the rail checks both.
+**Rejected:** relying on `HOME` alone (recon D2-A) - works, but leaves isolation as an implicit side effect with no explicit, testable seam and larger blast radius.
+
+### D3 / D4 (runner + amortization): GitHub-hosted, full `init` every run, no infra now (recon D3, §7 Q1/Q2)
+**Chosen:** GitHub-hosted `ubuntu-latest`, drop the `container:`, install `uv` via `astral-sh/setup-uv`, run the full real `cwcli init` each run. No pre-built base image, no self-hosted runners in this change.
+**Why:** zero infra to own or secure, and a full-`init`-every-run E2E is the honest end-to-end test - it is the only thing that actually covers `init` itself (image pull + compose customization + `bench init` build + `new-site`), which is where the version-gated pyenv/nvm branches live. Amortization is a real cost lever but premature until we have measured per-job runtimes.
+**Rejected (deferred, not dismissed):** a pre-built "sited" base image per version and/or self-hosted runners (recon D3-B/C) - the highest-leverage speedups, but they add a build pipeline / infra to maintain and (self-hosted + fork PRs) a security footgun. Noted as the future optimizations to revisit once real runtimes exist.
+
+### D5. Matrix: per-version parallel jobs; agnostic-once, sensitive-per-version (recon D5)
+**Chosen:** one parallel job PER Frappe version (`strategy.matrix.frappe: [14, 15, 16]`), each on its own runner. Version-agnostic E2E runs **once** (on the v16 leg). The version-sensitive set runs on all three: the MariaDB flag, the pyenv/nvm branches, the v14-only `--receive` bug, and apps behaviors.
+**Why:** per-version *jobs* give isolation (one leaky instance can't poison another leg), parallelism, per-version resource headroom, and clean per-version logs - directly answering the 4 vCPU / 16 GB / 14 GB hosted-runner ceiling (§6): three heavy Frappe stacks must not run concurrently on one runner. Running truly version-agnostic tests three times is pure waste, hence agnostic-once. The per-version set is not a guess - it is exactly the code's own version-gating plus the one documented v14-only bug.
+**Rejected:** one parametrized job (recon D5-B) - serial and slow, and three stacks contending on one 16 GB runner if concurrent; one failure can cascade.
+
+### D6. Destructive-path coverage (absorbs t6) + P2P scope (recon D6)
+**Chosen:** each destructive command asserts its **real** side effect (see the `e2e-test-suite` spec's destructive requirement), both modes. P2P is a single gated loopback send+receive on one runner (`e2e_p2p`), not on every version leg.
+**Why:** these paths are the primary justification for the rebuild - mock coverage there is line-high but behavior-blind, and `backup`/`unlock` have no suite at all. P2P needs two endpoints + the `sendme` binary + iroh networking (the flakiest surface); it is orthogonal to the restore-path logic, so one gated loopback run covers the receive path without multiplying flakiness across every leg.
+**Rejected:** keeping P2P fully stubbed/out (loses real receive-path coverage) or running it on every version leg (multiplies the flakiest surface for no version-sensitivity gain).
+
+### Upstream refs: track latest, make failures diagnosable, authenticate pulls (recon §6, §7 Q6)
+**Chosen:** track latest (compose `@main` + latest `frappe/bench` tag), matching real user behavior so the E2E catches upstream breakage. Make upstream-caused failures a **distinct signal** (compose fetch / image pull / bench-tag lookup failing is annotated separately from an assertion failure) so a red gate is never ambiguous. Mitigate Docker Hub anonymous rate limits with authenticated pulls.
+**Why:** pinning would trade away the single biggest reason to run real E2E - catching the day upstream frappe_docker/bench breaks a real `cwcli init`. The cost of tracking latest is non-determinism; the mitigation is diagnosability (tell a human "upstream moved" vs "our code regressed"), not pinning.
+**Rejected:** pinning the compose ref + bench tag (recon §6) - reproducible but blind to upstream breakage, defeating a core purpose.
+
+### CI gating: two tiers; E2E required on protected-branch PRs + on-demand label (recon §7 Q8)
+**Chosen:** the fast `unit` job runs on every push/PR and is the always-required gate; the `e2e` matrix is required on PRs into protected branches and available on-demand via a PR label.
+**Why:** the captain's "re-run E2E after every behavior change" standard implies E2E must gate merges into protected branches, but running the full matrix on every push to every feature branch is wasteful - the label gives an escape hatch to run it early on demand. **Caveat, called out for the captain:** `develop`/`master` have no branch protection today, so "required" does not actually block a merge until a repo admin enables branch protection and ticks these checks required.
+
+### Runtime budget: explicit `timeout-minutes`, provisional (recon §7 Q9)
+**Chosen:** every E2E job sets `timeout-minutes` (start ~45), tuned once real numbers exist.
+**Why:** there is no timeout today, so a hung `bench init` burns toward GitHub's 6h cap. An explicit, generous-but-bounded ceiling fails a hang fast. ~45 min is a starting guess (a full `init` is the dominant cost and unmeasured in CI); it is provisional by design.
+
+## Risks / Trade-offs
+
+- **Runtime is the make-or-break.** Full `init` every run on a hosted runner may be slow; if per-job minutes become intolerable, the escape hatch is the deferred amortization (pre-built sited base image, then self-hosted). Mitigation now: the `timeout-minutes` ceiling and per-version parallel jobs.
+- **Upstream non-determinism.** Tracking latest means an upstream break turns the gate red. Mitigation: the distinct upstream-failure signal so it's obviously "upstream moved", plus authenticated pulls for the rate-limit class of failure.
+- **Docker Hub rate limits** (100 anon pulls / 6h / IP) on a multi-GB image. Mitigation: authenticated pulls; layer caching is a later lever.
+- **P2P/iroh flakiness.** Mitigation: single gated loopback leg, isolated behind `e2e_p2p`, off the per-version matrix.
+- **Disk ceiling** (14 GB SSD): images + volumes + node_modules can approach it. Mitigation: prune between phases within a leg.
+- **Interactive-mode-in-CI races.** Mitigation: await the prompt_toolkit `ESC[?2004h` raw-mode marker before each pexpect keystroke (a documented cwcli hazard), and wait on **real readiness** (health / `bench` responds), never fixed sleeps.
+- **Migration window.** During the parallel-run transition both suites exist; the mock tests can still drift. Mitigation: retire each command's mock behavior tests promptly as its E2E proves out; keep the pure-logic tests permanently.
+
+## Open questions (for review, not blocking the proposal)
+
+These are calibration values the captain locked as provisional; the implementation phase confirms them against real numbers:
+- The `timeout-minutes` starting value (~45) and whether the full matrix or a subset is the required gate day one.
+- Whether the very first E2E green justifies immediately standing up the deferred amortization (pre-built base image) or waiting for measured pain.

--- a/openspec/changes/rebuild-e2e-test-suite/proposal.md
+++ b/openspec/changes/rebuild-e2e-test-suite/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+cwcli's entire test suite is mock-only and proves nothing about real behavior.
+A full run against a deliberately broken Docker endpoint (`DOCKER_HOST=tcp://127.0.0.1:1 uv run pytest`) still passes all 409 tests in ~9s: nothing in `tests/` ever opens a Docker daemon (recon r4 §1).
+Every destructive command is "covered" only by asserting the exact shell string it hands to a fake `container.exec_run`, so the coverage numbers measure "did we build the right command", not "did the instance actually get backed up / restored / removed".
+The fakes are a shadow re-implementation of bench's and Docker's behavior that drifts from reality silently - the `docker top` secrecy correction (commit `e8f35e9`) is a documented case of the mock model asserting something the real system does not do.
+Worse, the destructive paths the captain cares about most are where the mock model is thinnest: `backup.py` and `unlock.py` have no dedicated suite at all, and `rm`/`restore` coverage is mock-string coverage against a fake container.
+The declared `slow`/`integration`/`unit` markers are dead scaffolding (never applied to a single test), and there is no shared `FakeFrappeContainer` - the name is re-implemented independently in three files plus a fourth multi-bench variant.
+
+Meanwhile the project already has a mature, isolated, real-instance E2E discipline that is run **by hand** for every behavior change (`docs/e2e/` worked runs; the "End-to-End Testing" recipe in `AGENTS.md`).
+That manual recipe - temp `HOME`, unique `cwe2e-*` names, genuine `cwcli init` benches, pexpect for TTY prompts, flags for non-interactive, teardown - is the de-facto spec for a real E2E harness.
+This change automates and CI-ifies that recipe so the destructive-path guarantees are enforced by machine on every PR, across the Frappe versions that actually diverge (v14/v15/v16), instead of resting on brittle string matches plus a human remembering to re-run the docs by hand.
+
+## What Changes
+
+- **Two-tier pytest suite.** Keep the mock-free pure-logic tests (validators, the `resolve_frappe_ref`/`_frappe_major_version` resolver, the `_redact_config_for_cache` whitelist, the label model, MariaDB-flag selection, `select_backup_set`) as a fast `unit` tier that runs with no Docker in the existing uv container. Add a real-Docker `e2e` tier whose session-scoped fixtures stand up a genuine instance with `cwcli init` and tear it down with `cwcli rm`, driving the real `cwcli` console script (so Typer parsing is exercised too). Repurpose the declared-but-unused `slow`/`integration`/`unit` markers into a real `unit` / `e2e` / `e2e_p2p` split. Reject `testcontainers` - cwcli itself owns the `docker compose` lifecycle, so the harness drives *cwcli*, not containers directly.
+- **Real side effects, not string matches, for the destructive commands** (this absorbs the standalone destructive-path coverage task t6). Each of `rm`, `restore`, `backup`, `update`, `unlock` gets a real-instance E2E asserting the actual outcome: `rm` removes the named volumes + project dir AND a verified non-empty DB dump existed first (the C1 gate); `backup` produces a real non-empty dump; `restore` actually replaces the site's data + runs `bench migrate` + restarts; `update` pulls/migrates apps + toggles maintenance mode; `unlock` clears the site lock. Both interactive (pexpect, awaiting the prompt_toolkit `ESC[?2004h` raw-mode marker before keystrokes) AND non-interactive (flags) per command.
+- **Isolation + hard safety rails.** Temp `HOME` + a new explicit `CWCLI_HOME` override (see below) + unique `cwe2e-` project/site names + a port allocator (bases ≥1006 apart; web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`). A hard rail refuses to run any E2E if `HOME` resolves to the real home directory or if any project name lacks the `cwe2e-` prefix. An unconditional teardown backstop sweeps every `com.docker.compose.project` matching `cwe2e-` (`compose down -v` + volume prune by label + drop the temp `HOME`) so a crashed test never leaks. The captain's real instances must never be touched.
+- **Source hardening (decision #9, its own PR): an explicit `CWCLI_HOME` env override** that relocates cwcli's on-disk footprint (`config`, `projects`, `cache/cwc-cache.db`) without repointing the whole process `HOME`. This is a genuine user-facing feature (redirect cwcli's state cleanly) and the isolation seam the E2E harness builds on, so it lands first/separately as source hardening the rest of the work depends on.
+- **Permanent v14/v15/v16 CI matrix.** One parallel GitHub-hosted `ubuntu-latest` job PER Frappe version (drop the `container:`; install `uv` via `astral-sh/setup-uv`), running the full real `cwcli init` each run. Version-agnostic E2E tests run **once** (on v16); the version-sensitive set runs per version: the MariaDB flag (`≤14 --no-mariadb-socket` vs `15+ --mariadb-user-host-login-scope=%`), the pyenv/nvm install branches (v14 python3.10 + node16 + yarn, v15 python3.12, v16 image defaults), the v14-only `--receive` bare-filename bug, and apps behaviors.
+- **Two-tier CI gating.** The fast `unit` job runs on every push/PR (stays in the uv container). The `e2e` matrix is required on PRs into protected branches plus on-demand via a PR label. (Branch protection is not enabled on `develop`/`master` today; it must be turned on for "required" to actually block a merge.)
+- **Track latest upstream, with diagnosable failures and authenticated pulls.** `init` keeps pulling the compose file from `frappe_docker@main` and the latest `frappe/bench` tag, matching real user behavior so the E2E catches upstream breakage. Upstream-caused failures (compose fetch / image pull / bench-tag lookup) surface as a **distinct "upstream pull/compose fetch failed" signal**, never an ambiguous red assertion. Docker Hub anonymous pull rate limits are mitigated with authenticated pulls.
+- **A single gated P2P loopback E2E.** `restore --send`/`--receive` is covered by one loopback send+receive on a single runner, marked `e2e_p2p`, NOT run on every version leg.
+- **An explicit per-job runtime budget.** Every E2E job sets `timeout-minutes` (start ~45 - generous but well under GitHub's 6h cap so a hung `bench init` fails fast). Provisional, to tune once real runtimes are known.
+- **Parallel-run transition, not a big-bang.** The current mock suite stays green while the E2E layer is built; each command's brittle container-mock tests are retired only as its real E2E lands and proves out. The pure-logic tests are kept permanently.
+
+## Capabilities
+
+### New Capabilities
+- `cwcli-home-override`: an explicit `CWCLI_HOME` environment override that relocates cwcli's entire on-disk footprint (config, projects, cache DB) to a caller-chosen directory in place of `~/.cwcli`, resolved at a single point, taking precedence over `HOME`, without repointing the process `HOME` (so git/ssh/other HOME-derived tooling is unaffected).
+- `e2e-test-suite`: a two-tier pytest suite - a permanent fast mock-free `unit` tier plus a real-Docker `e2e`/`e2e_p2p` tier that drives the real `cwcli` binary against genuine throwaway Frappe instances - with hard isolation safety rails and a leaked-resource teardown backstop, real-side-effect assertions for the destructive commands in both interactive and non-interactive modes, a permanent v14/v15/v16 CI matrix (agnostic-once, sensitive-per-version), two-tier CI gating, latest-upstream tracking with a distinct upstream-failure signal and authenticated pulls, a gated single P2P loopback test, explicit per-job runtime budgets, and a parallel-run migration off the mock suite that keeps the pure-logic tests permanently.
+
+### Modified Capabilities
+- (none - `openspec/specs/` holds no archived capabilities yet, so nothing's requirements change. The deprecation of the mock-based container tests is a test-code change captured by the new `e2e-test-suite` capability's transition requirement and the Impact below.)
+
+## Impact
+
+- **New source (decision #9, separate PR):**
+  - `src/caffeinated_whale_cli/utils/config_utils.py` and `src/caffeinated_whale_cli/utils/db_utils.py` - resolve the cwcli base directory through one helper that honors `CWCLI_HOME` (env) before falling back to `Path.home() / ".cwcli"`; `CONFIG_DIR`, `PROJECTS_DIR`, `CACHE_DIR`/`DB_PATH` all derive from it, keeping the existing 0700/0600 permissions.
+  - `README.md` - document the `CWCLI_HOME` override; `CHANGELOG.md` entry.
+- **New tests / harness:**
+  - A `tests/e2e/` package: shared session/instance fixtures (real `cwcli init` up, `cwcli rm` down), the isolation safety rails + `cwe2e-` label teardown backstop, a port allocator, a pexpect helper (awaits `ESC[?2004h`), and per-command real-side-effect E2E modules for `rm`/`restore`/`backup`/`update`/`unlock` (+ `init`, `apps`) in both modes, plus a single `e2e_p2p` loopback restore test.
+  - `pyproject.toml` - repurpose the `slow`/`integration`/`unit` markers into real `unit` / `e2e` / `e2e_p2p` markers; add an E2E-only dep group (`pexpect`) and a default `-m "not e2e and not e2e_p2p"` so a bare `pytest` stays fast.
+- **New CI:**
+  - `.github/workflows/e2e.yml` - a `strategy.matrix.frappe: [14, 15, 16]` of GitHub-hosted `ubuntu-latest` jobs (no `container:`), `astral-sh/setup-uv`, authenticated Docker Hub login, `timeout-minutes`, a distinct upstream-failure step/annotation, and the `cwe2e-` teardown backstop in an `always()` step. Version-agnostic tests run only on the v16 leg; the P2P loopback runs on one gated leg.
+  - `.github/workflows/test.yml` - the existing `Pytest` job stays in the uv container but runs only the fast `unit` tier (`-m unit`).
+- **Modified tests (parallel-run retirement):** the container-mock behavior tests in `tests/test_rm_safety.py`, `tests/test_restore_safety.py`, `tests/test_restore_inspect_fixes.py`, `tests/test_inspect_partial_refresh.py`, `tests/test_apps.py`, `tests/test_yes_flag.py`, and the shared fakes (`tests/bench_fakes.py`, `tests/bench_fakes_mb.py`) are retired per command **only as** its real E2E lands and proves out - not up front.
+- **Kept permanently (pure logic, mock-free):** `tests/test_init_mariadb_flag.py`, `tests/test_config_validation.py`, `tests/test_bench_labels.py`, the resolver cases in `tests/test_init_frappe_version.py`, the `select_backup_set` / redaction-whitelist tests, and any other test that touches no Docker.
+- **Docs:** update `tests/README.md` and `docs/testing/README.md` for the two-tier model; add an E2E-harness note to `AGENTS.md`; the manual `docs/e2e/` runs remain the human-precedent reference the harness is built from.
+- **Dependencies:** add `pexpect` (E2E extra only). No runtime dependency added. `testcontainers` explicitly NOT added.
+- **Future optimizations noted, not built now:** a pre-built "sited" base image per version and/or self-hosted runners to amortize `init` cost - revisit once real per-job runtimes are known.
+
+## Non-Goals
+
+- Removing the pure-logic unit tests (kept permanently) or deleting the mock suite in a big bang (retired per command, parallel-run).
+- A `testcontainers`-managed lifecycle (cwcli owns `docker compose`; the harness drives cwcli).
+- A pre-built base image, image-layer cache pipeline, or self-hosted runners in this change (future optimizations only).
+- Pinning upstream refs for reproducibility (deliberately track latest to catch upstream breakage; the mitigation is a diagnosable upstream-failure signal, not pinning).
+- Windows/macOS Docker E2E (Linux-only; `port_utils`, `startup`, `vscode_utils`, and named-pipe Docker-error paths stay unit-tested).
+- Frappe v13 coverage (out of the requested matrix).

--- a/openspec/changes/rebuild-e2e-test-suite/specs/cwcli-home-override/spec.md
+++ b/openspec/changes/rebuild-e2e-test-suite/specs/cwcli-home-override/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: CWCLI_HOME relocates cwcli's home directory
+The system SHALL honor a `CWCLI_HOME` environment variable that, when set, is used verbatim as the base directory for cwcli's entire on-disk footprint in place of `~/.cwcli`.
+The config directory SHALL resolve to `$CWCLI_HOME/config`, the projects directory to `$CWCLI_HOME/projects`, and the cache database to `$CWCLI_HOME/cache/cwc-cache.db`.
+When `CWCLI_HOME` is unset or empty, the base directory SHALL remain `Path.home() / ".cwcli"`, so existing installs are unaffected.
+The base directory SHALL be resolved through a single shared helper, so `config_utils` and `db_utils` cannot diverge on where cwcli's state lives.
+The relocated directories SHALL be created with the same restrictive permissions as today (cache directory `0700`, cache DB file `0600`).
+
+#### Scenario: CWCLI_HOME set redirects all of cwcli's state
+- **WHEN** `CWCLI_HOME=/tmp/cwe2e-home-1` is set and any cwcli command reads or writes its config, projects registry, or cache
+- **THEN** cwcli uses `/tmp/cwe2e-home-1/config`, `/tmp/cwe2e-home-1/projects`, and `/tmp/cwe2e-home-1/cache/cwc-cache.db`, and never touches `~/.cwcli`
+
+#### Scenario: CWCLI_HOME unset keeps the default location
+- **WHEN** `CWCLI_HOME` is unset (or empty) and a cwcli command runs
+- **THEN** cwcli uses `~/.cwcli/config`, `~/.cwcli/projects`, and `~/.cwcli/cache/cwc-cache.db` exactly as before
+
+#### Scenario: relocated cache keeps secure permissions
+- **WHEN** `CWCLI_HOME` points at a fresh directory and cwcli first creates its cache
+- **THEN** the cache directory is created `0700` and the cache DB file `0600`, identical to the default location's hardening
+
+### Requirement: CWCLI_HOME does not repoint the process HOME
+Setting `CWCLI_HOME` SHALL affect ONLY cwcli's own on-disk paths.
+It SHALL NOT change the process `HOME` environment variable, so host-side tooling that derives its own state from `HOME` (git config, ssh, shell) is unaffected by redirecting cwcli's state.
+
+#### Scenario: redirecting cwcli state leaves HOME-derived tooling alone
+- **WHEN** `CWCLI_HOME` is set to a temporary directory but `HOME` is left at the user's real home
+- **THEN** cwcli reads and writes only under `$CWCLI_HOME`, while any host tool that reads `HOME` (e.g. git, ssh) still resolves to the user's real home unchanged

--- a/openspec/changes/rebuild-e2e-test-suite/specs/e2e-test-suite/spec.md
+++ b/openspec/changes/rebuild-e2e-test-suite/specs/e2e-test-suite/spec.md
@@ -39,13 +39,18 @@ The harness SHALL wait on real readiness (health / a `bench` command responding)
 
 ### Requirement: Hard isolation safety rails and a leaked-resource backstop
 The E2E harness SHALL guarantee it can never touch the operator's real cwcli state or instances.
-Before any Docker work, a hard rail SHALL refuse to run (fail-closed, non-zero) if `HOME` resolves to the operator's real home directory, or if any E2E project name lacks the `cwe2e-` prefix.
-Isolation SHALL be provided by a per-session temporary `HOME` plus the `CWCLI_HOME` override, unique `cwe2e-<runid>-<n>` project and site names, and a port allocator that assigns non-overlapping bases at least 1006 apart (web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`).
+Before any Docker work, a hard rail SHALL refuse to run (fail-closed, non-zero) if `HOME` resolves to (or nests under) the operator's real home directory, if `CWCLI_HOME` is unset or does not resolve to a location inside that isolated `HOME`, or if any E2E project name lacks the `cwe2e-` prefix.
+Because `CWCLI_HOME` is where cwcli writes ALL of its on-disk state, validating only that it is *set* is insufficient: the rail SHALL additionally verify (via realpath) that `CWCLI_HOME` is contained within the isolated `HOME`, so a `CWCLI_HOME` pointing at or under the operator's real home can never pass while cwcli writes real state.
+Isolation SHALL be provided by a per-session temporary `HOME` plus the `CWCLI_HOME` override (with `CWCLI_HOME` nested inside that temporary `HOME`), unique `cwe2e-<runid>-<n>` project and site names, and a port allocator that assigns non-overlapping bases at least 1006 apart (web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`).
 An unconditional teardown backstop SHALL run regardless of test outcome and sweep every `com.docker.compose.project` matching the `cwe2e-` prefix (`docker compose down -v` + volume prune by label + drop the temporary `HOME`), so a crashed or aborted test never leaks containers, volumes, or a project directory.
 
 #### Scenario: Refuse to run against the real home
 - **WHEN** the E2E harness is started but `HOME` still resolves to the operator's real home directory
 - **THEN** the harness refuses to run any E2E, exits non-zero, and touches no Docker resource
+
+#### Scenario: Refuse a CWCLI_HOME outside the isolated root
+- **WHEN** the E2E harness is started with an isolated `HOME` but `CWCLI_HOME` resolves to a location at or under the operator's real home (or otherwise outside the isolated `HOME`)
+- **THEN** the harness refuses to run any E2E, exits non-zero, and touches no Docker resource or real cwcli state
 
 #### Scenario: Refuse a non-prefixed project name
 - **WHEN** an E2E attempts to create or operate on a project whose name lacks the `cwe2e-` prefix

--- a/openspec/changes/rebuild-e2e-test-suite/specs/e2e-test-suite/spec.md
+++ b/openspec/changes/rebuild-e2e-test-suite/specs/e2e-test-suite/spec.md
@@ -1,0 +1,186 @@
+## ADDED Requirements
+
+### Requirement: Two-tier pytest suite (fast unit + real-Docker E2E)
+The test suite SHALL be organized into two tiers selected by pytest markers.
+A fast `unit` tier SHALL contain only mock-free pure-logic tests (input validators, the `resolve_frappe_ref` / `_frappe_major_version` version resolver, the `_redact_config_for_cache` whitelist, the label model, MariaDB-flag selection, `select_backup_set`) and SHALL require no Docker daemon.
+A real-Docker `e2e` tier SHALL drive the real `cwcli` console script against genuine throwaway instances.
+The declared-but-unused `slow` / `integration` / `unit` markers SHALL be repurposed into real `unit` / `e2e` / `e2e_p2p` markers, registered in `pyproject.toml`, and a bare `pytest` invocation SHALL default to the fast tier (`-m "not e2e and not e2e_p2p"`).
+The suite SHALL NOT adopt `testcontainers`: cwcli itself owns the `docker compose` lifecycle, so the harness drives `cwcli`, not containers directly.
+
+#### Scenario: Unit tier runs with no Docker
+- **WHEN** the `unit` tier runs with no reachable Docker daemon (e.g. `DOCKER_HOST` pointed at a dead endpoint)
+- **THEN** every unit test still passes, because no unit test opens a Docker connection
+
+#### Scenario: Bare pytest stays fast
+- **WHEN** a developer runs `pytest` with no marker selection
+- **THEN** only the `unit` tier runs and the `e2e` / `e2e_p2p` tiers are excluded by default
+
+#### Scenario: E2E tier is real Docker
+- **WHEN** the `e2e` tier runs
+- **THEN** it invokes the real `cwcli` console script (exercising Typer parsing) against a real Docker daemon, not an in-process function call with a fake container
+
+### Requirement: E2E instances are stood up and torn down with real cwcli
+The E2E harness SHALL stand up each test instance by running the real `cwcli init` (a genuine `bench init` + `bench new-site` against a freshly pulled image), expose it to tests through a session-scoped fixture, and tear it down by running the real `cwcli rm --yes --volumes`.
+Interactive flows SHALL be driven through a real pty with pexpect, awaiting the prompt_toolkit raw-mode readiness marker `ESC[?2004h` before each keystroke.
+Non-interactive flows SHALL be driven with flags (`--yes`, `--mariadb-root-username`/`--mariadb-root-password`, `--site`, backup selectors, `--bench`).
+The harness SHALL wait on real readiness (health / a `bench` command responding), never fixed sleeps.
+
+#### Scenario: Session fixture builds and tears down a genuine instance
+- **WHEN** an E2E module requests the shared instance fixture
+- **THEN** the fixture runs `cwcli init` to build a real bench + site, yields the running instance to the tests, and on teardown runs `cwcli rm --yes --volumes`
+
+#### Scenario: Interactive prompt driven via pexpect
+- **WHEN** an E2E test drives an interactive confirmation or credential prompt
+- **THEN** it awaits the `ESC[?2004h` raw-mode marker before sending each keystroke, so no keystroke races the prompt
+
+#### Scenario: Readiness is waited on, never slept
+- **WHEN** the harness needs an instance or bench to be ready
+- **THEN** it polls a real readiness signal until ready (or times out with a clear error) rather than sleeping a fixed duration
+
+### Requirement: Hard isolation safety rails and a leaked-resource backstop
+The E2E harness SHALL guarantee it can never touch the operator's real cwcli state or instances.
+Before any Docker work, a hard rail SHALL refuse to run (fail-closed, non-zero) if `HOME` resolves to the operator's real home directory, or if any E2E project name lacks the `cwe2e-` prefix.
+Isolation SHALL be provided by a per-session temporary `HOME` plus the `CWCLI_HOME` override, unique `cwe2e-<runid>-<n>` project and site names, and a port allocator that assigns non-overlapping bases at least 1006 apart (web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`).
+An unconditional teardown backstop SHALL run regardless of test outcome and sweep every `com.docker.compose.project` matching the `cwe2e-` prefix (`docker compose down -v` + volume prune by label + drop the temporary `HOME`), so a crashed or aborted test never leaks containers, volumes, or a project directory.
+
+#### Scenario: Refuse to run against the real home
+- **WHEN** the E2E harness is started but `HOME` still resolves to the operator's real home directory
+- **THEN** the harness refuses to run any E2E, exits non-zero, and touches no Docker resource
+
+#### Scenario: Refuse a non-prefixed project name
+- **WHEN** an E2E attempts to create or operate on a project whose name lacks the `cwe2e-` prefix
+- **THEN** the harness refuses, exits non-zero, and creates nothing
+
+#### Scenario: Port allocator prevents collisions between parallel instances
+- **WHEN** two E2E instances are stood up in the same run
+- **THEN** the allocator gives them port bases at least 1006 apart so their web and socketio ranges never overlap
+
+#### Scenario: Backstop sweeps leaked resources after a crash
+- **WHEN** a test aborts mid-run and its `cwcli rm` teardown does not fire
+- **THEN** the unconditional backstop still removes every `cwe2e-`-labelled compose project's containers and volumes and drops the temporary `HOME`
+
+### Requirement: Destructive commands assert real side effects in both modes
+The E2E tier SHALL cover each destructive command (`rm`, `restore`, `backup`, `update`, `unlock`) by asserting the actual on-disk / in-container side effect, never a mock string match, in BOTH interactive and non-interactive modes.
+- `rm` SHALL be verified to remove the project's named volumes and its `~/.cwcli/projects/<name>` directory, AND a verified non-empty database dump SHALL be shown to exist first (the C1 backup gate).
+- `backup` SHALL be verified to produce a real, non-empty database dump.
+- `restore` SHALL be verified to actually replace the site's data, run `bench migrate`, and restart the instance.
+- `update` SHALL be verified to pull/migrate the app(s) and to toggle maintenance mode (on then off).
+- `unlock` SHALL be verified to clear the site lock.
+
+#### Scenario: rm removes volumes and dir only after a verified backup
+- **WHEN** an E2E runs `cwcli rm cwe2e-<name> --yes --volumes` on a real instance
+- **THEN** the test asserts a non-empty DB dump was produced before deletion, then asserts the named volumes and `~/.cwcli/projects/cwe2e-<name>` no longer exist
+
+#### Scenario: backup produces a real non-empty dump
+- **WHEN** an E2E runs `cwcli backup` on a real instance
+- **THEN** the test asserts a database dump file exists on the host and is non-empty
+
+#### Scenario: restore replaces data, migrates, and restarts
+- **WHEN** an E2E restores a backup into a real site
+- **THEN** the test asserts the site's data reflects the backup, that `bench migrate` ran, and that the instance was restarted
+
+#### Scenario: update pulls, migrates, and toggles maintenance mode
+- **WHEN** an E2E runs `cwcli update` (or `cwcli apps update`) on a real instance
+- **THEN** the test asserts the app was pulled/migrated and that maintenance mode was turned on during and off after the update
+
+#### Scenario: unlock clears the site lock
+- **WHEN** a site holds a lock and an E2E runs `cwcli unlock`
+- **THEN** the test asserts the lock is cleared afterward
+
+#### Scenario: Both modes are exercised per command
+- **WHEN** a destructive command's E2E runs
+- **THEN** it exercises both the interactive path (pexpect, `ESC[?2004h`) and the non-interactive path (flags), and asserts a non-TTY without the required flag refuses with a non-zero exit
+
+### Requirement: Permanent v14/v15/v16 CI matrix, agnostic-once and sensitive-per-version
+CI SHALL run the E2E tier as one parallel job PER Frappe version (14, 15, 16), each on its own GitHub-hosted `ubuntu-latest` runner.
+Version-agnostic E2E tests SHALL run only once (on the v16 leg), not three times.
+The version-sensitive set SHALL run on every version leg and SHALL include: the MariaDB flag divergence (`≤14 --no-mariadb-socket` vs `15+ --mariadb-user-host-login-scope=%`), the pyenv/nvm install branches (v14 python3.10 + node16 + yarn, v15 python3.12, v16 image defaults), the v14-only `--receive` bare-filename bug, and apps behaviors.
+
+#### Scenario: Version-sensitive test runs on all three legs
+- **WHEN** the E2E matrix runs
+- **THEN** the MariaDB-flag, pyenv/nvm-branch, `--receive` bare-filename, and apps tests each run on the v14, v15, and v16 legs
+
+#### Scenario: Version-agnostic test runs once
+- **WHEN** the E2E matrix runs
+- **THEN** a version-agnostic E2E runs only on the v16 leg and is skipped on the v14 and v15 legs
+
+#### Scenario: v14-only receive bug is caught on v14
+- **WHEN** the `--receive` E2E runs on the v14 leg
+- **THEN** it exercises the bare-filename path that only reproduces on v14 (v15's alternative-directory fallback masks it) and asserts the restore succeeds
+
+### Requirement: E2E jobs run on a host runner with an explicit runtime budget
+Each E2E job SHALL run directly on GitHub-hosted `ubuntu-latest` with no `container:`, so `docker` and `docker compose` and the daemon are reachable.
+`uv` SHALL be installed via `astral-sh/setup-uv` (the E2E job cannot use the uv container image).
+Each E2E job SHALL run the full real `cwcli init` each run (no pre-built base image in this change).
+Each E2E job SHALL set an explicit `timeout-minutes` (starting at ~45, provisional) so a hung `bench init` fails fast rather than burning toward GitHub's 6h cap.
+Disk pressure SHALL be managed within a leg by pruning Docker images/volumes between phases, respecting the 4 vCPU / 16 GB / 14 GB hosted-runner ceiling.
+
+#### Scenario: E2E job reaches the Docker daemon
+- **WHEN** an E2E job starts on `ubuntu-latest`
+- **THEN** it runs on the host (no `container:`), installs uv via `astral-sh/setup-uv`, and `docker` / `docker compose` reach the preinstalled daemon
+
+#### Scenario: A hung init is bounded by the job timeout
+- **WHEN** a `bench init` hangs during an E2E job
+- **THEN** the job's `timeout-minutes` ceiling fails it fast rather than running toward the 6h cap
+
+### Requirement: Docker-not-available skips loudly, never a silent green
+The E2E harness SHALL detect an unavailable Docker daemon (`docker info` / `client.ping()`) and SKIP loudly - the E2E result SHALL make the missing-Docker condition obvious as an infrastructure failure, never report a silent green pass as if the tests had run.
+
+#### Scenario: No Docker daemon is an obvious skip
+- **WHEN** the E2E tier runs on a machine with no reachable Docker daemon
+- **THEN** it emits a loud skip that clearly signals "Docker unavailable - infrastructure problem" rather than passing silently
+
+### Requirement: Track latest upstream with a distinct failure signal and authenticated pulls
+The E2E SHALL track latest upstream (the `frappe_docker@main` compose file and the latest `frappe/bench` tag), matching real user behavior, so it catches upstream breakage of a real `cwcli init`.
+Upstream-caused failures (compose fetch, image pull, or bench-tag lookup) SHALL surface as a DISTINCT "upstream pull/compose fetch failed" signal, separable from a real assertion failure, so a red gate is never ambiguous.
+Docker Hub anonymous pull rate limits SHALL be mitigated with authenticated pulls.
+
+#### Scenario: Upstream fetch failure is distinguishable from a test failure
+- **WHEN** an upstream compose fetch or image pull fails during an E2E run
+- **THEN** the failure is annotated as an upstream/infrastructure failure, visibly distinct from a cwcli assertion failure
+
+#### Scenario: Authenticated pulls dodge anonymous rate limits
+- **WHEN** an E2E job pulls the multi-GB `frappe/bench` image
+- **THEN** it authenticates to Docker Hub so the pull is not subject to the anonymous per-IP rate limit
+
+### Requirement: P2P sendme is a single gated loopback E2E
+The `restore --send` / `--receive` P2P path SHALL be covered by a SINGLE loopback E2E (send + receive on one runner), marked `e2e_p2p`, and SHALL NOT run on every version leg.
+
+#### Scenario: P2P runs once, gated, off the version matrix
+- **WHEN** the E2E suite runs
+- **THEN** the P2P send+receive loopback test runs on a single gated leg under the `e2e_p2p` marker and is excluded from the per-version `e2e` matrix legs
+
+### Requirement: Two-tier CI gating
+CI SHALL run the fast `unit` tier on every push and pull request (kept in the existing uv container).
+The `e2e` matrix SHALL be required on pull requests into protected branches and SHALL also be runnable on-demand via a PR label.
+The proposal SHALL note that branch protection must be enabled on `develop`/`master` for a "required" E2E gate to actually block a merge (it is not enabled today).
+
+#### Scenario: Unit tier gates every push
+- **WHEN** any push or PR is made
+- **THEN** the fast `unit` job runs as an always-required gate in the uv container
+
+#### Scenario: E2E gates protected-branch PRs and runs on-demand via label
+- **WHEN** a PR targets a protected branch, OR a PR carries the E2E label
+- **THEN** the `e2e` matrix runs; on a protected-branch PR it is a required gate (contingent on branch protection being enabled)
+
+### Requirement: Parallel-run transition off the mock suite
+The migration SHALL be parallel-run, not a big bang.
+The current mock-based suite SHALL stay green while the E2E layer is built.
+Each command's brittle container-mock behavior tests SHALL be retired only as that command's real E2E lands and proves out.
+The mock-free pure-logic tests SHALL be kept permanently.
+
+#### Scenario: Mock suite stays green during the transition
+- **WHEN** the E2E layer is being built but a given command's E2E has not yet landed
+- **THEN** that command's existing mock tests remain in place and green
+
+#### Scenario: A command's mock tests are retired only after its E2E proves out
+- **WHEN** a command's real E2E has landed and proven out
+- **THEN** that command's container-mock behavior tests are retired, while the pure-logic unit tests are kept
+
+### Requirement: Docker E2E is Linux-only; OS-specific code stays unit-tested
+The real-Docker E2E SHALL be Linux-only.
+Windows/macOS-specific code (`port_utils`, `startup`, `vscode_utils`, named-pipe Docker-error handling) SHALL remain covered by the mock-free / mock-based unit tier rather than the Docker E2E.
+
+#### Scenario: OS-specific paths are not in the Docker E2E
+- **WHEN** the Docker E2E matrix runs
+- **THEN** it runs only on Linux, and the Windows/macOS-specific code paths are exercised by the unit tier instead

--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -1,0 +1,71 @@
+Tasks are unchecked - this is the PROPOSE phase; nothing is implemented yet.
+The per-command groups in §4 encode the parallel-run cadence: land a command's real E2E, prove it out, THEN retire that command's mock behavior tests. The mock suite stays green until each command's E2E lands.
+
+## 1. CWCLI_HOME source hardening (decision #9 - lands first, its own PR)
+
+- [x] 1.1 Add a single shared base-directory helper (e.g. `cwcli_home()` in `utils/config_utils.py`) that returns `Path(os.environ["CWCLI_HOME"])` when `CWCLI_HOME` is set and non-empty, else `Path.home() / ".cwcli"`.
+- [x] 1.2 Route `CONFIG_DIR`, `PROJECTS_DIR` (`config_utils.py`) and `CACHE_DIR` / `DB_PATH` (`db_utils.py`) through the helper so config, projects, and cache all relocate together; keep the existing `0700` dir / `0600` file permissions.
+- [x] 1.3 Confirm `CWCLI_HOME` only moves cwcli's own paths and never mutates the process `HOME` (host-side git/ssh unaffected).
+- [x] 1.4 Unit tests (mock-free): `CWCLI_HOME` set redirects all three locations; unset keeps `~/.cwcli`; relocated cache keeps secure permissions; single-helper means `config_utils` and `db_utils` agree.
+- [x] 1.5 Document `CWCLI_HOME` in `README.md`; add a `CHANGELOG.md` entry.
+
+## 2. Shared E2E harness (the reusable seam every command E2E builds on)
+
+- [x] 2.1 Create the `tests/e2e/` package and repurpose the markers in `pyproject.toml`: `unit` / `e2e` / `e2e_p2p` (retire the dead `slow` / `integration`); set default `addopts` to `-m "not e2e and not e2e_p2p"` so a bare `pytest` stays fast.
+- [x] 2.2 Add the E2E-only dependency group with `pexpect` (NOT `testcontainers`).
+- [x] 2.3 Docker-availability gate: detect `docker info` / `client.ping()` and SKIP LOUDLY (obvious infra failure, never silent green) when no daemon is reachable.
+- [x] 2.4 Hard isolation rails (fail-closed before any Docker work): refuse if `HOME` resolves to the real home, or if any project name lacks the `cwe2e-` prefix.
+- [x] 2.5 Isolation fixtures: per-session temp `HOME` + `CWCLI_HOME` override + unique `cwe2e-<runid>-<n>` project/site names.
+- [x] 2.6 Port allocator: non-overlapping bases ≥1006 apart (web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`).
+- [x] 2.7 Session/instance fixture: stand up a real instance via `cwcli init` (full `bench init` + `new-site`), wait on REAL readiness (never fixed sleeps), yield, tear down via `cwcli rm --yes --volumes`.
+- [x] 2.8 pexpect helper for interactive flows: await the prompt_toolkit `ESC[?2004h` raw-mode marker before each keystroke; a non-interactive helper drives flags.
+- [x] 2.9 Unconditional teardown backstop: sweep every `com.docker.compose.project` matching `cwe2e-` (`compose down -v` + volume prune by label + drop temp `HOME`), plus between-phase Docker prune for the 14 GB disk ceiling.
+
+## 3. CI: host-runner E2E matrix + two-tier gating
+
+- [x] 3.1 `.github/workflows/test.yml`: scope the existing `Pytest` job to the fast unit tier (`-m unit`), still inside the uv container, on every push/PR (always-required gate).
+- [x] 3.2 New `.github/workflows/e2e.yml`: `strategy.matrix.frappe: [14, 15, 16]` of `ubuntu-latest` jobs with NO `container:`; install uv via `astral-sh/setup-uv`.
+- [x] 3.3 Authenticated Docker Hub login step (dodge anonymous pull rate limits); a distinct "upstream pull/compose fetch failed" annotation separable from an assertion failure.
+- [x] 3.4 Per-job `timeout-minutes` (start ~45, provisional); the `cwe2e-` teardown backstop in an `always()` step.
+- [x] 3.5 Run version-agnostic E2E only on the v16 leg; version-sensitive E2E on all three legs.
+- [x] 3.6 Gating triggers: required on PRs into protected branches, plus on-demand via a PR label. Note in the workflow/PR that branch protection must be enabled on `develop`/`master` for "required" to bite.
+
+## 4. Per-command E2E + mock retirement (parallel-run cadence)
+
+Each subgroup: (a) land the real-side-effect E2E in both modes, (b) prove it out, (c) THEN retire that command's mock behavior tests. Pure-logic tests are kept.
+
+- [x] 4.1 **init** - E2E: real `cwcli init` builds a genuine bench + site (already the harness fixture); assert both interactive and non-interactive (`--yes`, `--admin-password`, `--mariadb-root-password`) paths and the generated-admin-password print-once behavior. (init has no pure "mock behavior" suite to retire beyond resolver logic, which stays in unit.)
+- [x] 4.2 **backup** - E2E: assert a real, non-empty DB dump lands on the host; both modes; multi-bench `--bench`. Retire the mock backup assertions once green (`backup` has no dedicated mock suite today - this is net-new real coverage).
+- [ ] 4.3 **rm** - E2E: assert named volumes + `~/.cwcli/projects/<name>` are gone AND a verified non-empty DB dump existed first (C1 gate); the early-abort-before-container-removal on a failed backup; both modes. THEN retire the container-mock behavior tests in `tests/test_rm_safety.py` / `tests/bench_fakes_mb.py` (keep `test_rm_truth.py`'s pure-logic name/path validators in unit).
+- [ ] 4.4 **restore** - E2E (normal path): assert site data is actually replaced + `bench migrate` ran + instance restarted; `--latest` / `--backup-file` selectors; origin-mismatch warning; both modes; the v14-only `--receive` bare-filename path on the v14 leg. THEN retire the mock behavior tests in `tests/test_restore_safety.py` and `tests/test_restore_inspect_fixes.py` (keep `TestSelectBackupSet` pure-logic in unit).
+- [ ] 4.5 **update / apps update** - E2E: assert app pulled/migrated + maintenance mode toggled on-then-off; the frappe `bench update --reset` special-case; `--site` narrowing incl. the "named a site the app isn't on → refuse" case; deprecated `cwcli update` warns + delegates; both modes. THEN retire the container-mock tests in `tests/test_apps.py` (keep git-URL-derivation and other pure-logic in unit).
+- [ ] 4.6 **unlock** - E2E: hold a site lock, run `cwcli unlock`, assert the lock is cleared; both modes; multi-bench `--bench`. Net-new real coverage (`unlock` has no suite today).
+- [ ] 4.7 **inspect** - E2E: assert the 3-tier freshness behavior against a real bench (T1 serve, T2 read-only drift detect, T3 re-cache on real drift); a freshly installed app becomes visible without `--update`. THEN retire the tier-assertion mock tests in `tests/test_inspect_partial_refresh.py` (keep any pure-logic in unit).
+- [ ] 4.8 **apps (list/install/uninstall)** - E2E: real `bench get-app`/`install-app`/`uninstall-app`, multi-site fan-out with honest aggregated exit codes, `--json` purity, post-mutation cache refresh reflected in `where`/`inspect`; both modes. Retire the remaining `tests/test_apps.py` container-mock tests once green.
+- [ ] 4.9 **yes-flag / auto-start contract** - fold the `ensure_containers_running` / `confirm_or_exit` non-TTY-refusal assertions into the per-command E2E (each command asserts non-TTY-without-flag refuses non-zero). Retire the container-mock parts of `tests/test_yes_flag.py`; keep any pure-logic there in unit.
+
+## 5. Version-sensitive matrix coverage (runs on all three legs)
+
+- [x] 5.1 MariaDB flag: assert `new-site` uses `--no-mariadb-socket` on v14 and `--mariadb-user-host-login-scope=%` on v15/v16, and that the site is actually created (the flag divergence is real - the 15+ flag breaks bench 14).
+- [x] 5.2 pyenv/nvm branches: assert v14 provisions python3.10 + node16 + yarn, v15 provisions python3.12, v16 uses image defaults (no pyenv/nvm step).
+- [ ] 5.3 `--receive` bare-filename: assert the v14 leg reproduces-then-passes the full-container-path fix (v15/v16 mask it via alternative-directory fallback).
+- [ ] 5.4 apps behaviors on each version leg (per §4.8), plus the v16-first-ever real E2E coverage (no v16 manual evidence exists yet).
+
+## 6. P2P (gated, single loopback)
+
+- [ ] 6.1 Ensure `sendme` is installed on the P2P leg (or gate the test off cleanly when absent).
+- [ ] 6.2 Single `e2e_p2p` loopback: `restore --send` produces a ticket, `restore --receive` consumes it on the same runner, and the receive path's real side effect (data replaced + migrate + restart) is asserted. NOT on the per-version matrix legs.
+
+## 7. Docs
+
+- [x] 7.1 Rewrite `tests/README.md` and `docs/testing/README.md` for the two-tier model (fast unit vs real-Docker E2E), the marker split, and the isolation/backstop contract.
+- [x] 7.2 Add an E2E-harness note to `AGENTS.md` (how the automated harness relates to the manual `docs/e2e/` recipe it was built from; the `cwe2e-` prefix + `CWCLI_HOME` + safety rails).
+- [x] 7.3 `CHANGELOG.md` entries for the test-suite rebuild (user-facing surface only) and the `CWCLI_HOME` feature.
+
+## 8. Validation (definition of done for the implementation phase)
+
+- [x] 8.1 Fast unit tier stays green with a broken Docker endpoint (proves it is still mock-free).
+- [ ] 8.2 The full E2E matrix goes green on all three legs (v14/v15/v16) at least once; the P2P leg goes green.
+- [x] 8.3 Deliberately leak a container mid-test and confirm the `cwe2e-` backstop sweeps it; deliberately point `HOME` at the real home and confirm the rail refuses.
+- [x] 8.4 Confirm each destructive command's E2E asserts the REAL side effect (not a string match) and that both modes are exercised.
+- [ ] 8.5 Ship the tests + the `CWCLI_HOME` change + the `openspec/` specs through /no-mistakes per the gate rules (respond to gates, escalate ask-user findings, no `--yes`).

--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -1,4 +1,4 @@
-Tasks are unchecked - this is the PROPOSE phase; nothing is implemented yet.
+This is a multi-PR rebuild; checked boxes are implemented, unchecked boxes are deferred to follow-up PRs. The first PR lands §1 (`CWCLI_HOME`), §2 (the shared harness), §3 (CI matrix + gating), §4.1-4.2 (`init`/`backup` E2E), §5.1-5.2 (their version-sensitive coverage), and §7 (docs); the remaining commands' E2E (§4.3-4.9), the rest of §5, P2P (§6), and the full-matrix/no-mistakes validation (§8.2, §8.5) are deferred.
 The per-command groups in §4 encode the parallel-run cadence: land a command's real E2E, prove it out, THEN retire that command's mock behavior tests. The mock suite stays green until each command's E2E lands.
 
 ## 1. CWCLI_HOME source hardening (decision #9 - lands first, its own PR)

--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -14,7 +14,7 @@ The per-command groups in §4 encode the parallel-run cadence: land a command's 
 - [x] 2.1 Create the `tests/e2e/` package and repurpose the markers in `pyproject.toml`: `unit` / `e2e` / `e2e_p2p` (retire the dead `slow` / `integration`); set default `addopts` to `-m "not e2e and not e2e_p2p"` so a bare `pytest` stays fast.
 - [x] 2.2 Add the E2E-only dependency group with `pexpect` (NOT `testcontainers`).
 - [x] 2.3 Docker-availability gate: detect `docker info` / `client.ping()` and SKIP LOUDLY (obvious infra failure, never silent green) when no daemon is reachable.
-- [x] 2.4 Hard isolation rails (fail-closed before any Docker work): refuse if `HOME` resolves to the real home, or if any project name lacks the `cwe2e-` prefix.
+- [x] 2.4 Hard isolation rails (fail-closed before any Docker work): refuse if `HOME` is (or nests under) the real home, if `CWCLI_HOME` is unset or does not resolve to a location inside that isolated `HOME`, or if any project name lacks the `cwe2e-` prefix.
 - [x] 2.5 Isolation fixtures: per-session temp `HOME` + `CWCLI_HOME` override + unique `cwe2e-<runid>-<n>` project/site names.
 - [x] 2.6 Port allocator: non-overlapping bases ≥1006 apart (web `{port}..{port+5}`, socketio `{port+1000}..{port+1005}`).
 - [x] 2.7 Session/instance fixture: stand up a real instance via `cwcli init` (full `bench init` + `new-site`), wait on REAL readiness (never fixed sleeps), yield, tear down via `cwcli rm --yes --volumes`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,14 @@ dev = [
     "types-requests>=2.33.0.20260518",
     "types-toml>=0.10.8.20260518",
 ]
+# Real-Docker E2E tier only. pexpect drives the interactive TTY flows (awaiting
+# the prompt_toolkit ESC[?2004h raw-mode marker before each keystroke). NOT
+# testcontainers - cwcli owns the `docker compose` lifecycle, so the harness
+# drives the real `cwcli` binary, not containers directly. Picked up by
+# `uv sync --all-extras`.
+e2e = [
+    "pexpect>=4.9.0",
+]
 
 [tool.black]
 line-length = 100
@@ -79,16 +87,22 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+# A bare `pytest` runs only the fast tier: the default `-m` deselects the
+# real-Docker E2E markers, so no Docker daemon is needed for local dev / the
+# unit CI job. Override on the CLI (`-m e2e`) to run the E2E tier - the last
+# `-m` on the command line wins over this default.
 addopts = [
     "-v",
     "--strict-markers",
     "--tb=short",
     "--cov-report=term-missing",
+    "-m",
+    "not e2e and not e2e_p2p",
 ]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "unit: marks tests as unit tests",
+    "unit: fast, mock-free/mock-based tests that need no Docker daemon (the default tier). During the parallel-run migration this also carries the legacy container-mock tests until each command's real E2E lands; see tests/conftest.py.",
+    "e2e: real-Docker end-to-end tests that drive the real `cwcli` binary against genuine throwaway instances (requires a Docker daemon).",
+    "e2e_p2p: real-Docker P2P (sendme loopback) end-to-end tests; gated, off the per-version matrix.",
 ]
 
 [tool.coverage.run]

--- a/tests/README.md
+++ b/tests/README.md
@@ -60,10 +60,15 @@ The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit
 
 ## Test Files
 
-As of 0.37.0, `tests/` holds 22 `test_*.py` suites totaling 416 tests
-(measured with `uv run pytest --cov`). Run `ls tests/` for the
+As of 0.37.0, `tests/` holds 22 `test_*.py` suites totaling 416 tests in the
+`unit` tier (measured with `uv run pytest --cov`). Run `ls tests/` for the
 authoritative current list; see [../docs/testing/README.md](../docs/testing/README.md)
 for the per-area breakdown.
+
+`tests/e2e/` adds 3 more `test_*.py` suites in the real-Docker `e2e` tier
+(`test_init_e2e.py`, `test_backup_e2e.py`, `test_harness_safety.py`); run
+`ls tests/e2e/` for the current list. They are not part of the 416/22 count
+above since they need a Docker daemon and are excluded from a bare `pytest`.
 
 ### `test_completion_utils.py`
 Tests for tab completion functionality.
@@ -237,17 +242,18 @@ Status as of 0.34.0 (see [../docs/testing/README.md](../docs/testing/README.md) 
 ### Done
 1. **Project inspection** (`commands/inspect.py`) - covered by `test_inspect_partial_refresh`, `test_inspect_label_recovery` (~62%).
 2. **Database operations** (`utils/db_utils.py`) - covered by `test_db_security`, `test_config_validation` (~68%).
+3. **Real-Docker E2E for `init` and `backup`** - covered by `tests/e2e/test_init_e2e.py`, `tests/e2e/test_backup_e2e.py` (both interactive and non-interactive, on the v14/v15/v16 matrix).
 
 ### Partial
-3. **Port conflict detection** (`commands/start.py`) - `test_yes_flag` covers the non-interactive/`--yes` contract, but the port-scanning and interactive-resolution logic has no dedicated suite (~59%).
+4. **Port conflict detection** (`commands/start.py`) - `test_yes_flag` covers the non-interactive/`--yes` contract, but the port-scanning and interactive-resolution logic has no dedicated suite (~59%).
 
 ### Still needed
-4. **Docker utilities** (`utils/docker_utils.py`) - foundation for all commands; error handling only incidentally covered (~37%).
-5. **Port utilities** (`utils/port_utils.py`) - cross-platform process detection (~9%).
-6. **VS Code integration** (`utils/vscode_utils.py`) - container attachment fallback (~16%).
-7. **Configuration management** (`utils/config_utils.py`) - distinct from `db_utils`'s config validation (~37%).
-8. **Integration tests** - full command workflows, end-to-end scenarios.
-9. Other command modules at or near 0%: `backup.py`, `list.py`, `run.py`, `status.py`, `unlock.py`, `where.py`.
+5. **Docker utilities** (`utils/docker_utils.py`) - foundation for all commands; error handling only incidentally covered (~37%).
+6. **Port utilities** (`utils/port_utils.py`) - cross-platform process detection (~9%).
+7. **VS Code integration** (`utils/vscode_utils.py`) - container attachment fallback (~16%).
+8. **Configuration management** (`utils/config_utils.py`) - distinct from `db_utils`'s config validation (~37%).
+9. **Real-Docker E2E for the remaining commands** (`rm`, `restore`, `update`/`apps`, `unlock`, `inspect`) and the P2P (`sendme`) loopback - tracked in `openspec/changes/rebuild-e2e-test-suite`.
+10. Other command modules at or near 0%: `backup.py`, `list.py`, `run.py`, `status.py`, `unlock.py`, `where.py`.
 
 ## Resources
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,14 +2,35 @@
 
 This directory contains all tests for the caffeinated-whale-cli project.
 
+## Two tiers: fast `unit` vs real-Docker `e2e`
+
+The suite is split into two tiers by pytest marker.
+
+- **`unit`** - fast, needs no Docker daemon.
+  It is the default tier: a bare `pytest` runs only this tier.
+  It is the mock-free/mock-based suite that verifies pure logic and command wiring against fakes, and it runs inside the uv container in CI (`test.yml`, `-m unit`).
+  During the migration off the legacy mock suite (see [`../openspec/changes/rebuild-e2e-test-suite`](../openspec/changes/rebuild-e2e-test-suite)) this tier also carries the container-mock behavior tests; they are retired per command as each command's real E2E lands, and the mock-free pure-logic tests are kept permanently.
+- **`e2e`** / **`e2e_p2p`** - real Docker.
+  These live under [`tests/e2e/`](e2e/) and drive the real `cwcli` console script against genuine throwaway Frappe instances (real `cwcli init` up, real side-effect assertions, `cwcli rm` down).
+  They require a reachable Docker daemon and are excluded by default; run them explicitly with `-m e2e`.
+  See [E2E harness](#e2e-harness-real-docker) below.
+
+The `unit`, `e2e`, and `e2e_p2p` markers are registered in `pyproject.toml`; `tests/conftest.py` auto-applies `unit` to any test not marked `e2e`/`e2e_p2p`, so there is nothing to hand-mark.
+
 ## Quick Reference
 
 ```bash
-# Run all tests
+# Fast tier only (the default; no Docker needed)
 uv run pytest
 
-# Run all tests with coverage
-uv run pytest --cov
+# Fast tier, explicit + coverage (what CI's unit job runs)
+uv run pytest -m unit --cov=caffeinated_whale_cli
+
+# Prove the fast tier is mock-free: still green with a dead Docker endpoint
+DOCKER_HOST=tcp://127.0.0.1:1 uv run pytest -m unit
+
+# Real-Docker E2E tier (needs a Docker daemon), one Frappe version leg
+CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 
 # Run specific test file
 uv run pytest tests/test_completion_utils.py
@@ -17,18 +38,25 @@ uv run pytest tests/test_completion_utils.py
 # Run tests matching a pattern
 uv run pytest -k "cache"
 
-# Run with verbose output
-uv run pytest -v
-
-# Stop on first failure
+# Stop on first failure / show locals / debugger
 uv run pytest -x
-
-# Show local variables on failure
 uv run pytest -l
-
-# Drop into debugger on failure
 uv run pytest --pdb
 ```
+
+## E2E harness (real Docker)
+
+The E2E harness ([`tests/e2e/harness.py`](e2e/harness.py) + [`tests/e2e/conftest.py`](e2e/conftest.py)) automates the manual `docs/e2e/` recipe so the destructive-path guarantees are enforced by machine.
+It drives the real `cwcli` binary (subprocess for non-interactive, `pexpect` for interactive - awaiting the prompt_toolkit `ESC[?2004h` raw-mode marker before each keystroke), waits on real readiness (never fixed sleeps), and asserts real side effects (e.g. a non-empty DB dump copied out to the host), in both modes.
+
+Isolation and safety are non-negotiable and layered:
+
+- Each session gets a temporary `HOME` **and** a `CWCLI_HOME` override (the precise seam that relocates only cwcli's own footprint), plus unique `cwe2e-<runid>-<n>` project/site names and a port allocator (bases ≥1006 apart).
+- A **hard rail** (`enforce_isolation`) fails closed before any Docker work if `HOME` still resolves to the operator's real home or `CWCLI_HOME` is unset, and a name rail refuses any project name lacking the `cwe2e-` prefix.
+- An **unconditional teardown backstop** (`sweep_cwe2e`) removes every `cwe2e-`-labelled compose project's containers, volumes, and networks on session teardown, so a crashed test never leaks.
+
+`CWE2E_FRAPPE_MAJOR` selects the Frappe version leg (default 16); version-agnostic E2E tests run only on the v16 leg, version-sensitive ones on every leg.
+The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit tier.
 
 ## Test Files
 
@@ -139,7 +167,14 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = ["-v", "--strict-markers", "--tb=short", "--cov-report=term-missing"]
+# The default `-m` deselects the real-Docker tiers, so a bare `pytest` runs only
+# the fast unit tier; override with `-m e2e` on the CLI (the last `-m` wins).
+addopts = ["-v", "--strict-markers", "--tb=short", "--cov-report=term-missing", "-m", "not e2e and not e2e_p2p"]
+markers = [
+    "unit: fast tests that need no Docker daemon (the default tier)",
+    "e2e: real-Docker end-to-end tests driving the real cwcli binary",
+    "e2e_p2p: real-Docker P2P (sendme loopback) end-to-end tests",
+]
 ```
 
 Coverage configuration:
@@ -152,14 +187,22 @@ omit = ["*/tests/*", "*/__init__.py"]
 
 ## CI/CD
 
-Tests run in CI on every push and PR via `.github/workflows/test.yml`:
+CI is two-tiered.
 
-```yaml
-- name: Run tests with coverage
-  run: uv run pytest --cov=caffeinated_whale_cli --cov-report=term-missing
-```
+- **`.github/workflows/test.yml`** runs the fast `unit` tier on every push and PR, inside the uv container:
 
-The `Pytest` job is the intended required gate. See the [CI/CD Workflows guide](../docs/contributing/ci-cd.md) for the full setup.
+  ```yaml
+  - name: Run unit tests with coverage
+    run: uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
+  ```
+
+  The `Pytest` (unit) job is the always-required gate.
+
+- **`.github/workflows/e2e.yml`** runs the real-Docker `e2e` tier as a `strategy.matrix.frappe: [14, 15, 16]` of GitHub-hosted `ubuntu-latest` jobs (no `container:`, so `docker`/`docker compose` reach the daemon).
+  It is triggered on PRs into `develop`/`master` and on-demand via the `e2e` PR label, with per-job `timeout-minutes` and an `always()` `cwe2e-` teardown backstop.
+  Note: `develop`/`master` have no branch protection today, so a repo admin must enable it and tick these checks before the E2E matrix is a *required* gate; until then the unit tier is the only gate that blocks a merge.
+
+See the [CI/CD Workflows guide](../docs/contributing/ci-cd.md) for the full setup.
 
 ## Common Issues
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -52,7 +52,7 @@ It drives the real `cwcli` binary (subprocess for non-interactive, `pexpect` for
 Isolation and safety are non-negotiable and layered:
 
 - Each session gets a temporary `HOME` **and** a `CWCLI_HOME` override (the precise seam that relocates only cwcli's own footprint), plus unique `cwe2e-<runid>-<n>` project/site names and a port allocator (bases ≥1006 apart).
-- A **hard rail** (`enforce_isolation`) fails closed before any Docker work if `HOME` still resolves to the operator's real home or `CWCLI_HOME` is unset, and a name rail refuses any project name lacking the `cwe2e-` prefix.
+- A **hard rail** (`enforce_isolation`) fails closed before any Docker work if `HOME` is (or nests under) the operator's real home, or if `CWCLI_HOME` is unset or does not resolve to a location inside that isolated `HOME` (so a `CWCLI_HOME` pointing at the real home can never slip through), and a name rail refuses any project name lacking the `cwe2e-` prefix.
 - An **unconditional teardown backstop** (`sweep_cwe2e`) removes every `cwe2e-`-labelled compose project's containers, volumes, and networks on session teardown, so a crashed test never leaks.
 
 `CWE2E_FRAPPE_MAJOR` selects the Frappe version leg (default 16); version-agnostic E2E tests run only on the v16 leg, version-sensitive ones on every leg.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Top-level pytest config for the two-tier suite.
+
+The suite is split into a fast ``unit`` tier (no Docker) and a real-Docker
+``e2e`` / ``e2e_p2p`` tier (``tests/e2e/``). Rather than hand-mark every legacy
+test, this hook auto-applies the ``unit`` marker to any collected test that is
+not already marked ``e2e`` / ``e2e_p2p``. That way:
+
+- a bare ``pytest`` (default ``-m "not e2e and not e2e_p2p"``) runs the unit tier,
+- the unit CI job (``-m unit``) selects the same set, and
+- ``-m e2e`` selects only the real-Docker tier.
+
+During the parallel-run migration off the mock suite, the legacy container-mock
+tests are carried in the ``unit`` tier alongside the permanent mock-free
+pure-logic tests; they are retired per command as each command's real E2E lands
+(see ``openspec/changes/rebuild-e2e-test-suite``). The end state is a ``unit``
+tier of only mock-free pure-logic tests.
+"""
+
+
+def pytest_collection_modifyitems(config, items):
+    import pytest
+
+    for item in items:
+        if item.get_closest_marker("e2e") or item.get_closest_marker("e2e_p2p"):
+            continue
+        item.add_marker(pytest.mark.unit)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -50,10 +50,21 @@ def isolated_home(tmp_path_factory):
     saved = {k: os.environ.get(k) for k in ("HOME", "CWCLI_HOME")}
     os.environ["HOME"] = str(tmp_home)
     os.environ["CWCLI_HOME"] = str(cwcli_home)
+    # `cwcli init` bind-mounts $CWCLI_HOME/projects/<name> into the frappe
+    # container as /workspace, and `bench init` writes there as the container's
+    # `frappe` user (UID 1000). When the HOST user's UID differs - GitHub-hosted
+    # runners run as UID 1001 - a default-umask 0755 workspace is not writable by
+    # frappe, so `bench init` fails immediately. Relax the umask (inherited by the
+    # cwcli subprocess) so the project/workspace dirs are created world-writable
+    # and the container can write regardless of host UID. cwcli's cache dir keeps
+    # its explicit 0700 mode (umask only removes bits, never adds), so no secret
+    # dir is loosened. Local runs whose host UID is already 1000 are unaffected.
+    saved_umask = os.umask(0o000)
     harness.enforce_isolation()  # fail closed before any instance work
     try:
         yield tmp_home
     finally:
+        os.umask(saved_umask)
         for k, v in saved.items():
             if v is None:
                 os.environ.pop(k, None)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,130 @@
+"""E2E fixtures: isolation, the safety backstop, and the shared real instance.
+
+All Docker/rail work happens inside these fixtures (never at import), so
+collecting the e2e modules under ``-m unit`` (which deselects them) stays cheap
+and Docker-free.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import pytest
+
+from . import harness
+
+# A fixed, non-secret throwaway admin password for the non-interactive session
+# instance (the interactive test covers the GENERATED-password path separately).
+SESSION_ADMIN_PW = "CwE2ETestAdmin-123"
+
+
+@dataclass
+class Instance:
+    name: str
+    site: str
+    bench: str
+    port: int
+    init_stdout: str
+    init_stderr: str
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _docker_gate():
+    """SKIP LOUDLY when no Docker daemon is reachable - an infra failure, never
+    a silent green pass."""
+    if not harness.docker_available():
+        pytest.skip(
+            "DOCKER UNAVAILABLE - no reachable daemon (`docker info` failed). "
+            "This is an INFRASTRUCTURE problem, not a passing E2E run; the "
+            "real-Docker E2E tier cannot execute here."
+        )
+
+
+@pytest.fixture(scope="session", autouse=True)
+def isolated_home(tmp_path_factory):
+    """Per-session temp HOME + CWCLI_HOME so ~/.cwcli is never touched, then the
+    hard isolation rail. Restores the environment on teardown."""
+    tmp_home = tmp_path_factory.mktemp("cwe2e-home")
+    cwcli_home = tmp_home / ".cwcli"
+    saved = {k: os.environ.get(k) for k in ("HOME", "CWCLI_HOME")}
+    os.environ["HOME"] = str(tmp_home)
+    os.environ["CWCLI_HOME"] = str(cwcli_home)
+    harness.enforce_isolation()  # fail closed before any instance work
+    try:
+        yield tmp_home
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _teardown_backstop(_docker_gate):
+    """Unconditional sweep of every cwe2e- compose project on session teardown,
+    so a crashed test (whose `cwcli rm` never fired) cannot leak."""
+    yield
+    harness.sweep_cwe2e()
+
+
+@pytest.fixture(scope="session")
+def port_allocator():
+    return harness.PortAllocator()
+
+
+@pytest.fixture(scope="session")
+def session_instance(isolated_home, _docker_gate, _teardown_backstop, port_allocator):
+    """One real throwaway instance for the whole session: a genuine `cwcli init`
+    (bench init + new-site), torn down with `cwcli rm --yes --volumes`.
+
+    Stood up NON-INTERACTIVELY (stdin closed, `--admin-password` supplied), so it
+    doubles as the non-interactive init proof; the interactive/generated-password
+    path is a separate dedicated test.
+    """
+    harness.enforce_isolation()
+    name = harness.project_name("main")
+    port = port_allocator.next()
+    result = harness.run_cwcli(
+        "init",
+        name,
+        "--port",
+        str(port),
+        "--frappe-branch",
+        harness.FRAPPE_BRANCH,
+        "--admin-password",
+        SESSION_ADMIN_PW,
+        "--auto-start",
+        timeout=harness.INIT_TIMEOUT,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"`cwcli init {name}` (frappe {harness.FRAPPE_BRANCH}) failed "
+            f"(exit {result.returncode}). If the preflight upstream check passed, "
+            f"this is a cwcli regression.\n--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+    # Real readiness: Frappe boots and reaches its DB for the site.
+    harness.wait_for_site_ready(name, harness.DEFAULT_SITE)
+    inst = Instance(
+        name=name,
+        site=harness.DEFAULT_SITE,
+        bench=harness.DEFAULT_BENCH_PATH,
+        port=port,
+        init_stdout=result.stdout,
+        init_stderr=result.stderr,
+    )
+    try:
+        yield inst
+    finally:
+        harness.cwcli_rm(name)
+
+
+@pytest.fixture()
+def running_instance(session_instance):
+    """The session instance, guaranteed to have a running frappe container."""
+    if harness.frappe_container_id(session_instance.name) is None:
+        harness.run_cwcli("start", session_instance.name, "--yes")
+        harness.wait_for_site_ready(session_instance.name, session_instance.site)
+    return session_instance

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -8,6 +8,7 @@ and Docker-free.
 from __future__ import annotations
 
 import os
+import shutil
 from dataclasses import dataclass
 
 import pytest
@@ -70,6 +71,7 @@ def isolated_home(tmp_path_factory):
                 os.environ.pop(k, None)
             else:
                 os.environ[k] = v
+        shutil.rmtree(tmp_home, ignore_errors=True)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -89,8 +89,11 @@ def enforce_isolation() -> None:
     The one unacceptable failure is touching the operator's real cwcli state, so
     this is checked before any Docker/instance work.
     """
-    home = os.path.realpath(os.environ.get("HOME", ""))
-    if not home or home == _REAL_HOME:
+    raw_home = os.environ.get("HOME", "")
+    if not raw_home:
+        raise RuntimeError("E2E isolation rail: HOME is unset/empty; refusing to run any E2E.")
+    home = os.path.realpath(raw_home)
+    if home == _REAL_HOME:
         raise RuntimeError(
             f"E2E isolation rail: HOME ({home!r}) resolves to the operator's real "
             f"home ({_REAL_HOME!r}); refusing to run any E2E."

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -12,8 +12,9 @@ footprint - see ``utils/config_utils.cwcli_home``). Two independent safety
 layers guard the operator's real state:
 
 - a hard rail (``enforce_isolation``) that fails closed before any Docker work if
-  ``HOME`` still resolves to the real home or ``CWCLI_HOME`` is unset, and a name
-  rail that refuses any project name lacking the ``cwe2e-`` prefix;
+  ``HOME`` is (or nests under) the real home, or if ``CWCLI_HOME`` is unset or does
+  not resolve to a location inside that isolated ``HOME``, and a name rail that
+  refuses any project name lacking the ``cwe2e-`` prefix;
 - an unconditional teardown backstop (``sweep_cwe2e``) that removes every
   ``cwe2e-``-labelled compose project's containers, volumes, and networks even
   when a test crashes before its ``cwcli rm`` teardown fires.
@@ -83,23 +84,50 @@ CWCLI = shutil.which("cwcli") or "cwcli"
 # --------------------------------------------------------------------------- #
 # Safety rails (fail-closed before any Docker work)
 # --------------------------------------------------------------------------- #
+def _at_or_under(path: str, ancestor: str) -> bool:
+    """True if ``path`` equals or is nested inside ``ancestor`` (both absolute).
+
+    Fail-safe: if the two paths share no common root (``commonpath`` raises), they
+    are not nested, so this returns False.
+    """
+    try:
+        return os.path.commonpath([path, ancestor]) == ancestor
+    except ValueError:
+        return False
+
+
 def enforce_isolation() -> None:
     """Refuse to run if we are not genuinely isolated. Fail closed, non-zero.
 
     The one unacceptable failure is touching the operator's real cwcli state, so
-    this is checked before any Docker/instance work.
+    both HOME and CWCLI_HOME are validated before any Docker/instance work:
+
+    - ``HOME`` must not be the operator's real home (nor nested under it).
+    - ``CWCLI_HOME`` - where cwcli writes ALL of its on-disk state - must resolve
+      to a location INSIDE that isolated ``HOME``. Requiring containment (not just
+      "is set") closes the hole where a ``CWCLI_HOME`` pointing at/under the real
+      home would pass while cwcli wrote real state.
     """
     raw_home = os.environ.get("HOME", "")
     if not raw_home:
         raise RuntimeError("E2E isolation rail: HOME is unset/empty; refusing to run any E2E.")
     home = os.path.realpath(raw_home)
-    if home == _REAL_HOME:
+    if _at_or_under(home, _REAL_HOME):
         raise RuntimeError(
-            f"E2E isolation rail: HOME ({home!r}) resolves to the operator's real "
+            f"E2E isolation rail: HOME ({home!r}) is at or under the operator's real "
             f"home ({_REAL_HOME!r}); refusing to run any E2E."
         )
-    if not os.environ.get("CWCLI_HOME"):
+    raw_cwcli_home = os.environ.get("CWCLI_HOME", "")
+    if not raw_cwcli_home:
         raise RuntimeError("E2E isolation rail: CWCLI_HOME is not set; refusing to run any E2E.")
+    cwcli_home = os.path.realpath(raw_cwcli_home)
+    if not _at_or_under(cwcli_home, home):
+        raise RuntimeError(
+            f"E2E isolation rail: CWCLI_HOME ({cwcli_home!r}) is not inside the isolated "
+            f"session HOME ({home!r}); cwcli writes all of its state there, so a "
+            f"CWCLI_HOME outside the isolated root (e.g. at/under the operator's real "
+            f"home) could touch real instances. Refusing to run any E2E."
+        )
 
 
 def assert_prefixed(name: str) -> None:

--- a/tests/e2e/harness.py
+++ b/tests/e2e/harness.py
@@ -1,0 +1,332 @@
+"""Shared E2E harness: the reusable seam every command E2E builds on.
+
+This automates the manual ``docs/e2e/`` recipe (temp HOME, unique ``cwe2e-``
+names, genuine ``cwcli init`` benches, pexpect for TTY, flags for non-TTY,
+teardown) so the destructive-path guarantees are enforced by machine. It drives
+the real ``cwcli`` console script (subprocess / pexpect), NOT in-process Typer
+functions, so Typer parsing is exercised too.
+
+Isolation is layered: a per-session temp ``HOME`` (the belt) plus the
+``CWCLI_HOME`` override (the precise control that redirects only cwcli's own
+footprint - see ``utils/config_utils.cwcli_home``). Two independent safety
+layers guard the operator's real state:
+
+- a hard rail (``enforce_isolation``) that fails closed before any Docker work if
+  ``HOME`` still resolves to the real home or ``CWCLI_HOME`` is unset, and a name
+  rail that refuses any project name lacking the ``cwe2e-`` prefix;
+- an unconditional teardown backstop (``sweep_cwe2e``) that removes every
+  ``cwe2e-``-labelled compose project's containers, volumes, and networks even
+  when a test crashes before its ``cwcli rm`` teardown fires.
+
+Nothing here touches Docker or the rails at import/collection time; all of that
+lives in functions the fixtures/tests call, so collecting these modules under
+``-m unit`` (which deselects them) is safe.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+# CSI escape sequences (SGR colours, the ?2004h/l bracketed-paste toggles, etc.).
+# rich's default highlighter sprinkles these INSIDE phrases, so string assertions
+# on pexpect output must strip them first.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[ -/]*[@-~]")
+
+
+def strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+CWE2E_PREFIX = "cwe2e-"
+
+# The Frappe major for this leg (the CI matrix sets CWE2E_FRAPPE_MAJOR per job;
+# default 16 for a bare local run). The version-sensitive tests key off this.
+FRAPPE_MAJOR = int(os.environ.get("CWE2E_FRAPPE_MAJOR", "16"))
+FRAPPE_BRANCH = f"version-{FRAPPE_MAJOR}"
+
+# A short run id so parallel/repeat runs never collide on names. The CI job can
+# pin it (CWE2E_RUN_ID) so a whole matrix leg shares one prefix for the backstop.
+RUN_ID = os.environ.get("CWE2E_RUN_ID") or uuid.uuid4().hex[:6]
+
+DEFAULT_SITE = "development.localhost"
+DEFAULT_BENCH_NAME = "frappe-bench"
+# init's default --bench-parent is /workspace, so the bench lives here.
+DEFAULT_BENCH_PATH = f"/workspace/{DEFAULT_BENCH_NAME}"
+
+# A full `cwcli init` (image pull + bench init build + new-site) is the dominant
+# cost; keep the subprocess/pexpect ceiling under the CI job's timeout-minutes so
+# a hang surfaces as a captured timeout rather than an opaque job kill.
+INIT_TIMEOUT = 2100
+
+# prompt_toolkit's raw-mode readiness marker. Await it before EVERY pexpect
+# keystroke so nothing races the prompt (a documented cwcli hazard). Compiled as
+# a regex by pexpect: \x1b -> ESC, \[ and \? escape the literal bracket/qmark.
+RAW_MODE_MARKER = r"\x1b\[\?2004h"
+
+# The operator's real home, captured at import (before any fixture overrides
+# HOME) so the isolation rail can compare against it even after HOME is
+# repointed at the temp dir.
+_REAL_HOME = os.path.realpath(os.environ.get("HOME", "") or str(Path.home()))
+
+# Resolve the console script once. Under `uv run pytest` the venv bin dir is on
+# PATH, so `cwcli` resolves; fall back to the bare name otherwise.
+CWCLI = shutil.which("cwcli") or "cwcli"
+
+
+# --------------------------------------------------------------------------- #
+# Safety rails (fail-closed before any Docker work)
+# --------------------------------------------------------------------------- #
+def enforce_isolation() -> None:
+    """Refuse to run if we are not genuinely isolated. Fail closed, non-zero.
+
+    The one unacceptable failure is touching the operator's real cwcli state, so
+    this is checked before any Docker/instance work.
+    """
+    home = os.path.realpath(os.environ.get("HOME", ""))
+    if not home or home == _REAL_HOME:
+        raise RuntimeError(
+            f"E2E isolation rail: HOME ({home!r}) resolves to the operator's real "
+            f"home ({_REAL_HOME!r}); refusing to run any E2E."
+        )
+    if not os.environ.get("CWCLI_HOME"):
+        raise RuntimeError("E2E isolation rail: CWCLI_HOME is not set; refusing to run any E2E.")
+
+
+def assert_prefixed(name: str) -> None:
+    if not name.startswith(CWE2E_PREFIX):
+        raise RuntimeError(
+            f"E2E name rail: project name {name!r} lacks the required "
+            f"{CWE2E_PREFIX!r} prefix; refusing to create or operate on it."
+        )
+
+
+def project_name(suffix: str) -> str:
+    """A guaranteed-isolated project name: ``cwe2e-<runid>-<suffix>``."""
+    name = f"{CWE2E_PREFIX}{RUN_ID}-{suffix}"
+    assert_prefixed(name)
+    return name
+
+
+# --------------------------------------------------------------------------- #
+# Port allocator
+# --------------------------------------------------------------------------- #
+class PortAllocator:
+    """Hand out non-overlapping port bases (>= 1006 apart).
+
+    init maps web ``{port}..{port+5}`` and socketio ``{port+1000}..{port+1005}``;
+    a step of 1100 keeps every instance's web AND socketio ranges disjoint.
+    """
+
+    def __init__(self, base: int = 11000, step: int = 1100) -> None:
+        self._base = base
+        self._step = step
+        self._n = 0
+
+    def next(self) -> int:
+        port = self._base + self._n * self._step
+        self._n += 1
+        return port
+
+
+# --------------------------------------------------------------------------- #
+# Docker helpers (via the CLI, so the backstop works purely by compose label)
+# --------------------------------------------------------------------------- #
+def _docker(*args: str, timeout: int = 120) -> subprocess.CompletedProcess:
+    return subprocess.run(["docker", *args], capture_output=True, text=True, timeout=timeout)
+
+
+def docker_available() -> bool:
+    try:
+        return _docker("info", timeout=30).returncode == 0
+    except Exception:
+        return False
+
+
+def frappe_container_id(project: str) -> str | None:
+    r = _docker(
+        "ps",
+        "-q",
+        "--filter",
+        f"label=com.docker.compose.project={project}",
+        "--filter",
+        "label=com.docker.compose.service=frappe",
+    )
+    ids = r.stdout.split()
+    return ids[0] if ids else None
+
+
+def exec_in_frappe(project: str, script: str, workdir: str | None = None) -> tuple[int, str]:
+    """Run a shell script in the project's frappe container. Returns (code, output)."""
+    cid = frappe_container_id(project)
+    if not cid:
+        return (127, f"no running frappe container for {project}")
+    args = ["exec"]
+    if workdir:
+        args += ["-w", workdir]
+    args += [cid, "bash", "-lc", script]
+    r = _docker(*args, timeout=300)
+    return (r.returncode, (r.stdout or "") + (r.stderr or ""))
+
+
+def docker_cp_out(project: str, container_path: str, host_path: Path) -> bool:
+    """Copy a file out of the frappe container to the host. Returns success."""
+    cid = frappe_container_id(project)
+    if not cid:
+        return False
+    r = _docker("cp", f"{cid}:{container_path}", str(host_path), timeout=300)
+    return r.returncode == 0
+
+
+# --------------------------------------------------------------------------- #
+# Teardown backstop (unconditional; sweeps by cwe2e- label)
+# --------------------------------------------------------------------------- #
+def cwe2e_projects() -> list[str]:
+    """Every distinct ``cwe2e-`` compose project with a live container or volume."""
+    projs: set[str] = set()
+    for cid in _docker("ps", "-aq", "--filter", "label=com.docker.compose.project").stdout.split():
+        name = _docker(
+            "inspect", "-f", '{{index .Config.Labels "com.docker.compose.project"}}', cid
+        ).stdout.strip()
+        if name.startswith(CWE2E_PREFIX):
+            projs.add(name)
+    for vol in _docker(
+        "volume", "ls", "-q", "--filter", "label=com.docker.compose.project"
+    ).stdout.split():
+        name = _docker(
+            "volume", "inspect", "-f", '{{index .Labels "com.docker.compose.project"}}', vol
+        ).stdout.strip()
+        if name.startswith(CWE2E_PREFIX):
+            projs.add(name)
+    return sorted(projs)
+
+
+def sweep_cwe2e(only: str | None = None) -> list[str]:
+    """Force-remove ``cwe2e-`` projects' containers, volumes, and networks.
+
+    The unconditional session backstop calls this with no argument to sweep EVERY
+    ``cwe2e-`` project (so a crashed test never leaks). ``only`` restricts the
+    sweep to one project - identical per-project removal logic, used by the
+    leaked-resource test so it can prove the backstop without touching the live
+    session instance. Safe to call when nothing matches (returns an empty list).
+    """
+    projects = cwe2e_projects()
+    if only is not None:
+        projects = [p for p in projects if p == only]
+    swept = []
+    for proj in projects:
+        filt = f"label=com.docker.compose.project={proj}"
+        ids = _docker("ps", "-aq", "--filter", filt).stdout.split()
+        if ids:
+            _docker("rm", "-f", *ids, timeout=300)
+        vols = _docker("volume", "ls", "-q", "--filter", filt).stdout.split()
+        if vols:
+            _docker("volume", "rm", "-f", *vols, timeout=300)
+        for net in _docker("network", "ls", "-q", "--filter", filt).stdout.split():
+            _docker("network", "rm", net)
+        swept.append(proj)
+    return swept
+
+
+# NOTE: no broad `docker system prune` lives here on purpose. This harness also
+# runs on the operator's own machine, where a system-wide prune would remove
+# THEIR stopped containers / dangling images. sweep_cwe2e is deliberately scoped
+# to cwe2e- resources only. Reclaiming the 14 GB SSD ceiling is a CI concern and
+# is done (broadly, safely) on the ephemeral runner in e2e.yml, not here.
+
+
+# --------------------------------------------------------------------------- #
+# Readiness (poll a real signal - never a fixed sleep)
+# --------------------------------------------------------------------------- #
+def wait_until(predicate, *, timeout: int = 180, interval: float = 3, desc: str = "condition"):
+    deadline = time.time() + timeout
+    last: object = None
+    while time.time() < deadline:
+        try:
+            last = predicate()
+            if last:
+                return last
+        except Exception as exc:  # noqa: BLE001 - poll-and-retry
+            last = exc
+        time.sleep(interval)
+    raise TimeoutError(f"Timed out after {timeout}s waiting for {desc} (last result: {last!r})")
+
+
+def wait_for_site_ready(
+    project: str, site: str, bench: str = DEFAULT_BENCH_PATH, *, timeout: int = 300
+) -> None:
+    """Poll until Frappe boots and reaches its DB for ``site`` (real readiness)."""
+
+    def ready() -> bool:
+        code, _ = exec_in_frappe(
+            project, f"cd {shlex.quote(bench)} && bench --site {shlex.quote(site)} list-apps"
+        )
+        return code == 0
+
+    wait_until(ready, timeout=timeout, interval=5, desc=f"site {site!r} ready")
+
+
+# --------------------------------------------------------------------------- #
+# Driving the real cwcli binary
+# --------------------------------------------------------------------------- #
+def run_cwcli(*args: str, timeout: int = 1800, input_text: str | None = None):
+    """Run ``cwcli <args>`` non-interactively (stdin closed, a real non-TTY).
+
+    With ``input_text`` given, feeds it on a pipe instead (still non-TTY). Returns
+    the CompletedProcess (never raises on non-zero - callers assert on returncode).
+    """
+    if input_text is None:
+        return subprocess.run(
+            [CWCLI, *args],
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=os.environ.copy(),
+        )
+    return subprocess.run(
+        [CWCLI, *args],
+        input=input_text,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=os.environ.copy(),
+    )
+
+
+def spawn_cwcli(args, timeout: int = 1800):
+    """Spawn ``cwcli <args>`` on a real pty (interactive mode) via pexpect."""
+    import pexpect
+
+    return pexpect.spawn(
+        CWCLI,
+        list(args),
+        env=os.environ.copy(),
+        encoding="utf-8",
+        timeout=timeout,
+        dimensions=(50, 140),
+    )
+
+
+def expect_prompt_ready(child, timeout: int = 180) -> None:
+    """Await prompt_toolkit's raw-mode marker before sending a keystroke."""
+    child.expect(RAW_MODE_MARKER, timeout=timeout)
+
+
+# --------------------------------------------------------------------------- #
+# init / teardown convenience
+# --------------------------------------------------------------------------- #
+def cwcli_rm(project: str, timeout: int = 600):
+    """Tear an instance down: containers + named volumes + project dir.
+
+    Uses ``--no-backup`` because a throwaway teardown does not need a live backup
+    (the C1 backup gate itself is covered by the deferred rm E2E).
+    """
+    assert_prefixed(project)
+    return run_cwcli("rm", project, "--yes", "--volumes", "--no-backup", timeout=timeout)

--- a/tests/e2e/test_backup_e2e.py
+++ b/tests/e2e/test_backup_e2e.py
@@ -1,0 +1,61 @@
+"""§4.2 backup E2E - the first destructive-command real-side-effect proof.
+
+Asserts a real, non-empty DB dump actually lands on the host (copied out of the
+container), not a string match, in BOTH non-interactive (flags, stdin closed)
+and interactive (pty) modes. This proves the whole pattern end to end: the
+session fixture stands the instance up, backup produces a genuine artifact, and
+`cwcli rm` tears it down.
+"""
+
+from __future__ import annotations
+
+import shlex
+
+import pytest
+
+from . import harness
+
+pytestmark = pytest.mark.e2e
+
+
+def _newest_dump_path(inst) -> str | None:
+    """Full container path of the newest DB dump (*.sql.gz) for the site, or None."""
+    backups = f"{inst.bench}/sites/{inst.site}/private/backups"
+    code, out = harness.exec_in_frappe(
+        inst.name, f"ls -1t {shlex.quote(backups)}/*.sql.gz 2>/dev/null | head -1"
+    )
+    path = out.strip()
+    return path if code == 0 and path else None
+
+
+def _assert_real_dump_on_host(inst, tmp_path, fname):
+    """The core real-side-effect assertion: the newest dump copies out of the
+    container and is non-empty on the host filesystem."""
+    dump = _newest_dump_path(inst)
+    assert dump, "no *.sql.gz dump found in the container's backups dir"
+    host_file = tmp_path / fname
+    assert harness.docker_cp_out(inst.name, dump, host_file), f"docker cp failed for {dump}"
+    assert host_file.stat().st_size > 0, "DB dump copied to the host is empty"
+
+
+def test_backup_noninteractive_creates_real_dump(running_instance, tmp_path):
+    inst = running_instance
+    result = harness.run_cwcli("backup", inst.name, "--site", inst.site, "-y")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Successfully created backup" in result.stdout
+    _assert_real_dump_on_host(inst, tmp_path, "noninteractive.sql.gz")
+
+
+def test_backup_interactive_creates_real_dump(running_instance, tmp_path):
+    import pexpect
+
+    inst = running_instance
+    child = harness.spawn_cwcli(["backup", inst.name, "--site", inst.site], timeout=900)
+    try:
+        # The instance is running, so backup runs straight through with no prompt;
+        # this exercises the real TTY path and asserts the genuine artifact.
+        child.expect("Successfully created backup", timeout=900)
+        child.expect(pexpect.EOF, timeout=120)
+    finally:
+        child.close(force=True)
+    _assert_real_dump_on_host(inst, tmp_path, "interactive.sql.gz")

--- a/tests/e2e/test_harness_safety.py
+++ b/tests/e2e/test_harness_safety.py
@@ -1,0 +1,77 @@
+"""§8.3 - prove the isolation rails and the leaked-resource backstop.
+
+These guard the one unacceptable failure: touching the operator's real cwcli
+state. The name-rail and port-allocator checks are pure logic; the HOME-rail and
+backstop checks exercise the real mechanism (the latter against real Docker).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from . import harness
+
+pytestmark = pytest.mark.e2e
+
+
+def test_name_rail_refuses_unprefixed():
+    with pytest.raises(RuntimeError):
+        harness.assert_prefixed("myrealproject")
+    assert harness.project_name("x").startswith(harness.CWE2E_PREFIX)
+
+
+def test_home_rail_refuses_real_home(isolated_home):
+    """Point HOME back at the operator's real home and confirm the rail refuses."""
+    saved = os.environ["HOME"]
+    os.environ["HOME"] = harness._REAL_HOME
+    try:
+        with pytest.raises(RuntimeError):
+            harness.enforce_isolation()
+    finally:
+        os.environ["HOME"] = saved
+    # sanity: with the isolated HOME restored, the rail passes again
+    harness.enforce_isolation()
+
+
+def test_port_allocator_spacing():
+    alloc = harness.PortAllocator()
+    p0, p1, p2 = alloc.next(), alloc.next(), alloc.next()
+    # bases at least 1006 apart
+    assert p1 - p0 >= 1006
+    assert p2 - p1 >= 1006
+    # each instance's web {p..p+5} and socketio {p+1000..p+1005} are disjoint,
+    # and the next instance's web range clears this instance's socketio range.
+    assert p0 + 5 < p0 + 1000
+    assert p1 > p0 + 1005
+
+
+def _create_fake_leaked_project(name: str) -> None:
+    label = f"com.docker.compose.project={name}"
+    subprocess.run(
+        ["docker", "volume", "create", "--label", label, f"{name}-vol"],
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["docker", "run", "-d", "--label", label, "--name", f"{name}-c", "busybox", "sleep", "600"],
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_backstop_sweeps_leaked_container(_docker_gate):
+    """A deliberately leaked cwe2e- compose project (container + volume) is
+    discovered and swept by the backstop's mechanism. Scoped with `only=` so it
+    proves the sweep without touching the live session instance."""
+    leaked = harness.project_name("leaktest")
+    _create_fake_leaked_project(leaked)
+    try:
+        assert leaked in harness.cwe2e_projects(), "backstop discovery missed the leak"
+        swept = harness.sweep_cwe2e(only=leaked)
+        assert leaked in swept
+        assert leaked not in harness.cwe2e_projects(), "leak survived the sweep"
+    finally:
+        harness.sweep_cwe2e(only=leaked)

--- a/tests/e2e/test_harness_safety.py
+++ b/tests/e2e/test_harness_safety.py
@@ -36,6 +36,20 @@ def test_home_rail_refuses_real_home(isolated_home):
     harness.enforce_isolation()
 
 
+def test_home_rail_refuses_unset_home(isolated_home):
+    """Delete HOME entirely and confirm the rail refuses rather than silently
+    passing (realpath("") resolves to the CWD, not "", so the check must read
+    the raw env value before calling realpath)."""
+    saved = os.environ.pop("HOME")
+    try:
+        with pytest.raises(RuntimeError):
+            harness.enforce_isolation()
+    finally:
+        os.environ["HOME"] = saved
+    # sanity: with HOME restored, the rail passes again
+    harness.enforce_isolation()
+
+
 def test_port_allocator_spacing():
     alloc = harness.PortAllocator()
     p0, p1, p2 = alloc.next(), alloc.next(), alloc.next()

--- a/tests/e2e/test_harness_safety.py
+++ b/tests/e2e/test_harness_safety.py
@@ -50,6 +50,30 @@ def test_home_rail_refuses_unset_home(isolated_home):
     harness.enforce_isolation()
 
 
+def test_cwcli_home_rail_refuses_outside_isolated_root(isolated_home):
+    """A CWCLI_HOME pointing at/under the operator's real home must be refused even
+    when HOME itself is isolated - otherwise cwcli would write real state through a
+    rail that only checked HOME. CWCLI_HOME must resolve INSIDE the isolated HOME."""
+    saved = os.environ["CWCLI_HOME"]
+    try:
+        # CWCLI_HOME == the real home (HOME stays isolated) -> refused
+        os.environ["CWCLI_HOME"] = harness._REAL_HOME
+        with pytest.raises(RuntimeError):
+            harness.enforce_isolation()
+        # a subdirectory of the real home is refused too
+        os.environ["CWCLI_HOME"] = os.path.join(harness._REAL_HOME, ".cwcli")
+        with pytest.raises(RuntimeError):
+            harness.enforce_isolation()
+        # any absolute path outside the isolated HOME is refused
+        os.environ["CWCLI_HOME"] = "/tmp/cwe2e-not-under-isolated-home"
+        with pytest.raises(RuntimeError):
+            harness.enforce_isolation()
+    finally:
+        os.environ["CWCLI_HOME"] = saved
+    # sanity: with the isolated CWCLI_HOME (inside HOME) restored, the rail passes
+    harness.enforce_isolation()
+
+
 def test_port_allocator_spacing():
     alloc = harness.PortAllocator()
     p0, p1, p2 = alloc.next(), alloc.next(), alloc.next()

--- a/tests/e2e/test_init_e2e.py
+++ b/tests/e2e/test_init_e2e.py
@@ -1,0 +1,133 @@
+"""§4.1 init E2E + §5.1/§5.2 version-sensitive init behaviors.
+
+The session fixture already stands up a genuine bench + site non-interactively;
+these tests add explicit assertions for both modes, the generated-admin-password
+print-once behavior, and the per-version-leg divergences (MariaDB flag,
+pyenv/nvm branches). The version-sensitive tests run on every matrix leg; the
+version-agnostic interactive test runs only on the v16 leg.
+"""
+
+from __future__ import annotations
+
+import io
+import shlex
+
+import pytest
+
+from . import harness
+
+pytestmark = pytest.mark.e2e
+
+# Version-agnostic tests run once (on the v16 leg), not three times.
+v16_only = pytest.mark.skipif(
+    harness.FRAPPE_MAJOR != 16,
+    reason="version-agnostic test runs only on the v16 leg",
+)
+
+
+def _in_frappe_ok(project: str, script: str) -> tuple[bool, str]:
+    code, out = harness.exec_in_frappe(project, script)
+    return code == 0, out
+
+
+# --- §4.1 non-interactive ------------------------------------------------- #
+def test_noninteractive_init_built_real_bench_and_site(session_instance):
+    """The non-interactive `cwcli init` really created a bench and ran new-site."""
+    inst = session_instance
+    assert "Successfully initialized" in inst.init_stdout, inst.init_stdout
+
+    ok, out = _in_frappe_ok(inst.name, f"test -d {shlex.quote(inst.bench)}")
+    assert ok, f"bench dir missing: {out}"
+
+    # A real site_config.json is only written by a genuine `bench new-site`.
+    site_config = f"{inst.bench}/sites/{inst.site}/site_config.json"
+    ok, out = _in_frappe_ok(inst.name, f"test -f {shlex.quote(site_config)}")
+    assert ok, f"site_config.json missing (new-site did not run): {out}"
+
+
+def test_noninteractive_init_did_not_print_generated_password(session_instance):
+    """With --admin-password supplied, init must NOT print a generated password
+    (it would be a lie - the supplied value was used verbatim)."""
+    combined = session_instance.init_stdout + session_instance.init_stderr
+    assert "Administrator password (generated):" not in combined
+
+
+# --- §4.1 interactive + generated-password print-once (v16 leg only) ------- #
+@v16_only
+def test_interactive_init_generates_and_prints_admin_password_once(port_allocator):
+    """Drive init interactively via a real pty: omit the project name so the
+    prompt_toolkit prompt fires (await ESC[?2004h, then type the name), and omit
+    --admin-password so a strong password is GENERATED and printed exactly once.
+    """
+    import pexpect
+
+    name = harness.project_name("initgen")
+    port = port_allocator.next()
+    log = io.StringIO()
+    child = harness.spawn_cwcli(
+        ["init", "--port", str(port), "--frappe-branch", harness.FRAPPE_BRANCH],
+        timeout=harness.INIT_TIMEOUT,
+    )
+    child.logfile_read = log
+    try:
+        harness.expect_prompt_ready(child)  # ESC[?2004h before the keystroke
+        child.sendline(name)
+        # Let the full init run, then assert on the captured output: rich's
+        # highlighter injects ANSI codes inside the phrase, so strip them before
+        # matching rather than racing a fragile mid-stream regex.
+        child.expect(pexpect.EOF, timeout=harness.INIT_TIMEOUT)
+    finally:
+        child.close(force=True)
+        harness.cwcli_rm(name)
+
+    output = harness.strip_ansi(log.getvalue())
+    assert "Successfully initialized" in output, output[-2000:]
+    assert (
+        output.count("Administrator password (generated):") == 1
+    ), "generated admin password must be printed exactly once"
+
+
+# --- §5.1 MariaDB flag divergence (runs on every leg) --------------------- #
+def test_mariadb_flag_created_site_on_this_leg(session_instance):
+    """The MariaDB flag diverges by version (<=14 --no-mariadb-socket vs 15+
+    --mariadb-user-host-login-scope=%); passing the wrong one makes `bench
+    new-site` fail. A created site on THIS leg is therefore the proof the
+    version-correct flag ran.
+
+    ponytail: created-site is the flag-divergence proof; a direct mysql.user
+    host-scope query is the upgrade path if a finer signal is ever needed.
+    """
+    inst = session_instance
+    site_config = f"{inst.bench}/sites/{inst.site}/site_config.json"
+    ok, out = _in_frappe_ok(inst.name, f"test -f {shlex.quote(site_config)}")
+    assert ok, f"site not created on frappe v{harness.FRAPPE_MAJOR}: {out}"
+
+
+# --- §5.2 pyenv/nvm version branches (runs on every leg) ------------------ #
+def test_venv_python_matches_frappe_version(session_instance):
+    """The bench venv Python reflects the version-gated pyenv branch: v14->3.10,
+    v15->3.12, v16->the image default (no pyenv override)."""
+    inst = session_instance
+    code, out = harness.exec_in_frappe(
+        inst.name, f"{shlex.quote(inst.bench)}/env/bin/python --version"
+    )
+    assert code == 0, out
+    ver = out.strip()
+    if harness.FRAPPE_MAJOR == 14:
+        assert "3.10" in ver, ver
+    elif harness.FRAPPE_MAJOR == 15:
+        assert "3.12" in ver, ver
+    else:  # v16: image default, no pyenv override - just a valid 3.x
+        assert "Python 3." in ver, ver
+
+
+def test_v14_provisions_node16_and_yarn(session_instance):
+    """v14's bench init runs under nvm node16 with a global yarn (the branch v16
+    skips entirely)."""
+    if harness.FRAPPE_MAJOR != 14:
+        pytest.skip("v14-only pyenv/nvm branch")
+    inst = session_instance
+    code, out = harness.exec_in_frappe(inst.name, "ls -d ~/.nvm/versions/node/v16* 2>/dev/null")
+    assert code == 0 and "v16" in out, f"node16 not provisioned via nvm: {out}"
+    code, out = harness.exec_in_frappe(inst.name, "ls ~/.nvm/versions/node/v16*/bin/yarn")
+    assert code == 0, f"yarn not installed for node16: {out}"

--- a/uv.lock
+++ b/uv.lock
@@ -59,6 +59,9 @@ dev = [
     { name = "types-requests" },
     { name = "types-toml" },
 ]
+e2e = [
+    { name = "pexpect" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -66,6 +69,7 @@ requires-dist = [
     { name = "docker", specifier = ">=7.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "peewee", specifier = ">=3.17.0" },
+    { name = "pexpect", marker = "extra == 'e2e'", specifier = ">=4.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "questionary", specifier = ">=2.1.0" },
@@ -76,7 +80,7 @@ requires-dist = [
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.33.0.20260518" },
     { name = "types-toml", marker = "extra == 'dev'", specifier = ">=0.10.8.20260518" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "e2e"]
 
 [[package]]
 name = "certifi"
@@ -417,6 +421,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/04/89/76f6f1b744c8608e0d416b588b9d63c2a500ff800065ae610f7c80f532d6/peewee-3.18.2.tar.gz", hash = "sha256:77a54263eb61aff2ea72f63d2eeb91b140c25c1884148e28e4c0f7c4f64996a0", size = 949220, upload-time = "2025-07-08T12:52:03.941Z" }
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -444,6 +460,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Intent

Follow-up safety hardening on the E2E harness PR (#60), requested by the captain: close a hole in the never-touch-real-instances guarantee. enforce_isolation() previously checked only that CWCLI_HOME was SET, not where it pointed, so a CWCLI_HOME at/under the operator's real home would pass the rail while cwcli wrote real state. Fix: realpath CWCLI_HOME and fail closed unless it is contained inside the isolated session HOME (new _at_or_under helper); the HOME check is likewise strengthened from '== real home' to 'at or under real home'. Added a test_harness_safety.py case covering CWCLI_HOME at the real home, a subdir of it, and any path outside the isolated HOME, and updated the rail text in the e2e-test-suite spec (requirement + new scenario), design.md, the harness module docstring, and tests/README.md to match. This is a test-harness-only change (no cwcli source/behavior change); the legit isolated env still passes the rail (harness-safety tests + a full local v16 e2e leg both green). Everything else in this PR is unchanged and already validated: the two-tier unit/e2e suite, the init+backup real-side-effect E2E, the v14/v15/v16 CI matrix (all three legs went green last run with the umask fix that lets bench init write the bind-mounted workspace regardless of host UID), and the deferred follow-up scope (rm/restore/update/unlock/inspect/apps, P2P, mock-suite retirement) which is intentional.

## What Changed

- Adds `tests/e2e/` (`harness.py`, `conftest.py`) and a two-tier pytest suite covering `init` and `backup`, driving the real `cwcli` binary against genuine throwaway Frappe instances via a `CWCLI_HOME`/temp-`HOME` isolation seam, port allocator, and `pexpect`-driven pty prompts; adds `.github/workflows/e2e.yml` to run it as a v14/v15/v16 CI matrix and registers the `unit`/`e2e`/`e2e_p2p` pytest markers (`pyproject.toml`, auto-applied by `tests/conftest.py`) so a bare `pytest` stays Docker-free.
- Hardens `enforce_isolation()` to realpath `CWCLI_HOME` and require it to resolve strictly at-or-under the isolated session `HOME` (new `_at_or_under` helper) instead of only checking that it is set, closing a gap where a `CWCLI_HOME` at or under the operator's real home would have passed the rail while cwcli wrote real state; the `HOME` check is strengthened the same way, and `isolated_home`'s teardown now drops its temp `HOME` directory.
- Relaxes the harness umask so `bench init` can write the bind-mounted workspace, and syncs `tests/README.md`, `docs/testing/`, `docs/contributing/ci-cd.md`, `AGENTS.md`, `CONTRIBUTING.md`, and the `openspec/changes/rebuild-e2e-test-suite/` spec/design/tasks artifacts with the new two-tier suite and the isolation-rail fix.

## Risk Assessment

✅ Low: The new hardening commit is a small, well-contained test-harness-only change: the `_at_or_under` containment check is correct (proper argument order in both call sites, uses os.path.commonpath for component-wise containment rather than a naive string prefix), it avoids the same empty-string dead-branch pitfall already fixed for HOME, and the accompanying tests/spec/docs were updated consistently; the rest of the branch (harness, CI workflow, conftest fixtures, backup/init E2E tests) is internally consistent and has no observable defects.

## Testing

Ran the new e2e harness-safety test suite against Docker (available in this environment) confirming all 6 cases pass including the new CWCLI_HOME-containment case, then proved that case is non-vacuous by temporarily reverting harness.py to the pre-fix parent commit and showing the same test fails exactly as expected (CWCLI_HOME at the real home slips through), before restoring the fix and re-confirming green; the full 416-test unit tier also stayed green, matching the PR's claim of a test-harness-only change with no cwcli source/behavior impact.

<details>
<summary>Evidence: Regression proof: new test fails against pre-fix harness.py, passes against fixed harness.py</summary>

```text
Verification: does the new test_cwcli_home_rail_refuses_outside_isolated_root
actually catch the hole the fix closes (CWCLI_HOME at/under the real home
passing the isolation rail)?

Step 1: run the new test against the FIXED harness.py (commit 6b57ae5):

$ uv run pytest tests/e2e/test_harness_safety.py -m e2e -v
tests/e2e/test_harness_safety.py::test_name_rail_refuses_unprefixed PASSED [ 16%]
tests/e2e/test_harness_safety.py::test_home_rail_refuses_real_home PASSED [ 33%]
tests/e2e/test_harness_safety.py::test_home_rail_refuses_unset_home PASSED [ 50%]
tests/e2e/test_harness_safety.py::test_cwcli_home_rail_refuses_outside_isolated_root PASSED [ 66%]
tests/e2e/test_harness_safety.py::test_port_allocator_spacing PASSED     [ 83%]
tests/e2e/test_harness_safety.py::test_backstop_sweeps_leaked_container PASSED [100%]
============================== 6 passed in 3.32s ===============================

Step 2: temporarily swap in the PRE-FIX harness.py (parent commit 6e03042,
whose enforce_isolation only checked `if not os.environ.get("CWCLI_HOME")`,
never validating where it pointed) and re-run just the new test:

$ git show 6e03042:tests/e2e/harness.py > tests/e2e/harness.py
$ uv run pytest tests/e2e/test_harness_safety.py -m e2e -v -k test_cwcli_home_rail_refuses_outside_isolated_root
tests/e2e/test_harness_safety.py::test_cwcli_home_rail_refuses_outside_isolated_root FAILED [100%]
E   Failed: DID NOT RAISE <class 'RuntimeError'>
======================= 1 failed, 5 deselected in 0.99s ========================

This confirms: with the pre-fix rail, setting CWCLI_HOME to the operator's real
home (or a subdirectory of it) does NOT raise - the exact hole described in the
commit message/spec. The fix (realpath + _at_or_under containment check) closes
it, and the new test fails without the fix and passes with it.

Step 3: restore the fixed harness.py (git checkout -- tests/e2e/harness.py),
confirmed identical to the pre-test state via diff, and re-ran the full test
file green again (6 passed).

Step 4: full fast/unit tier sanity check (this PR is test-harness-only, no
cwcli source changes):

$ uv run pytest
===================== 416 passed, 14 deselected in 10.25s ======================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv sync --frozen --all-extras`
- `uv run pytest tests/e2e/test_harness_safety.py -m e2e -v (6 passed, incl. new test_cwcli_home_rail_refuses_outside_isolated_root)`
- `Manual regression proof: swapped in parent commit 6e03042's tests/e2e/harness.py, re-ran the new test with -k, confirmed it FAILS (DID NOT RAISE RuntimeError) against the pre-fix rail, then git checkout restored the fixed file`
- `uv run pytest (full fast/unit tier: 416 passed, 14 deselected)`
- `git status --short (worktree clean after verification)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added real-Docker end-to-end testing across Frappe versions 14, 15, and 16.
  * Added coverage for initialization, backups, interactive flows, version-specific behavior, and test-environment safety.
  * Added isolated test environments with automatic cleanup to prevent leaked resources.

* **Bug Fixes**
  * Default test runs now execute the faster unit suite without requiring Docker.

* **Documentation**
  * Updated testing, CI, contribution, and release documentation with the new unit and E2E workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->