### PR TITLE
test(exit-codes): Pin failure-never-exits-zero invariant across the surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,10 @@ Each entry is the contract; the linked source file is authoritative and the name
 - **Distribution.** cwcli is distributed as a uv tool: `uv tool install caffeinated-whale-cli` (unpinned, so `uv tool upgrade` works) or `uvx --from caffeinated-whale-cli cwcli ...`.
   Both `cwcli` and `caffeinated-whale-cli` console scripts point at `caffeinated_whale_cli.main:cli`; the `--from` is needed because the command name differs from the package name.
   Install/run/upgrade docs live in `README.md`; the isolated E2E evidence is `docs/e2e/uv-tool-distribution.md`.
+- **Exit codes.** A step the tool itself reports as failed must NEVER exit 0: the exit code is the only failure signal automation has, and an agent-facing CLI that pins it to 0 cannot be driven safely.
+  Every frontend that aggregates per-step results reads its own report (`report.ok`, `outcome.failures`, `migrate_ok`), NEVER `result.status` - a partial fan-out failure is a `WARNING`-shaped envelope and every other verb maps `WARNING` to exit 0, so reading the envelope reports success for a half-finished mutation.
+  `tests/test_exit_codes_on_failure.py` is the cross-surface pin (both the failure and its success twin, since a change that makes everything fail is not a fix); the per-command pins live in `test_apps_characterization.py` and `test_core_run.py`.
+  The standing hazard: `typer.Exit` subclasses `RuntimeError`, hence `Exception`, so any broad `except Exception` around a call that raises it silently converts a failure into exit 0 - the frontend handlers that wrap such calls re-raise `typer.Exit` explicitly before their broad branch, and a new one must do the same.
 - **Types.** Keep `uv run mypy src/` at zero errors; it is a blocking gate.
   Prefer accurate annotations over `# type: ignore` (there are none in `src/`), and add the matching `types-*` stub (`types-requests`, `types-toml` are dev deps) rather than ignoring an untyped import.
   Do not loosen `[tool.mypy]` to hide errors.

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,7 +81,7 @@ The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit
 
 ## Test Files
 
-As of 1.0.0, `tests/` holds 91 `test_*.py` suites totaling 1656 tests in the
+As of 1.0.0, `tests/` holds 92 `test_*.py` suites totaling 1670 tests in the
 `unit` tier (measured with `uv run pytest --cov`). Run `ls tests/` for the
 authoritative current list; see [../docs/testing/README.md](../docs/testing/README.md)
 for the per-area breakdown.
@@ -149,7 +149,7 @@ Tests for tab completion functionality.
 
 ## Test Coverage
 
-Current overall coverage at 1.0.0 (1656 tests across 91 test files, ~82% overall).
+Current overall coverage at 1.0.0 (1670 tests across 92 test files, ~82% overall).
 
 ### Covered Modules
 - ✅ `utils/completion_utils.py` - 92% (7 missing lines)

--- a/tests/test_exit_codes_on_failure.py
+++ b/tests/test_exit_codes_on_failure.py
@@ -37,6 +37,7 @@ import typer
 from caffeinated_whale_cli.commands import apps as apps_mod
 from caffeinated_whale_cli.core.apps import AppResult, AppsReport
 from caffeinated_whale_cli.core.envelope import Result, Status
+from caffeinated_whale_cli.utils import docker_utils
 
 
 def _report(*, ok: bool) -> AppsReport:
@@ -99,6 +100,19 @@ def no_docker(monkeypatch):
     Only the exit plumbing is under test here, so the container work is stubbed
     out entirely - this suite must stay in the fast, Docker-free unit tier.
     """
+    # Bypass the @handle_docker_errors preflight on every apps command (the
+    # tests/test_apps.py pattern): it checks for a real `docker` binary and a
+    # live daemon before the function body runs, so without this a runner with
+    # no Docker installed raises typer.Exit(1) here regardless of what the
+    # verb's own logic would have done.
+    monkeypatch.setattr(docker_utils.shutil, "which", lambda name: "/usr/bin/docker")
+
+    class _Client:
+        def ping(self):
+            return True
+
+    monkeypatch.setattr(docker_utils.docker, "from_env", lambda: _Client())
+
     monkeypatch.setattr(apps_mod, "ensure_containers_running", lambda *a, **k: None)
     monkeypatch.setattr(apps_mod, "_resolve_bench", lambda *a, **k: "/workspace/frappe-bench")
     # The post-mutation recache is a frontend epilogue that runs BEFORE the exit

--- a/tests/test_exit_codes_on_failure.py
+++ b/tests/test_exit_codes_on_failure.py
@@ -1,0 +1,220 @@
+"""The surface-wide pin: a reported failure must NEVER exit 0.
+
+The exit code is the only failure signal automation has. Two field reports
+(2026-07-19) described `cwcli apps install` and `cwcli run` printing a failure
+mark, printing "Completed with errors.", and still exiting 0 - which makes every
+wrapper, pipeline step and agent workflow read a failed operation as a completed
+one. Neither reproduced at `cd0d298` (the reports were against an older build and
+the plumbing was already sound), so this file does not accompany a behaviour fix.
+It exists so the plumbing CANNOT silently regress to the reported shape.
+
+What the existing suite already pins, and this file deliberately does not repeat:
+`tests/test_apps_characterization.py` covers one apps fan-out partial failure end
+to end, and `tests/test_core_run.py` covers `cwcli run` forwarding a bench exit
+code verbatim (7 stays 7, 0 stays 0).
+
+What is NEW here is the CROSS-SURFACE guarantee. Those are per-command tests: a
+verb added tomorrow, or an exit read quietly reseated from `report.ok` onto
+`result.status`, gets no pin from them. So this file drives every frontend that
+AGGREGATES per-step results through one parametrized sweep, asserting the same
+invariant for all of them at once, and pins the shared renderer they route
+through directly.
+
+The invariant has two halves, and both are load-bearing: a failed step must exit
+non-zero, AND a clean run must still exit 0. A change that makes everything fail
+is not a fix, so every failure case here has a success twin.
+
+Why `report.ok` and not `result.status`: a partial fan-out failure is a
+``WARNING``-shaped envelope, and every other verb maps ``WARNING`` to exit 0.
+Reading the envelope's status here would report success for an install that half
+failed - the exact defect the reports describe. See `commands/apps.py`'s
+`_report_and_exit` docstring.
+"""
+
+import pytest
+import typer
+
+from caffeinated_whale_cli.commands import apps as apps_mod
+from caffeinated_whale_cli.core.apps import AppResult, AppsReport
+from caffeinated_whale_cli.core.envelope import Result, Status
+
+
+def _report(*, ok: bool) -> AppsReport:
+    """A fan-out report whose per-step results agree with its ``ok`` aggregate."""
+    results = [
+        AppResult(app="custom_app", site=None, action="get-app", ok=True),
+        AppResult(app="custom_app", site="a.localhost", action="install-app", ok=ok),
+    ]
+    return AppsReport(project="proj", bench_path="/workspace/frappe-bench", results=results, ok=ok)
+
+
+def _envelope(report: AppsReport) -> Result:
+    """The envelope shape a partial failure really arrives in.
+
+    A failed step yields ``WARNING``, NOT ``ERROR``. That is precisely why the
+    exit code must read ``report.ok``: a frontend reading ``result.status`` and
+    mapping ``WARNING`` to 0 would swallow the failure.
+    """
+    return Result(
+        status=Status.WARNING if not report.ok else Status.OK,
+        data=report,
+        warnings=[],
+    )
+
+
+# ------------------------------------------------- the shared renderer, pinned directly
+
+
+@pytest.mark.parametrize("json_output", [False, True], ids=["human", "json"])
+def test_report_and_exit_exits_non_zero_when_a_step_failed(json_output, capsys):
+    """`_report_and_exit` is the single exit path for install/uninstall/checkout.
+
+    Pinned in BOTH render modes: `--json` is the agent-facing shape, so a failure
+    that exits 0 there is the one automation is likeliest to act on.
+    """
+    with pytest.raises(typer.Exit) as exc:
+        apps_mod._report_and_exit(_report(ok=False), json_output, success_msg="App(s) installed.")
+
+    assert exc.value.exit_code != 0, "a reported failure must never exit 0"
+    assert exc.value.exit_code == 1
+    capsys.readouterr()
+
+
+@pytest.mark.parametrize("json_output", [False, True], ids=["human", "json"])
+def test_report_and_exit_stays_zero_when_every_step_succeeded(json_output, capsys):
+    """The success twin: an all-green report must not be dragged to non-zero."""
+    # A clean run returns normally; Typer then exits 0. Raising here would mean
+    # the failure path had been widened to swallow successes too.
+    apps_mod._report_and_exit(_report(ok=True), json_output, success_msg="App(s) installed.")
+    capsys.readouterr()
+
+
+# ------------------------------------------------- every aggregating verb, swept at once
+
+
+@pytest.fixture
+def no_docker(monkeypatch):
+    """Defuse the preflight, the interactive prologue and the recache epilogue.
+
+    Only the exit plumbing is under test here, so the container work is stubbed
+    out entirely - this suite must stay in the fast, Docker-free unit tier.
+    """
+    monkeypatch.setattr(apps_mod, "ensure_containers_running", lambda *a, **k: None)
+    monkeypatch.setattr(apps_mod, "_resolve_bench", lambda *a, **k: "/workspace/frappe-bench")
+    # The post-mutation recache is a frontend epilogue that runs BEFORE the exit
+    # read whenever any step succeeded. It degrades to a warning by design, so it
+    # must not be able to influence the exit code either way.
+    monkeypatch.setattr(apps_mod, "_refresh_cache", lambda *a, **k: None)
+
+
+# Every apps verb that aggregates per-step results, with the core call it routes
+# through and the kwargs that reach it. Adding a verb here is cheaper than
+# discovering in production that its exit code was wired to the wrong field.
+AGGREGATING_VERBS = [
+    pytest.param(
+        "install_apps",
+        "install_apps",
+        dict(
+            project_name="proj",
+            apps=["custom_app"],
+            bench=None,
+            bench_path=None,
+            sites=["a.localhost"],
+            branch=None,
+            fetch_only=False,
+            yes=True,
+            verbose=False,
+        ),
+        id="apps-install",
+    ),
+    pytest.param(
+        "uninstall_apps",
+        "uninstall_apps",
+        dict(
+            project_name="proj",
+            apps=["custom_app"],
+            bench=None,
+            bench_path=None,
+            sites=["a.localhost"],
+            yes=True,
+            verbose=False,
+        ),
+        id="apps-uninstall",
+    ),
+    pytest.param(
+        "checkout_app",
+        "checkout_app",
+        dict(
+            project_name="proj",
+            app="custom_app",
+            ref="feature-branch",
+            bench=None,
+            bench_path=None,
+            reset=False,
+            yes=True,
+            verbose=False,
+        ),
+        id="apps-checkout",
+    ),
+]
+
+
+@pytest.mark.parametrize(("verb", "core_name", "kwargs"), AGGREGATING_VERBS)
+@pytest.mark.parametrize("json_output", [False, True], ids=["human", "json"])
+def test_aggregating_verb_exits_non_zero_when_a_step_failed(
+    verb, core_name, kwargs, json_output, monkeypatch, no_docker, capsys
+):
+    """The regression this file exists for: a failed step, a non-zero exit.
+
+    Driven through the real Typer command function so the assertion covers the
+    whole frontend - the core call, the recache epilogue, and the exit read - not
+    just the renderer in isolation.
+    """
+    monkeypatch.setattr(apps_mod.core_apps, core_name, lambda *a, **k: _envelope(_report(ok=False)))
+
+    with pytest.raises(typer.Exit) as exc:
+        getattr(apps_mod, verb)(json_output=json_output, **kwargs)
+
+    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
+    capsys.readouterr()
+
+
+@pytest.mark.parametrize(("verb", "core_name", "kwargs"), AGGREGATING_VERBS)
+def test_aggregating_verb_exits_zero_when_every_step_succeeded(
+    verb, core_name, kwargs, monkeypatch, no_docker, capsys
+):
+    """The success twin, per verb: a green run must still be exit 0."""
+    monkeypatch.setattr(apps_mod.core_apps, core_name, lambda *a, **k: _envelope(_report(ok=True)))
+
+    getattr(apps_mod, verb)(json_output=False, **kwargs)
+    capsys.readouterr()
+
+
+def test_warning_status_alone_never_decides_the_exit_code(monkeypatch, no_docker, capsys):
+    """The specific trap: `WARNING` + `ok=False` must still exit non-zero.
+
+    A frontend reseated onto `result.status` would map this envelope to 0, which
+    is exactly how a half-finished install reads as a clean success. Pinned as its
+    own case so the reason survives even if the sweep above is ever rewritten.
+    """
+    envelope = _envelope(_report(ok=False))
+    assert envelope.status is Status.WARNING  # the shape the trap depends on
+
+    monkeypatch.setattr(apps_mod.core_apps, "install_apps", lambda *a, **k: envelope)
+
+    with pytest.raises(typer.Exit) as exc:
+        apps_mod.install_apps(
+            project_name="proj",
+            apps=["custom_app"],
+            bench=None,
+            bench_path=None,
+            sites=["a.localhost"],
+            branch=None,
+            fetch_only=False,
+            json_output=False,
+            yes=True,
+            verbose=False,
+        )
+
+    assert exc.value.exit_code != 0
+    capsys.readouterr()


### PR DESCRIPTION
## Intent

Goal: make cwcli exit non-zero when an operation fails. Two field reports dated 2026-07-19 said 'cwcli apps install <repo> --branch testing --yes' and 'cwcli run visa15 --site development.localhost migrate' each printed a failure mark and 'Completed with errors.' yet exited 0, so automation could not tell a failure from a success. The user asked me to reproduce both cases first and explicitly warned not to reason about the exit path from reading the code, then to fix it at the shared point every command routes through rather than in the two named commands, and to cover it with a regression test that fails if the exit code is ever pinned back to 0.

Key outcome the reviewer must know: THE DEFECT DOES NOT REPRODUCE at commit cd0d298 and THIS BRANCH CONTAINS NO BEHAVIOUR FIX - that is deliberate and was explicitly approved by the user, not an oversight. I reproduced against the live visa15 instance before changing anything: apps install with a failing get-app exits 1; the reporter's exact shape (get-app succeeds, install-app FAILS, with the _refresh_cache epilogue actually running - which is what distinguished my first repro from theirs) exits 1; 'cwcli run visa15 --site development.localhost <fatal traceback>' exits 1 both piped and unpiped; and a sweep of 14 commands driven to real failures all exit 1, with only a no-match 'where' and a successful 'ls' at 0, both correct. A static sweep confirmed every path printing a failure mark reaches typer.Exit(1) and all four 'except typer.Exit' sites re-raise or deliberately convert to an abort. The captain's live binary was reinstalled 2026-07-20 14:23, so the 07-19 reports ran an OLDER build; the exit plumbing has been sound since the apps group was introduced. I reported this as needs-decision rather than inventing a fix, and the user chose: land the regression test only, do not claim a fix I did not make, and additionally investigate whether bench itself exits 0 (report findings, do not expand scope to fix).

So the diff is deliberately test-plus-docs only, with ZERO production code changed. tests/test_exit_codes_on_failure.py adds the CROSS-SURFACE pin that the existing per-command tests do not give: test_apps_characterization.py already covers one apps fan-out partial failure and test_core_run.py already covers run forwarding a bench exit code verbatim, but neither would catch a NEW verb wired to the wrong field or an exit read quietly reseated from report.ok onto result.status. The new file therefore sweeps every apps frontend that aggregates per-step results (install, uninstall, checkout), pins the shared _report_and_exit renderer directly in both human and --json modes, and gives every failure case a success twin because a change that makes everything fail is not a fix. I verified the test actually bites by temporarily pinning the exit back to 0: 9 tests went red with the exact reported output. Deliberate choices a reviewer might question: I did NOT duplicate the existing per-command assertions (called out in the module docstring); I stubbed the container work so the suite stays in the fast Docker-free unit tier; and I asserted 'exit_code != 0' as the invariant with '== 1' only as a secondary assertion, because the hard requirement the user stated is only that failure is never 0.

AGENTS.md gains an 'Exit codes' convention recording the invariant, the report.ok-not-result.status rule, a pointer to the new test, and the standing hazard I found: typer.Exit subclasses RuntimeError and therefore Exception, so any broad 'except Exception' around a call that raises it silently converts a failure into exit 0.

Investigation finding, reported not fixed per the user's scope call: frappe's migrate has no except (try/finally only) and bench os.execv's into frappe, so a fatal ValidationError measured directly in the container exits 1 - the 'bench exits 0' theory is disproved for that path. But frappe/utils/bench_helper.py:get_app_commands catches ModuleNotFoundError-with-a-different-name AND bare Exception, calls traceback.print_exc(), returns {} and lets command discovery continue - demonstrated live: full traceback printed, exit 0. That is a real 'traceback on screen, exit 0' mechanism, but it is upstream in frappe, not in cwcli.

No existing test changed meaning and none broke. Full unit suite green (pytest exit 0, all 92 files); black, ruff and mypy clean. Note the shared box has a root-owned /tmp/pytest-of-cmckay that mass-errors the suite with OSError at setup; I used --basetemp rather than modifying a directory outside my worktree, so that is environmental and not a branch regression.

## What Changed

- Add `tests/test_exit_codes_on_failure.py`, a parametrized cross-surface regression test asserting that any command frontend aggregating per-step results (`apps install`/`uninstall`/`checkout`, both human and `--json` modes) exits non-zero on a reported failure and 0 on a clean run, pinning the shared `_report_and_exit` renderer and its `report.ok`-driven exit code directly rather than `result.status`.
- Document the exit-code invariant in `AGENTS.md`: failure must never exit 0, every aggregating frontend must read its own report field (not the envelope's `result.status`), and the standing hazard that `typer.Exit` subclasses `Exception` so a broad `except Exception` can silently swallow it into exit 0.
- Refresh the stale test file/count totals in `tests/README.md` (91 -> 92 files, 1656 -> 1670 tests) to match the new suite.

No production code changed: the reported exit-0-on-failure defect did not reproduce against the current codebase, so this branch adds only the regression pin and its documentation.

## Risk Assessment

✅ Low: The change is test-and-docs only (zero production code touched); the new test file correctly matches the real Typer command signatures, DTO fields, and envelope shape it exercises, and the AGENTS.md addition accurately reflects existing per-command coverage it references.

## Testing

Confirmed the branch's diff is exactly test-plus-docs as claimed, ran the new cross-surface exit-code regression suite to green, and directly demonstrated it catches the reported defect by reintroducing the exact `typer.Exit(code=0)` bug in commands/apps.py and watching 9 of 14 tests fail with the reported symptom before restoring the file cleanly; the full 1670-test fast unit suite is green with no regressions.

<details>
<summary>Evidence: Regression test catching the reported exit-0-on-failure defect</summary>

`9 of 14 tests in tests/test_exit_codes_on_failure.py fail when _report_and_exit's raise typer.Exit(code=1) is temporarily changed to code=0), reproducing the exact reported shape: stderr shows the install-app failure mark and 'Completed with errors.' while exit_code == 0. File was restored immediately after and git status confirmed clean.`

```text
tests/test_exit_codes_on_failure.py                       FAIL    0.19s

=================================== FAILURES ===================================
________ test_report_and_exit_exits_non_zero_when_a_step_failed[human] _________
tests/test_exit_codes_on_failure.py:78: in test_report_and_exit_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, "a reported failure must never exit 0"
E   AssertionError: a reported failure must never exit 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=2>.value
----------------------------- Captured stderr call -----------------------------
  ✓ get-app custom_app
  ✗ install-app custom_app on a.localhost
Completed with errors.
_________ test_report_and_exit_exits_non_zero_when_a_step_failed[json] _________
tests/test_exit_codes_on_failure.py:78: in test_report_and_exit_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, "a reported failure must never exit 0"
E   AssertionError: a reported failure must never exit 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=2>.value
----------------------------- Captured stdout call -----------------------------
{
  "project": "proj",
  "bench": "/workspace/frappe-bench",
  "results": [
    {
      "app": "custom_app",
      "site": null,
      "action": "get-app",
      "ok": true
    },
    {
      "app": "custom_app",
      "site": "a.localhost",
      "action": "install-app",
      "ok": false
    }
  ],
  "ok": false
}
_ test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-install] __
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: install_apps reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stderr call -----------------------------
  ✓ get-app custom_app
  ✗ install-app custom_app on a.localhost
Completed with errors.
_ test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-uninstall] _
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: uninstall_apps reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stderr call -----------------------------
  ✓ get-app custom_app
  ✗ install-app custom_app on a.localhost
Completed with errors.
_ test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-checkout] _
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: checkout_app reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stderr call -----------------------------
Checking out feature-branch into custom_app...
  ✓ get-app custom_app
  ✗ install-app custom_app on a.localhost
Completed with errors.
__ test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-install] __
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: install_apps reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stdout call -----------------------------
{
  "project": "proj",
  "bench": "/workspace/frappe-bench",
  "results": [
    {
      "app": "custom_app",
      "site": null,
      "action": "get-app",
      "ok": true
    },
    {
      "app": "custom_app",
      "site": "a.localhost",
      "action": "install-app",
      "ok": false
    }
  ],
  "ok": false
}
_ test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-uninstall] _
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: uninstall_apps reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stdout call -----------------------------
{
  "project": "proj",
  "bench": "/workspace/frappe-bench",
  "results": [
    {
      "app": "custom_app",
      "site": null,
      "action": "get-app",
      "ok": true
    },
    {
      "app": "custom_app",
      "site": "a.localhost",
      "action": "install-app",
      "ok": false
    }
  ],
  "ok": false
}
_ test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-checkout] __
tests/test_exit_codes_on_failure.py:178: in test_aggregating_verb_exits_non_zero_when_a_step_failed
    assert exc.value.exit_code != 0, f"{verb} reported a failed step but exited 0"
E   AssertionError: checkout_app reported a failed step but exited 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stdout call -----------------------------
{
  "project": "proj",
  "bench": "/workspace/frappe-bench",
  "results": [
    {
      "app": "custom_app",
      "site": null,
      "action": "get-app",
      "ok": true
    },
    {
      "app": "custom_app",
      "site": "a.localhost",
      "action": "install-app",
      "ok": false
    }
  ],
  "ok": false
}
____________ test_warning_status_alone_never_decides_the_exit_code _____________
tests/test_exit_codes_on_failure.py:219: in test_warning_status_alone_never_decides_the_exit_code
    assert exc.value.exit_code != 0
E   assert 0 != 0
E    +  where 0 = Exit().exit_code
E    +    where Exit() = <ExceptionInfo Exit() tblen=4>.value
----------------------------- Captured stderr call -----------------------------
  ✓ get-app custom_app
  ✗ install-app custom_app on a.localhost
Completed with errors.
=========================== short test summary info ============================
FAILED tests/test_exit_codes_on_failure.py::test_report_and_exit_exits_non_zero_when_a_step_failed[human]
FAILED tests/test_exit_codes_on_failure.py::test_report_and_exit_exits_non_zero_when_a_step_failed[json]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-install]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-uninstall]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[human-apps-checkout]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-install]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-uninstall]
FAILED tests/test_exit_codes_on_failure.py::test_aggregating_verb_exits_non_zero_when_a_step_failed[json-apps-checkout]
FAILED tests/test_exit_codes_on_failure.py::test_warning_status_alone_never_decides_the_exit_code
9 failed, 5 passed in 0.43s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv sync --frozen --all-extras` to install dev deps (pytest was missing)</code>
- <code>`uv run pytest tests/test_exit_codes_on_failure.py -v` - all 14 tests pass</code>
- <code>Manual fault-injection: changed commands/apps.py `_report_and_exit`&#39;s `raise typer.Exit(code=1)` to `code=0)`, reran the same test file - exactly 9 tests failed with the reported symptom (failure mark + &#39;Completed with errors.&#39; printed, exit_code 0)</code>
- <code>Restored commands/apps.py from backup and confirmed `git status --short` is clean</code>
- <code>Re-ran `tests/test_exit_codes_on_failure.py` after restoration - green again</code>
- <code>`uv run pytest` (full fast/unit tier, short basetemp) - 1670 passed, 94 e2e deselected, 0 failed</code>
- <code>`git diff --stat cd0d298 639d424` and `git log --oneline` - confirmed diff is test-plus-docs only (AGENTS.md, tests/test_exit_codes_on_failure.py)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
