### PR TITLE
fix(commands): rewrite raw bench/docker-exec hints as copy-paste cwcli commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,9 @@ Each entry is the contract; the linked source file is authoritative and the name
   `test.yml` also runs `Pytest (Windows, auto-inspect)` on `windows-latest` - the ONLY non-Linux runner, deliberately narrow to `tests/test_auto_inspect.py`. It exists because a Windows-only defect in `utils/auto_inspect.py` survived precisely because everything ran `ubuntu-latest`, and the repo is public so Windows minutes are free. Platform-dependent process/path/signal work belongs in that suite, not assumed covered by the Linux jobs; widening it to the full `unit` tier is unproven and tracked separately. See `docs/testing/guide.md#the-windows-job-why-it-exists-and-why-it-is-narrow`.
   `develop` has no branch protection, so a repo admin must still tick `Pytest`/`Mypy` (and the `E2E (frappe vNN)` checks, to make E2E a required gate) as required status checks for them to block merges.
 - **Release.** See skill: `cwcli-release`.
+- **Suggested commands.** Any `bench`/`docker exec` command cwcli SUGGESTS to a user (hint, error, success message, help text) must be phrased as the `cwcli run <project> [--site <site>] <bench-args>` wrapper or the appropriate cwcli verb (`cwcli apps install`, ...), never a raw in-container command the user cannot run.
+  Substitute the live project/site/flag values at the point the hint is printed so it is copy-paste accurate against `commands/run.py`'s pass-through signature.
+  This is only for SUGGESTIONS; cwcli's own internal `bench`/`docker exec` construction it executes stays as is.
 - **Commits.** Author commits as `karotkriss <mckay.christopher73@outlook.com>` only.
   Never add an agent name as a co-author.
   Never hand-edit `CHANGELOG.md` outside a deliberate version bump, and never edit auto-generated files.

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Stop:    cwcli stop my-project
 Restart: cwcli restart my-project
 
 Administrator password (generated): 3sK9nQx7Lm-2pT4vWbY6Za
-Shown once and not stored anywhere. To change it later, run `bench --site development.localhost set-admin-password <new-password>`.
+Shown once and not stored anywhere. To change it later, run `cwcli run my-project --site development.localhost set-admin-password <new-password>`.
 ```
 
 The generated administrator password prints only when `--admin-password` is omitted in an interactive run; supply `--admin-password` to set it yourself (and to run non-interactively).

--- a/src/caffeinated_whale_cli/commands/init.py
+++ b/src/caffeinated_whale_cli/commands/init.py
@@ -660,5 +660,6 @@ def init(
         )
         console.print(
             "[dim]Shown once and not stored anywhere. To change it later, run "
-            f"`bench --site {report.site_name} set-admin-password <new-password>`.[/dim]"
+            f"`cwcli run {project} --site {report.site_name} set-admin-password "
+            "<new-password>`.[/dim]"
         )

--- a/src/caffeinated_whale_cli/commands/restore.py
+++ b/src/caffeinated_whale_cli/commands/restore.py
@@ -315,8 +315,8 @@ def _render_missing_apps_gate(plan, *, yes: bool, isatty: bool) -> None:
     console.print()
     console.print("[dim]You may need to install these apps before restoring to avoid errors.[/dim]")
     console.print(
-        f"[dim]Install apps with: bench get-app <app-name> && bench --site {plan.site} "
-        "install-app <app-name>[/dim]"
+        f"[dim]Install apps with: cwcli apps install {plan.project_name} <app-name> "
+        f"--site {plan.site}[/dim]"
     )
     console.print()
     _gate(
@@ -408,8 +408,8 @@ def _apply_and_render(
                 if w.code == "migrate.failed":
                     stderr_console.print(f"[bold yellow]⚠ Warning:[/bold yellow] {w.text}")
                     stderr_console.print(
-                        f"[dim]Run it manually: cwcli run {plan.project_name} -- "
-                        f"bench --site {plan.site} migrate[/dim]"
+                        f"[dim]Run it manually: cwcli run {plan.project_name} "
+                        f"--site {plan.site} migrate[/dim]"
                     )
         console.print()
         console.print("[bold cyan]Restarting instance...[/bold cyan]")

--- a/src/caffeinated_whale_cli/commands/update.py
+++ b/src/caffeinated_whale_cli/commands/update.py
@@ -323,7 +323,8 @@ def _report_summary(report: UpdateReport) -> None:
         for site in report.failed_maintenance_disable:
             console.print(
                 f"  • {site}: still in maintenance mode - run "
-                f"'bench --site {shlex.quote(site)} set-maintenance-mode off'"
+                f"'cwcli run {shlex.quote(report.project)} --site {shlex.quote(site)} "
+                f"set-maintenance-mode off'"
             )
 
 

--- a/tests/test_apps.py
+++ b/tests/test_apps.py
@@ -874,8 +874,8 @@ def test_update_stream_loss_mid_fanout_still_reports_stuck_site_remediation(
     # The summary is reachable, and the stuck site keeps its actionable remediation,
     # for BOTH sites the finally tried and failed to take back out of maintenance.
     assert "Update completed with errors" in out
-    assert "bench --site a.localhost set-maintenance-mode off" in out
-    assert "bench --site b.localhost set-maintenance-mode off" in out
+    assert "cwcli run proj --site a.localhost set-maintenance-mode off" in out
+    assert "cwcli run proj --site b.localhost set-maintenance-mode off" in out
 
     # The lost site is reported as UNKNOWN, not as a failure: retrying a migration
     # that may still be running is harmful, so the two must stay distinguishable.
@@ -941,7 +941,7 @@ def test_stuck_site_remediation_line_is_shlex_quoted(monkeypatch, capsys):
         update_mod.run_app_update("proj", ["payments"], verbose=True)
 
     out = " ".join(capsys.readouterr().out.split())
-    assert "bench --site 'weird site' set-maintenance-mode off" in out
+    assert "cwcli run proj --site 'weird site' set-maintenance-mode off" in out
 
 
 # ------------------------------------------- narration lines the table-driven

--- a/tests/test_init_admin_password.py
+++ b/tests/test_init_admin_password.py
@@ -222,6 +222,12 @@ class TestGeneratedPasswordPrint:
         joined = "\n".join(printed)
         assert "Administrator password (generated)" in joined
         assert joined.count(pw) == 1
+        # The "change it later" hint must be a copy-paste-accurate cwcli
+        # invocation, not a raw `bench` command the user cannot run directly.
+        assert (
+            "`cwcli run proj --site development.localhost set-admin-password "
+            "<new-password>`" in joined
+        )
 
     def test_not_printed_on_idempotent_rerun(self, monkeypatch):
         # Site already exists -> new-site is skipped -> no password was set, so a

--- a/tests/test_restore_safety.py
+++ b/tests/test_restore_safety.py
@@ -321,6 +321,13 @@ class TestReceiveMissingAppsGate:
 
         assert len(container.restore_calls()) == 1
         assert any("not available on this bench" in line for line in container.printed)
+        # The install hint must be a copy-paste-accurate cwcli invocation
+        # (cwcli apps install <project> <app> --site <site>), not the raw
+        # `bench get-app`/`bench --site ... install-app` the user cannot run.
+        assert any(
+            "cwcli apps install proj <app-name> --site development.localhost" in line
+            for line in container.printed
+        )
 
     def test_non_tty_without_yes_refuses_and_exits_nonzero(self, monkeypatch):
         container = FakeReceiveContainer()
@@ -829,3 +836,71 @@ class TestNormalPathSelectorsAndExitCodes:
         assert (
             len(cancelled) == 1
         ), f"expected 'Restore cancelled.' exactly once, got {len(cancelled)}: {cancelled}"
+
+
+class TestMigrateFailureRemediationHint:
+    """A failed post-restore migrate must point the user at the copy-paste-
+    accurate ``cwcli run <project> --site <site> migrate`` wrapper.
+
+    The hint previously read ``cwcli run <project> -- bench --site <site>
+    migrate``: everything after the ``--`` rides straight into the bench-args
+    list, so ``run_plan`` (``core/run.py``) would have assembled
+    ``"bench " + "bench --site <site> migrate"`` - a stray, non-functional
+    double ``bench`` invocation. Exercised at the ``_apply_and_render``
+    rendering seam directly (``core_restore.restore_apply`` stubbed to return
+    a migrate-failed report) since the full container simulation would also
+    have to fake the post-migrate restart.
+    """
+
+    def test_hint_is_cwcli_run_wrapper_not_raw_bench(self, monkeypatch):
+        from caffeinated_whale_cli.core.envelope import Message, Result, Status
+
+        plan = SimpleNamespace(
+            project_name="proj",
+            site="development.localhost",
+            backup_filename=DB_FILENAME,
+        )
+        report = restore_mod.core_restore.RestoreReport(
+            site="development.localhost",
+            bench_path=BENCH_PATH,
+            restored=True,
+            included_files=False,
+            encryption_key_updated=None,
+            migrate_ran=True,
+            migrate_ok=False,
+            restarted=True,
+            restart_log="restart.log",
+        )
+        warning = Message(
+            "migrate.failed", "'bench migrate' failed for site 'development.localhost'."
+        )
+        monkeypatch.setattr(
+            restore_mod.core_restore,
+            "restore_apply",
+            lambda *a, **k: Result(status=Status.WARNING, data=report, warnings=[warning]),
+        )
+        monkeypatch.setattr(restore_mod, "TipSpinner", _NullSpinner)
+        monkeypatch.setattr(restore_mod.config_utils, "get_show_tips", lambda: False)
+
+        printed: list[str] = []
+
+        def record(*args, **kwargs):
+            printed.append(" ".join(str(a) for a in args))
+
+        monkeypatch.setattr(restore_mod.console, "print", record)
+        monkeypatch.setattr(restore_mod.stderr_console, "print", record)
+
+        with pytest.raises(typer.Exit):
+            restore_mod._apply_and_render(
+                plan,
+                mariadb_root_username="root",
+                mariadb_root_password=SECRET_PW,
+                admin_password=None,
+                no_migrate=False,
+                verbose=False,
+            )
+
+        joined = "\n".join(printed)
+        assert "cwcli run proj --site development.localhost migrate" in joined
+        # Regression guard for the old stray `-- bench` double-bench bug.
+        assert "-- bench" not in joined


### PR DESCRIPTION
## Intent

Fix every user-facing hint in cwcli that tells a user to run a raw 'bench ...' or 'docker exec ...' command they cannot run directly. bench/docker exec run INSIDE the container; a cwcli user reaches them through cwcli's own wrapper (cwcli run <project> [--site <site>] <bench-args>, which passes flags/args straight through to bench) or a dedicated cwcli verb (cwcli apps install). Reported instance: commands/init.py set-admin-password hint. Rewrote four user-facing hints with live project/site substitution so each is copy-paste accurate: init.py set-admin-password -> cwcli run <project> --site <site> set-admin-password; restore.py missing-apps -> cwcli apps install <project> <app> --site <site>; restore.py manual-migrate (which also had a stray '-- bench' that would have run 'bench bench ...') -> cwcli run <project> --site <site> migrate; update.py stuck-maintenance recovery -> cwcli run <project> --site <site> set-maintenance-mode off. Deliberately left cwcli's own INTERNAL bench/docker exec command construction (core/*.py exec builders, backup.py, the deprecated update alias docstring describing cwcli's own automated steps, --help flag text) unchanged since those are not suggestions the user must run. Updated the 3 stdout-hint assertions in tests/test_apps.py to match the new text (the container.calls internal-exec assertions correctly still expect 'bench ...'). Added an AGENTS.md convention line requiring suggested bench/container commands to be phrased as copy-paste-accurate cwcli invocations. This is an output-string change only, no behavior change.

## What Changed

- Rewrote four user-facing hints that suggested a raw `bench ...`/`docker exec` command a user cannot run directly, substituting live project/site values so each is copy-paste accurate: `init.py`'s set-admin-password hint and `update.py`'s stuck-maintenance-mode recovery hint now suggest `cwcli run <project> --site <site> ...`; `restore.py`'s missing-apps hint now suggests `cwcli apps install <project> <app-name> --site <site>`; `restore.py`'s manual-migrate hint drops a stray `-- bench` (which would have run `bench bench ...`) and becomes `cwcli run <project> --site <site> migrate`.
- Updated `README.md`'s init example output to match the new set-admin-password hint text.
- Added an `AGENTS.md` convention documenting that any suggested `bench`/`docker exec` command must be phrased as a copy-paste-accurate `cwcli run`/`cwcli apps install`-style wrapper, distinct from cwcli's own internal exec construction which is unaffected.
- Updated the corresponding stdout-hint assertions in `tests/test_apps.py`, `tests/test_init_admin_password.py`, and `tests/test_restore_safety.py` to match the new text, and added a new test asserting the migrate hint no longer contains the stray `-- bench`.

## Risk Assessment

✅ Low: Pure output-string fix: each rewritten hint was verified against its call site's actual variable (project, plan.project_name, report.project) and against how cwcli run assembles its bench command, all four rewrites are copy-paste correct, the fixed stray '-- bench' bug is genuinely fixed, tests were updated to match, and a repo-wide grep found no other raw bench/docker-exec suggestions left unfixed.

## Testing

Ran the existing `tests/test_apps.py`, `tests/test_init_admin_password.py`, and `tests/test_restore_safety.py` suites (all pass, confirming the shipped update.py hint-text change and no regressions), then extended two of those existing tests and added a new dedicated test to directly assert the exact new hint strings the intent calls for (init admin-password rewrite, restore missing-apps rewrite, and the manual-migrate rewrite that fixes the stray '-- bench' double-bench bug) since no prior test pinned that exact text; all six targeted assertions pass, the full fast unit tier (`uv run pytest`) stays green, and `mypy src/` is clean. Confirmed by grep that no other user-facing raw bench/docker-exec suggestion remains in the three touched command modules (the two remaining `bench`-mentioning lines are excluded-by-design: a --help flag description and the deprecated update-alias docstring describing cwcli's own internal automated steps).

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_init_admin_password.py tests/test_restore_safety.py tests/test_apps.py -q` (all PASS)</code>
- <code>`uv run pytest tests/test_init_admin_password.py::TestGeneratedPasswordPrint::test_printed_once_when_site_created` extended with an exact-text assertion for the new `cwcli run proj --site development.localhost set-admin-password &lt;new-password&gt;` hint</code>
- <code>`uv run pytest tests/test_restore_safety.py::TestReceiveMissingAppsGate::test_yes_proceeds_despite_missing_apps` extended with an exact-text assertion for the new `cwcli apps install proj &lt;app-name&gt; --site development.localhost` hint</code>
- <code>Added `tests/test_restore_safety.py::TestMigrateFailureRemediationHint::test_hint_is_cwcli_run_wrapper_not_raw_bench`, exercising `_apply_and_render` directly with a stubbed migrate-failed `restore_apply` result, asserting the new `cwcli run proj --site development.localhost migrate` hint appears and the old stray `-- bench` text does not</code>
- <code>`uv run pytest -q` (full fast unit tier, all pass)</code>
- <code>`uv run mypy src/` (no issues)</code>
- <code>`grep` sweep of commands/init.py, restore.py, update.py confirming no remaining raw bench/docker-exec user-facing suggestions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
