### PR TITLE
fix(ci): stop using runner context in job-level env in clean-install

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,17 +84,23 @@ jobs:
   clean-install:
     name: Clean install smoke
     runs-on: ubuntu-latest
-    # Isolated tool dir/bin so this install resolves purely from
-    # [project.dependencies] and never leaks onto the runner's PATH.
-    env:
-      UV_TOOL_DIR: ${{ runner.temp }}/tooldir
-      UV_TOOL_BIN_DIR: ${{ runner.temp }}/toolbin
 
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: false
+
+      # Isolated tool dir/bin so this install resolves purely from
+      # [project.dependencies] and never leaks onto the runner's PATH. Set from
+      # $RUNNER_TEMP here rather than in a job-level `env:` block: the `runner`
+      # context is only available inside steps, so `${{ runner.temp }}` at
+      # job level is an "Unrecognized named-value" error that fails the ENTIRE
+      # workflow (every sibling job included) before anything runs.
+      - name: Set up isolated tool dirs
+        run: |
+          echo "UV_TOOL_DIR=$RUNNER_TEMP/tooldir" >> "$GITHUB_ENV"
+          echo "UV_TOOL_BIN_DIR=$RUNNER_TEMP/toolbin" >> "$GITHUB_ENV"
 
       - name: Install uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2


### PR DESCRIPTION
## Intent

P0 hotfix: cwcli's .github/workflows/test.yml was broken on develop - the whole Test workflow failed to load, so none of its jobs (Pytest, Mypy, Pytest-Windows, clean-install) ran and every PR's checks were missing/stuck, blocking merges. Root cause: the clean-install job (added by PR #99) set JOB-LEVEL env: UV_TOOL_DIR/UV_TOOL_BIN_DIR using ${{ runner.temp }}. The runner context is only available inside steps, not at job-level env:, so GitHub rejected the entire workflow at expression-eval time ('Unrecognized named-value: runner') before any job started - which is why sibling jobs never produced check-runs. The fix moves those two vars out of the job-level env: block and sets them from the runtime $RUNNER_TEMP into $GITHUB_ENV via a new early step, keeping the smoke job's isolated tool dir/bin intent intact. The step-level CWCLI_HOME: ${{ runner.temp }}/cwhome was deliberately left unchanged because the runner context IS valid inside step-level env:. I audited all workflows (test/lint/e2e/release/build) for other job-level runner or step-only context misuse and found none (e2e.yml's job-level env uses secrets, and its if: uses github/step-level env, all allowed). Validated locally with real actionlint via Docker: the original broken form errors 'context runner is not allowed here' and the fixed workflow passes clean. This is a CI-config-only change (single file, .github/workflows/test.yml); the real proof is CI itself executing its jobs green on this PR head.

## What Changed

- Removed the job-level `env:` block on the `clean-install` job in `.github/workflows/test.yml` that set `UV_TOOL_DIR`/`UV_TOOL_BIN_DIR` via `${{ runner.temp }}`, since the `runner` context is only valid inside steps, not at job level, and its presence there caused GitHub to reject the entire workflow at expression-eval time.
- Added a new early step, "Set up isolated tool dirs", that derives the same two isolated-install paths from the runtime `$RUNNER_TEMP` env var and writes them to `$GITHUB_ENV`, preserving the clean-install job's isolated tool dir/bin behavior.
- Left the step-level `CWCLI_HOME: ${{ runner.temp }}/cwhome` env untouched, since `runner` context is valid at step level.

## Risk Assessment

✅ Low: Single-file CI-config change that correctly relocates runner.temp usage from an invalid job-level env: block to a step that exports it via $RUNNER_TEMP/$GITHUB_ENV, with placement, ordering, and the untouched step-level CWCLI_HOME all verified correct.

## Testing

Since this is a CI-config-only single-file YAML change with no unit-test surface, I validated it the way the author described: ran the real actionlint tool (via the official rhysd/actionlint Docker image, already cached locally) against both the pre-fix and post-fix test.yml. The base version fails exactly as claimed ("context 'runner' is not allowed here" at the two job-level env lines, exit 1), and the fixed version at target commit bb77860 passes with zero findings (exit 0), both alone and as part of the full workflows directory (the only other findings are pre-existing shellcheck notes in build.yml/release.yml, files this diff never touches). As corroborating product-level evidence I also pulled the actual GitHub Actions run history for this repo's develop branch: the real push at this task's base commit (0d5225a, the PR #99 merge that introduced the bug) shows the workflow reported under its raw file path with zero jobs ever executed, confirming the exact live outage this hotfix fixes. The fix branch itself has not been pushed/opened as a PR yet, so no live CI run exists for the target commit; local actionlint plus the historical incident data is the available and sufficient evidence. All checks pass and the change is scoped exactly as described - no findings to report.

<details>
<summary>Evidence: actionlint on pre-fix test.yml (base commit 0d5225a) - reproduces the exact parse error</summary>

<code>test.yml.base:90:24: context &#34;runner&#34; is not allowed here. available contexts are &#34;github&#34;, &#34;inputs&#34;, &#34;matrix&#34;, &#34;needs&#34;, &#34;secrets&#34;, &#34;strategy&#34;, &#34;vars&#34; [expression]&#10;test.yml.base:91:28: context &#34;runner&#34; is not allowed here ... [expression]&#10;base exit code: 1&#10;fixed exit code: 0</code>

```text
=== actionlint on BASE (pre-fix) test.yml ===
[33mtest.yml.base[0m[90m:[0m90[90m:[0m24[90m: [0m[1mcontext "runner" is not allowed here. available contexts are "github", "inputs", "matrix", "needs", "secrets", "strategy", "vars". see https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability for more details[0m[90m [expression]
[0m[90m   |
[0m[90m90 | [0m      UV_TOOL_DIR: ${{ runner.temp }}/tooldir
[90m   | [0m[32m                       ^~~~~~~~~~~[0m
[33mtest.yml.base[0m[90m:[0m91[90m:[0m28[90m: [0m[1mcontext "runner" is not allowed here. available contexts are "github", "inputs", "matrix", "needs", "secrets", "strategy", "vars". see https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability for more details[0m[90m [expression]
[0m[90m   |
[0m[90m91 | [0m      UV_TOOL_BIN_DIR: ${{ runner.temp }}/toolbin
[90m   | [0m[32m                           ^~~~~~~~~~~[0m

=== actionlint on FIXED (target commit) test.yml ===

exit codes recorded above via tee; rerunning to capture explicit exit status:
base exit code: 1
fixed exit code: 0
```
</details>
<details>
<summary>Evidence: actionlint on fixed test.yml alone (target commit bb77860) - zero findings</summary>

```text
=== actionlint on test.yml alone at target commit (the only file this PR touches) ===
exit code: 0
```
</details>
<details>
<summary>Evidence: actionlint over the entire .github/workflows/ dir at target commit</summary>

```text
=== actionlint over the full .github/workflows/ dir at target commit (with git init) ===
[33m.github/workflows/build.yml[0m[90m:[0m20[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:15:33: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m20 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m41[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2144:error:5:11: -f doesn't work with globs. Use a for loop[0m[90m [shellcheck]
[0m[90m   |
[0m[90m41 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m41[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2144:error:5:34: -f doesn't work with globs. Use a for loop[0m[90m [shellcheck]
[0m[90m   |
[0m[90m41 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:1:28: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:2:12: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:3:43: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:4:12: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:5:26: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:6:15: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:7:17: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:8:15: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/build.yml[0m[90m:[0m59[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2129:style:1:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects[0m[90m [shellcheck]
[0m[90m   |
[0m[90m59 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m37[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:12:38: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m37 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m37[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:15:33: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m37 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m37[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:3:38: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m37 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m37[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:7:38: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m   |
[0m[90m37 | [0m        run: |
[90m   | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:10:83: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:11:15: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:1:30: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:2:12: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:3:62: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:4:54: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:5:12: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:6:114: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:7:12: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:8:31: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2086:info:9:19: Double quote to prevent globbing and word splitting[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
[33m.github/workflows/release.yml[0m[90m:[0m128[90m:[0m9[90m: [0m[1mshellcheck reported issue in this script: SC2129:style:1:1: Consider using { cmd1; cmd2; } >> file instead of individual redirects[0m[90m [shellcheck]
[0m[90m    |
[0m[90m128 | [0m        run: |
[90m    | [0m[32m        ^~~~[0m
exit code: 1
```
</details>
<details>
<summary>Evidence: Real GitHub Actions history confirming the live outage this fix addresses (gh api evidence)</summary>

`develop@0d5225a (this task's base commit): workflow run reports as ".github/workflows/test.yml" not "Test", conclusion=failure, gh run view says "This run likely failed because of a workflow file issue", and the jobs API returns total_count: 0 - zero jobs ever ran (Pytest/Mypy/Windows/clean-install all missing), exactly matching the reported P0 symptom.`

```text
Real GitHub Actions history for karotkriss/caffeinated-whale-cli, confirming the
P0 outage this fix addresses (queried via `gh api` against the live repo):

develop push at 9fbc95d (before PR #99 merged):
  workflow "Test" -> conclusion: success

develop push at 0d5225afddf9c308280692d5d7ec96ae23c0d7a5 (= this task's BASE commit,
the merge of PR #99 which added the broken clean-install job):
  workflow reported as ".github/workflows/test.yml" (not "Test" - GitHub falls back
  to the file path when it cannot even parse the workflow's `name:` key)
  conclusion: failure
  `gh run view 29589075269` -> "This run likely failed because of a workflow file issue."
  `gh api .../runs/29589075269/jobs` -> total_count: 0, jobs: []
    (zero jobs executed: Pytest, Mypy, Pytest-Windows, and Clean-install-smoke
     never ran, matching the reported symptom exactly)

This is the actual live incident on develop, independent of the local actionlint
run in actionlint-results.txt. The fix commit (bb77860) has not yet been pushed/
opened as a PR, so there is no live CI run for it yet; local actionlint is the
available substitute proof, matching the author's own stated validation method.
```
</details>
<details>
<summary>Evidence: Base test.yml snapshot used for actionlint comparison</summary>

```text
name: Test

# Least-privilege default token: these jobs only check out code and run local
# tooling, so read-only access to repo contents is all they need.
permissions:
  contents: read

on:
  push:
    branches: ["**"]  # Run on all branches
  pull_request:
    branches: ["**"]  # Run on PRs to all branches (includes the default branch, develop)

jobs:
  test:
    name: Pytest
    runs-on: ubuntu-latest
    container:
      image: ghcr.io/astral-sh/uv:python3.12-bookworm

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      # Fast tier only: the `unit` marker (auto-applied in tests/conftest.py to
      # every non-e2e test) selects the mock-free/mock-based suite, which needs
      # no Docker daemon and so runs inside this uv container. The real-Docker
      # `e2e` / `e2e_p2p` tiers run on host runners in e2e.yml.
      # No --cov-report override: addopts sets it empty so tests/conftest.py can
      # print one total % instead of pytest-cov's per-file table.
      - name: Run unit tests with coverage
        run: uv run pytest -m unit --cov=caffeinated_whale_cli

  # Every other job here runs ubuntu-latest, which is precisely how a Windows-only
  # defect lived in utils/auto_inspect.py unnoticed: os.kill(pid, 0) is an inert
  # liveness probe on POSIX, but on Windows signal.CTRL_C_EVENT == 0 routes it to
  # GenerateConsoleCtrlEvent, which SUCCEEDS for an already-dead pid - so the
  # daemon reported itself running off a stale PID file and `auto-inspect start`
  # refused forever. A mocked platform cannot catch that class of bug (a static
  # scan of this same code guessed the wrong mechanism for ten days) - only a real
  # Windows kernel can - and this repo is public, so windows-latest is free.
  #
  # Deliberately NARROW: this runs tests/test_auto_inspect.py, not the full unit
  # tier. The other jobs run inside a Linux uv container that a Windows runner
  # cannot use, and the rest of the suite has never been exercised on Windows, so
  # widening this to `-m unit` is its own piece of work rather than something to
  # bolt on here. See docs/testing/guide.md.
  windows-auto-inspect:
    name: Pytest (Windows, auto-inspect)
    runs-on: windows-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install uv
        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      - name: Run auto-inspect tests on real Windows
        run: uv run pytest tests/test_auto_inspect.py

  # Clean runtime-only install smoke test. This job exists because cwcli once
  # shipped SHIPPED-BROKEN on develop: commands/config.py imported `click`
  # directly but `click` was never declared in [project.dependencies] - it only
  # arrived transitively via typer. typer 0.27 stopped pulling it in, so a real
  # `uv tool install` (which installs ONLY runtime deps) had no click and every
  # command died at import with `ModuleNotFoundError: No module named 'click'`.
  # Nothing caught it: every other CI job and the local dev loop use
  # `uv sync --all-extras`, where click is present as a transitive/dev dep, so
  # `import click` always succeeded. This job is the ONLY thing that exercises a
  # runtime-deps-only install. `uv tool install .` resolves exactly the
  # [project.dependencies] set - no dev, no extras - mirroring what a user runs
  # (docs/e2e/uv-tool-distribution.md), so an undeclared runtime import fails here.
  clean-install:
    name: Clean install smoke
    runs-on: ubuntu-latest
    # Isolated tool dir/bin so this install resolves purely from
    # [project.dependencies] and never leaks onto the runner's PATH.
    env:
      UV_TOOL_DIR: ${{ runner.temp }}/tooldir
      UV_TOOL_BIN_DIR: ${{ runner.temp }}/toolbin

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install uv
        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

      - name: Install cwcli as a uv tool (runtime deps only)
        run: uv tool install .

      # A runtime-only environment must NOT contain dev/transitive-only extras.
      # click IS a declared runtime dep now, so it is expected; pytest is NOT and
      # its presence would mean the install pulled dev deps and this guard is blind.
      - name: Assert env is runtime-only (dev deps absent)
        run: |
          uv pip list --python "$UV_TOOL_DIR/caffeinated-whale-cli" > pkgs.txt
          cat pkgs.txt
          grep -qi '^click ' pkgs.txt || { echo "FAIL: click not installed (undeclared runtime dep?)"; exit 1; }
          if grep -qi '^pytest ' pkgs.txt; then echo "FAIL: pytest present - install pulled dev deps, smoke test is not runtime-only"; exit 1; fi

      # The smoke checks. Any undeclared runtime import surfaces as a
      # ModuleNotFoundError at import time and fails the step.
      - name: Smoke - import, --help, and a no-Docker command
        env:
          CWCLI_HOME: ${{ runner.temp }}/cwhome
          EDITOR: "true"   # config edit launches $EDITOR; `true` is a no-op that exits 0
          VISUAL: "true"
        run: |
          BIN="$UV_TOOL_BIN_DIR/cwcli"
          "$BIN" --help > /dev/null
          "$BIN" config --help > /dev/null
          # `config edit` is the exact command whose `click.edit` import shipped broken.
          "$BIN" config edit
          # A trivial no-Docker read that fully loads the command tree.
          "$BIN" config path > /dev/null
          echo "Clean-install smoke passed: no ModuleNotFoundError."

  typecheck:
    name: Mypy
    runs-on: ubuntu-latest
    container:
      image: ghcr.io/astral-sh/uv:python3.12-bookworm

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      # NOTE: mypy is now a zero-error gate. The historical ~50 errors have been
      # burned down to zero, so this step fails the job's status check whenever a
      # new type error is introduced. Keep it that way: do not re-add
      # continue-on-error. (If you ever need to make a step non-blocking again,
      # continue-on-error MUST go on the step, not the job: a job-level setting
      # still reports the job's conclusion as "failure" on the PR check.)
      # To make this *required to merge*, a repo admin must also tick "Mypy" as a
      # required status check in the develop branch-protection settings (same as
      # the Pytest gate).
      - name: Type-check with Mypy
        run: uv run mypy src/
```
</details>
<details>
<summary>Evidence: Fixed test.yml snapshot used for actionlint comparison</summary>

```text
name: Test

# Least-privilege default token: these jobs only check out code and run local
# tooling, so read-only access to repo contents is all they need.
permissions:
  contents: read

on:
  push:
    branches: ["**"]  # Run on all branches
  pull_request:
    branches: ["**"]  # Run on PRs to all branches (includes the default branch, develop)

jobs:
  test:
    name: Pytest
    runs-on: ubuntu-latest
    container:
      image: ghcr.io/astral-sh/uv:python3.12-bookworm

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      # Fast tier only: the `unit` marker (auto-applied in tests/conftest.py to
      # every non-e2e test) selects the mock-free/mock-based suite, which needs
      # no Docker daemon and so runs inside this uv container. The real-Docker
      # `e2e` / `e2e_p2p` tiers run on host runners in e2e.yml.
      # No --cov-report override: addopts sets it empty so tests/conftest.py can
      # print one total % instead of pytest-cov's per-file table.
      - name: Run unit tests with coverage
        run: uv run pytest -m unit --cov=caffeinated_whale_cli

  # Every other job here runs ubuntu-latest, which is precisely how a Windows-only
  # defect lived in utils/auto_inspect.py unnoticed: os.kill(pid, 0) is an inert
  # liveness probe on POSIX, but on Windows signal.CTRL_C_EVENT == 0 routes it to
  # GenerateConsoleCtrlEvent, which SUCCEEDS for an already-dead pid - so the
  # daemon reported itself running off a stale PID file and `auto-inspect start`
  # refused forever. A mocked platform cannot catch that class of bug (a static
  # scan of this same code guessed the wrong mechanism for ten days) - only a real
  # Windows kernel can - and this repo is public, so windows-latest is free.
  #
  # Deliberately NARROW: this runs tests/test_auto_inspect.py, not the full unit
  # tier. The other jobs run inside a Linux uv container that a Windows runner
  # cannot use, and the rest of the suite has never been exercised on Windows, so
  # widening this to `-m unit` is its own piece of work rather than something to
  # bolt on here. See docs/testing/guide.md.
  windows-auto-inspect:
    name: Pytest (Windows, auto-inspect)
    runs-on: windows-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install uv
        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      - name: Run auto-inspect tests on real Windows
        run: uv run pytest tests/test_auto_inspect.py

  # Clean runtime-only install smoke test. This job exists because cwcli once
  # shipped SHIPPED-BROKEN on develop: commands/config.py imported `click`
  # directly but `click` was never declared in [project.dependencies] - it only
  # arrived transitively via typer. typer 0.27 stopped pulling it in, so a real
  # `uv tool install` (which installs ONLY runtime deps) had no click and every
  # command died at import with `ModuleNotFoundError: No module named 'click'`.
  # Nothing caught it: every other CI job and the local dev loop use
  # `uv sync --all-extras`, where click is present as a transitive/dev dep, so
  # `import click` always succeeded. This job is the ONLY thing that exercises a
  # runtime-deps-only install. `uv tool install .` resolves exactly the
  # [project.dependencies] set - no dev, no extras - mirroring what a user runs
  # (docs/e2e/uv-tool-distribution.md), so an undeclared runtime import fails here.
  clean-install:
    name: Clean install smoke
    runs-on: ubuntu-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      # Isolated tool dir/bin so this install resolves purely from
      # [project.dependencies] and never leaks onto the runner's PATH. Set from
      # $RUNNER_TEMP here rather than in a job-level `env:` block: the `runner`
      # context is only available inside steps, so `${{ runner.temp }}` at
      # job level is an "Unrecognized named-value" error that fails the ENTIRE
      # workflow (every sibling job included) before anything runs.
      - name: Set up isolated tool dirs
        run: |
          echo "UV_TOOL_DIR=$RUNNER_TEMP/tooldir" >> "$GITHUB_ENV"
          echo "UV_TOOL_BIN_DIR=$RUNNER_TEMP/toolbin" >> "$GITHUB_ENV"

      - name: Install uv
        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2

      - name: Install cwcli as a uv tool (runtime deps only)
        run: uv tool install .

      # A runtime-only environment must NOT contain dev/transitive-only extras.
      # click IS a declared runtime dep now, so it is expected; pytest is NOT and
      # its presence would mean the install pulled dev deps and this guard is blind.
      - name: Assert env is runtime-only (dev deps absent)
        run: |
          uv pip list --python "$UV_TOOL_DIR/caffeinated-whale-cli" > pkgs.txt
          cat pkgs.txt
          grep -qi '^click ' pkgs.txt || { echo "FAIL: click not installed (undeclared runtime dep?)"; exit 1; }
          if grep -qi '^pytest ' pkgs.txt; then echo "FAIL: pytest present - install pulled dev deps, smoke test is not runtime-only"; exit 1; fi

      # The smoke checks. Any undeclared runtime import surfaces as a
      # ModuleNotFoundError at import time and fails the step.
      - name: Smoke - import, --help, and a no-Docker command
        env:
          CWCLI_HOME: ${{ runner.temp }}/cwhome
          EDITOR: "true"   # config edit launches $EDITOR; `true` is a no-op that exits 0
          VISUAL: "true"
        run: |
          BIN="$UV_TOOL_BIN_DIR/cwcli"
          "$BIN" --help > /dev/null
          "$BIN" config --help > /dev/null
          # `config edit` is the exact command whose `click.edit` import shipped broken.
          "$BIN" config edit
          # A trivial no-Docker read that fully loads the command tree.
          "$BIN" config path > /dev/null
          echo "Clean-install smoke passed: no ModuleNotFoundError."

  typecheck:
    name: Mypy
    runs-on: ubuntu-latest
    container:
      image: ghcr.io/astral-sh/uv:python3.12-bookworm

    steps:
      - name: Checkout code
        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
        with:
          persist-credentials: false

      - name: Install dependencies
        run: uv sync --frozen --all-extras

      # NOTE: mypy is now a zero-error gate. The historical ~50 errors have been
      # burned down to zero, so this step fails the job's status check whenever a
      # new type error is introduced. Keep it that way: do not re-add
      # continue-on-error. (If you ever need to make a step non-blocking again,
      # continue-on-error MUST go on the step, not the job: a job-level setting
      # still reports the job's conclusion as "failure" on the PR check.)
      # To make this *required to merge*, a repo admin must also tick "Mypy" as a
      # required status check in the develop branch-protection settings (same as
      # the Pytest gate).
      - name: Type-check with Mypy
        run: uv run mypy src/
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`docker run rhysd/actionlint:latest test.yml.base` - reproduces the exact reported error: &#34;context &#39;runner&#39; is not allowed here&#34; at both job-level env lines (90:24, 91:28), exit code 1</code>
- <code>`docker run rhysd/actionlint:latest test.yml.fixed` (target commit bb77860) - zero findings, exit code 0</code>
- <code>`docker run rhysd/actionlint:latest` over the full .github/workflows/ directory at the target commit - confirms test.yml itself has zero actionlint findings; the only findings anywhere are pre-existing shellcheck style notes in build.yml/release.yml, both untouched by this diff (`git diff 0d5225a..bb77860 --stat` for those files is empty)</code>
- <code>`grep -n &#34;runner\.&#34; .github/workflows/*.yml` across all 5 workflow files - confirms the only remaining runner-context usage is the step-level CWCLI_HOME env (allowed) and a comment; no other job-level misuse exists anywhere in the repo&#39;s workflows</code>
- <code>`gh api repos/karotkriss/caffeinated-whale-cli/actions/runs/...` for the real develop push at head_sha 0d5225a (this task&#39;s base commit) - confirms the live production incident: the run is reported under the raw file path &#34;.github/workflows/test.yml&#34; instead of the workflow&#39;s declared name &#34;Test&#34; (GitHub&#39;s tell for an unparseable workflow), conclusion=failure, and the jobs endpoint returns total_count: 0 - no Pytest/Mypy/Windows/clean-install jobs ran at all</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
