### PR TITLE
docs(ci): correct the false reason for E2E coverage being off

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -98,8 +98,16 @@ jobs:
       - name: Run E2E (frappe v${{ matrix.frappe }})
         # Version-sensitive tests run on every leg; version-agnostic tests skip
         # themselves off the non-v16 legs (see tests/e2e). Empty addopts drops
-        # the default `-m "not e2e"` and the coverage machinery - the E2E tier
-        # drives the real binary out of process, so per-line coverage is moot.
+        # the default `-m "not e2e"` and the coverage machinery.
+        #
+        # Cross-tier coverage IS obtainable, and "out of process" is no barrier:
+        # the harness drives the real `cwcli` console script, which is a Python
+        # process, so coverage.py attaches via COVERAGE_PROCESS_START with no
+        # harness change (both run_cwcli and spawn_cwcli already pass the env
+        # through). It is deliberately NOT wired, on cost: the 3-leg matrix runs
+        # on separate runners, so combining needs a cross-runner artifact dance,
+        # and a red or flaky E2E leg would then move the coverage number for
+        # reasons unrelated to any code change - a worse signal, for ~6-12 points.
         run: uv run pytest tests/e2e -m e2e -o addopts="" -v --tb=short
 
       - name: Teardown backstop - sweep leaked cwe2e- resources


### PR DESCRIPTION
## Intent

Fix a comment in .github/workflows/e2e.yml that gives a false reason.

The E2E job disables coverage with -o addopts="", and the comment explained why: 'the E2E tier drives the real binary out of process, so per-line coverage is moot.' That reason is false. 'Out of process' is precisely the case coverage.py's subprocess support exists to handle, and cwcli is a Python console script, so the E2E harness's subprocess.run/pexpect.spawn calls run cwcli's own code in a Python process that coverage.py can attach to via COVERAGE_PROCESS_START. This was proven end-to-end by measurement, not inference: with a coverage .pth in place, three real out-of-process cwcli invocations moved the combined total from 66.37% (unit tier alone) to 66.52%. The harness needs no changes - both run_cwcli and spawn_cwcli already pass env=os.environ.copy(), so the env var propagates on both paths. The only thing genuinely out of reach is what runs inside the Frappe containers, which is not cwcli's code and was never in the denominator.

The comment was therefore true-as-written (coverage is indeed off) and wrong-as-reasoned (the stated impossibility is not real). That cost real time: an investigation into whether the 66% coverage number was honest had to first disprove this comment's premise before it could answer the actual question. In a codebase whose comments carry a root-cause 'why' and are trusted for it, a wrong 'why' is a real defect - it terminates the next reader's enquiry with a wrong answer.

The fix replaces the false reason with the true one, carrying both halves: cross-tier coverage IS obtainable via COVERAGE_PROCESS_START, and it is deliberately NOT wired on cost. The three-leg (v14/v15/v16) matrix runs on separate runners, so combining coverage across legs would need a cross-runner artifact upload/download dance, and a red or flaky E2E leg would then move the coverage number for reasons unrelated to any code change - making the number a worse signal, for an estimated ~6-12 points.

Deliberate decisions a reviewer should not flag:

1. Cross-tier coverage is deliberately NOT implemented here. It was weighed and declined on the cost/signal tradeoff above. This change exists so the decision is recorded accurately, not to reverse it. Do not suggest wiring it up.
2. The comment is intentionally long (12 lines). This repo's house style is that a guard carries its root-cause 'why'; the comment is the entire deliverable here, and it must rebut the specific false premise ('out of process' is no barrier, because the console script is a Python process) rather than merely state the conclusion - otherwise the next reader re-derives the same wrong answer. Do not compress it back into a single line.
3. Scope is deliberately one file, comment-only. No change to what the E2E job runs, its markers, -o addopts="", the harness, or any coverage config in pyproject.toml. The run: line is byte-identical (verified by parsing the YAML and asserting the resolved run command). No coverage improvement anywhere was in scope.

Verification: the YAML parses and the resolved run step is unchanged; git diff is comment-only in one file. No tests were run because the diff has no runtime surface, and lint is scoped to src/.

## What Changed

- Rewrote the comment above `-o addopts=""` in `.github/workflows/e2e.yml` that justified disabling coverage on the E2E job: the old text claimed "out of process" execution makes per-line coverage moot, which is false since `subprocess.run`/`pexpect.spawn` still run cwcli's own Python code and coverage.py's `COVERAGE_PROCESS_START` subprocess support can attach to it.
- Replaced it with the true reasoning: cross-tier coverage is technically obtainable, but is deliberately not wired up because the v14/v15/v16 matrix runs on separate runners, and combining coverage across them would require a cross-runner artifact upload/download step while letting a red or flaky E2E leg move the coverage number for reasons unrelated to any code change.
- No behavior change: the resolved `run:` command for the E2E step, the `-o addopts=""` flag, and all markers are unchanged; only comment text was edited.

## Risk Assessment

✅ Low: Comment-only change in one CI workflow file; the run command is verified byte-identical and the YAML parses correctly, so there is no runtime behavior change.

## Testing

This is a comment-only CI-YAML change with no runtime surface, so per the author's own stated verification approach (YAML-parse + resolved-run-line equivalence) rather than a test run; I reproduced that verification independently on both commits and it holds - the E2E job's resolved run command is byte-identical, the YAML parses cleanly, and the diff touches nothing outside the comment block in the single target file.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --stat 30cf57c ff8d4ae` - confirms only .github/workflows/e2e.yml changed (10 insertions, 2 deletions)</code>
- <code>`git diff 30cf57c ff8d4ae -- .github/workflows/e2e.yml` - confirms every changed line is inside the comment block; no `run:`, marker, `-o addopts`, or non-comment line touched</code>
- <code>Parsed .github/workflows/e2e.yml with PyYAML on both base and target commits and compared the resolved `steps[].run` string for the &#39;Run E2E&#39; step - identical: `uv run pytest tests/e2e -m e2e -o addopts=&#34;&#34; -v --tb=short`</code>
- <code>`git status --porcelain` and a diff excluding e2e.yml - confirms clean worktree and no other file touched</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
