### PR TITLE
docs(tests): replace stale test statistics with live commands

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -114,7 +114,7 @@ CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e -m e2e
 
 ### Current Status
 
-- **Coverage and suite inventory**: [tests/README.md](../tests/README.md#test-coverage) is the single source for the overall coverage number, the test/file counts, and the per-module breakdown.
+- **Coverage and suite inventory**: [tests/README.md](../tests/README.md#test-coverage) is the single source for commands that report current test and coverage totals, plus the point-in-time per-module breakdown.
 - **Target**: Expand coverage on the modules that still have none (`port_utils.py`, `vscode_utils.py`).
 
 See [Testing Directory](./testing/) for complete documentation.

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -43,7 +43,8 @@ uv run pytest tests/test_completion_utils.py
 
 ### Test Coverage
 
-The overall coverage number, the test/file counts, and the full per-module breakdown (every suite, its module, and its coverage %) live in [tests/README.md](../../tests/README.md#test-coverage) - the single source. That is also where the list of modules with no dedicated suite yet is kept.
+[tests/README.md](../../tests/README.md#test-coverage) is the single source for commands that report current test and coverage totals, plus the point-in-time per-module breakdown.
+That is also where the list of modules with no dedicated suite yet is kept.
 
 ### Test Files
 

--- a/docs/testing/guide.md
+++ b/docs/testing/guide.md
@@ -107,7 +107,7 @@ uv run pytest -x
 
 ### Current Test Coverage
 
-For the overall coverage number, the test/file counts, and the full per-module breakdown, see [tests/README.md](../../tests/README.md#test-coverage) - the single source.
+For the commands that report current test and coverage totals, plus the point-in-time per-module breakdown, see [tests/README.md](../../tests/README.md#test-coverage), the single source.
 `test_completion_utils.py` (tab completion) is a good single-module suite to model a new one on: project name completion, app name completion, site name completion, cache functionality, Docker client management.
 
 ### Test Organization
@@ -249,7 +249,7 @@ def temp_cache():
 
 - **Minimum**: 80% coverage for new code
 - **Target**: 90%+ coverage for critical paths
-- **Current**: see [tests/README.md](../../tests/README.md#test-coverage) for the current overall coverage number and per-module breakdown
+- **Current**: see [tests/README.md](../../tests/README.md#test-coverage) for the commands that report current coverage and the point-in-time per-module breakdown
 
 ### Checking Coverage
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,10 +81,14 @@ The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit
 
 ## Test Files
 
-As of 1.0.0, `tests/` holds 92 `test_*.py` suites totaling 1670 tests in the
-`unit` tier (measured with `uv run pytest --cov`). Run `ls tests/` for the
-authoritative current list; see [../docs/testing/README.md](../docs/testing/README.md)
-for the per-area breakdown.
+`tests/` holds one `test_*.py` suite per area in the `unit` tier. Counts below
+are a moving target - a suite or a test is added or removed on nearly every
+PR - so treat any number in this file as illustrative, not authoritative.
+For the current suite-file count, run `ls tests/test_*.py | wc -l`; for the
+current test count and pass/fail totals, run `uv run pytest -m unit` and read
+its own summary line (see [Reading the output](#reading-the-output) above).
+See [../docs/testing/README.md](../docs/testing/README.md) for the per-area
+breakdown.
 
 `tests/e2e/` adds more `test_*.py` suites in the real-Docker `e2e` tier
 (`test_init_e2e.py`, `test_backup_e2e.py`, `test_start_status_e2e.py`,
@@ -137,9 +141,8 @@ generic loopback once on the v16 leg, and keeps the v14-only `--receive` bare-fi
 reproduction as a separate, clearly-labeled, v14-gated test.
 
 ### `test_completion_utils.py`
-Tests for tab completion functionality.
-
-**Coverage:** 92%
+Tests for tab completion functionality. Coverage is listed under
+`utils/completion_utils.py` in [Covered Modules](#covered-modules) below.
 
 **What it tests:**
 - Project name completion from Docker
@@ -150,15 +153,24 @@ Tests for tab completion functionality.
 - Error handling
 
 **Test classes:**
-- `TestCompleteProjectNames` - 7 tests
-- `TestCompleteAppNames` - 6 tests
-- `TestCompleteSiteNames` - 4 tests
-- `TestCacheHelpers` - 4 tests
-- `TestGetDockerClient` - 3 tests
+- `TestCompleteProjectNames`
+- `TestCompleteAppNames`
+- `TestCompleteSiteNames`
+- `TestCacheHelpers`
+- `TestGetDockerClient`
+
+Run `uv run pytest tests/test_completion_utils.py -v` for the current
+per-class test counts.
 
 ## Test Coverage
 
-Current overall coverage at 1.1.0 (1728 tests across 94 test files, ~82% overall).
+Every percentage below is a snapshot from the most recent full run, not a
+promise - it drifts with every test added or removed. Regenerate the current
+overall total and the per-module breakdown with:
+
+```bash
+uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
+```
 
 ### Covered Modules
 - ✅ `utils/completion_utils.py` - 92% (7 missing lines)

--- a/tests/README.md
+++ b/tests/README.md
@@ -81,14 +81,11 @@ The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit
 
 ## Test Files
 
-`tests/` holds one `test_*.py` suite per area in the `unit` tier. Counts below
-are a moving target - a suite or a test is added or removed on nearly every
-PR - so treat any number in this file as illustrative, not authoritative.
-For the current suite-file count, run `ls tests/test_*.py | wc -l`; for the
-current test count and pass/fail totals, run `uv run pytest -m unit` and read
-its own summary line (see [Reading the output](#reading-the-output) above).
-See [../docs/testing/README.md](../docs/testing/README.md) for the per-area
-breakdown.
+`tests/` holds one `test_*.py` suite per area in the `unit` tier.
+Counts below are a moving target because a suite or a test is added or removed on nearly every PR, so treat any number in this file as illustrative, not authoritative.
+For the current suite-file count, run `ls tests/test_*.py | wc -l`.
+For the current test count and pass/fail totals, run `uv run pytest -m unit` and read its own summary line (see [Reading the output](#reading-the-output) above).
+See [../docs/testing/README.md](../docs/testing/README.md) for the per-area breakdown.
 
 `tests/e2e/` adds more `test_*.py` suites in the real-Docker `e2e` tier
 (`test_init_e2e.py`, `test_backup_e2e.py`, `test_start_status_e2e.py`,
@@ -141,8 +138,8 @@ generic loopback once on the v16 leg, and keeps the v14-only `--receive` bare-fi
 reproduction as a separate, clearly-labeled, v14-gated test.
 
 ### `test_completion_utils.py`
-Tests for tab completion functionality. Coverage is listed under
-`utils/completion_utils.py` in [Covered Modules](#covered-modules) below.
+Tests for tab completion functionality.
+Coverage is listed under `utils/completion_utils.py` in [Covered Modules](#covered-modules) below.
 
 **What it tests:**
 - Project name completion from Docker
@@ -159,14 +156,13 @@ Tests for tab completion functionality. Coverage is listed under
 - `TestCacheHelpers`
 - `TestGetDockerClient`
 
-Run `uv run pytest tests/test_completion_utils.py -v` for the current
-per-class test counts.
+Run `uv run pytest tests/test_completion_utils.py -v` for the current per-class test counts.
 
 ## Test Coverage
 
-Every percentage below is a snapshot from the most recent full run, not a
-promise - it drifts with every test added or removed. Regenerate the current
-overall total and the per-module breakdown with:
+Every percentage below is a snapshot from the most recent full run, not a promise.
+It drifts with every test added or removed.
+Regenerate the current overall total and the per-module breakdown with:
 
 ```bash
 uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing


### PR DESCRIPTION
## Intent

Stop hardcoding exact test-suite counts in cwcli's docs so they don't go stale on every test add/remove and trip the no-mistakes documentation finding on every PR. The stale hardcoded numbers lived in tests/README.md: the top-of-file totals line ('92 test_*.py suites totaling 1670 tests'), the Test Coverage summary line ('1728 tests across 94 test files, ~82% overall'), the per-file 'Coverage: 92%' line under test_completion_utils.py, and the per-class test-count breakdown list (TestCompleteProjectNames - 7 tests, etc.). Replaced each with a pointer to the live authoritative source instead of a frozen number: 'ls tests/test_*.py | wc -l' for the current suite-file count, 'uv run pytest -m unit' (reading its own summary line) for the current test count/pass-fail totals, and 'uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing' for current coverage. Left the large 'Covered Modules' / 'Modules Needing Dedicated Suites' per-module percentage list intact (deliberately not rewritten line-by-line - that would be a much larger, lower-value diff) but added a framing sentence above it stating those percentages are point-in-time snapshots from the most recent run, not authoritative constants, with the regen command to reproduce them. Deliberately did NOT touch: docs/e2e/axi-rm-destructive-lifecycle.md's '22 tests ran' line (illustrating --module behavior, not a suite-count doc-stat) and docs/contributing/git-workflow.md's '27 tests across 6 test classes' (a hypothetical example commit message template, not a live stat about the actual current suite). This is a docs-only change; no test code or behavior was modified.

## What Changed

- Replaced hardcoded suite, test, per-class, and overall coverage totals with commands that report the current values.
- Clarified that per-module coverage percentages are point-in-time snapshots and updated testing docs to point readers to the live commands.

## Risk Assessment

✅ Low: The documentation-only change is well-bounded, removes the specified stale counts, supplies authoritative regeneration commands, preserves the intentionally retained snapshot list with clear framing, and conforms to the stated exclusions.

## Testing

Verified the docs-only diff and its deliberate non-changes, exercised every newly documented live command, resolved local dependency, temp ownership, and deep-path setup constraints, captured reader-facing text evidence, and completed the unit coverage run successfully with 1,732 passing tests at 82.45% coverage. No screenshot was applicable because the change only affects Markdown documentation for a CLI.

<details>
<summary>Evidence: Updated documentation as readers see it</summary>

```text
$ sed -n 80,177p tests/README.md
The real-Docker E2E is Linux-only; Windows/macOS-specific code stays in the unit tier.

## Test Files

`tests/` holds one `test_*.py` suite per area in the `unit` tier. Counts below
are a moving target - a suite or a test is added or removed on nearly every
PR - so treat any number in this file as illustrative, not authoritative.
For the current suite-file count, run `ls tests/test_*.py | wc -l`; for the
current test count and pass/fail totals, run `uv run pytest -m unit` and read
its own summary line (see [Reading the output](#reading-the-output) above).
See [../docs/testing/README.md](../docs/testing/README.md) for the per-area
breakdown.

`tests/e2e/` adds more `test_*.py` suites in the real-Docker `e2e` tier
(`test_init_e2e.py`, `test_backup_e2e.py`, `test_start_status_e2e.py`,
`test_start_status_new_behavior_e2e.py`, `test_per_process_supervisor_e2e.py`,
`test_status_unsupervised_e2e.py`, `test_logs_orphan_tail_e2e.py`,
`test_unlock_e2e.py`, `test_label_e2e.py`, `test_axi_rm_e2e.py`,
`test_harness_safety.py`); run `ls tests/e2e/`
for the current list. They are not part of the count above since they need a
Docker daemon and are excluded from a bare `pytest`. `test_axi_rm_e2e.py` is the
permanent net for `cwcli axi rm` (`add-axi-rm-verb`): its own dedicated instance
pair (never the shared `session_instance`, since `rm` destroys what it touches)
proves the whole destructive arc in one real run - a seeded record read back
before removal, the removal's TOON outcome and exit code, an honest deletion
(no container, no volume, no project directory left), and the archived backup
genuinely restored into a fresh second instance with the same record read back
through Frappe. It runs once (the v16 leg only; the C1 gate does not vary by
Frappe major), mirroring `test_init_e2e.py`'s existing `v16_only` precedent.
`test_start_status_e2e.py` is the
lifecycle-command net (`start`/`status`/`logs`/`restart`, both modes) that pins the
outcome-level invariants the start/status core migration must preserve; it is
structure-agnostic (it asserts observable states, not `/tmp` log paths, `pkill`
patterns, or the exact status tokens) so it survives that migration unchanged.
`test_start_status_new_behavior_e2e.py` is PR 2's own net for the NEW behavior the
migration adds (per-process health, `degraded`, the idempotent single-supervisor
no-op, the relocated bounded log, the multi-bench prompt/error), on top of PR 1's net.
`test_per_process_supervisor_e2e.py` is `add-per-process-supervisor`'s own net for the
features honcho's all-or-nothing model made impossible: supervisord as the live
supervisor, `cwcli restart --process`/`cwcli axi restart --process` cycling one program
while its siblings keep their pids, auto-heal after a killed process, `cwcli logs
--process`, and the unknown-process usage error.
`test_logs_orphan_tail_e2e.py` (`cwcli-logs-orphan-tail-o5`) guards the orphan
`tail -F` regression: a non-TTY `cwcli logs --follow` (agent/pipe) Ctrl+C'd out used
to leave the exec'd tail running INSIDE the container forever (no kill-exec API,
and no `-it` raw mode to forward `^C`); it now asserts no orphan `tail -F` survives
the follower's exit in either the non-TTY or the already-clean `-it` mode.
`test_restore_e2e.py` is batch 11's full-lifecycle proof for cwcli's most destructive
path (`migrate-restore-core`): a cache-free DB-table marker (seed ORIGINAL ->
`cwcli backup` -> mutate to MUTATED -> `cwcli restore` -> assert ORIGINAL is back)
proves the restore genuinely drops-and-recreates the DB, in both the non-interactive
(`--latest --yes --mariadb-root-password`) and interactive (pty menu + destructive
confirm + credential prompts) modes, plus `--no-migrate`, the non-TTY refusals, and
the flag mutual exclusions.
`test_restore_p2p_e2e.py` is the `e2e_p2p` marker's real transport proof: it moves
REAL bytes over sendme, loopback on one box - `cwcli restore --send` serves a genuine
ticket, then the non-interactive `cwcli restore --receive --ticket <t>` pulls-and-
restores it, and the same ORIGINAL/MUTATED marker proves the data arrived (it FAILS if
the sendme transport breaks). It uses its OWN dedicated instance (never the shared
session one, so a receive DB-wipe cannot corrupt another test's fixture), runs the
generic loopback once on the v16 leg, and keeps the v14-only `--receive` bare-filename
reproduction as a separate, clearly-labeled, v14-gated test.

### `test_completion_utils.py`
Tests for tab completion functionality. Coverage is listed under
`utils/completion_utils.py` in [Covered Modules](#covered-modules) below.

**What it tests:**
- Project name completion from Docker
- App name completion from cache
- Site name completion from cache
- Cache TTL behavior
- Docker client reuse
- Error handling

**Test classes:**
- `TestCompleteProjectNames`
- `TestCompleteAppNames`
- `TestCompleteSiteNames`
- `TestCacheHelpers`
- `TestGetDockerClient`

Run `uv run pytest tests/test_completion_utils.py -v` for the current
per-class test counts.

## Test Coverage

Every percentage below is a snapshot from the most recent full run, not a
promise - it drifts with every test added or removed. Regenerate the current
overall total and the per-module breakdown with:

`` `bash
uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
`` `

### Covered Modules
- ✅ `utils/completion_utils.py` - 92% (7 missing lines)
- ✅ `utils/bench_labels.py` - ~94% (`test_bench_labels`, `test_bench_selector`, `test_bench_label_db_and_command`)
```
</details>
<details>
<summary>Evidence: Documentation acceptance checks</summary>

`Live suite count: 94. Required replacement text is present, forbidden stale statistics are absent, and both deliberate non-changes remain.`

```text
$ ls tests/test_*.py | wc -l
94

$ git diff --name-only 21e4afba5a11ab7372c962f997006b4378b72073 5af25fd675b0a8edac018c67aaf3f9bc6d28193c
tests/README.md

$ required replacement and deliberate preservation checks
87:For the current suite-file count, run `ls tests/test_*.py | wc -l`; for the
167:Every percentage below is a snapshot from the most recent full run, not a
172:uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing
149:Two things this proves that could not be assumed: `bench` **accepts `--app` and `--module` together** (a real risk, since the flag was added on the reading of frappe's runner), and the narrowing is genuine - 22 tests ran where the frappe app's full suite runs thousands. The first attempt returned `Testing is disabled for the site!`, so `allow_tests` was set on the site and the run repeated; cwcli forwarded bench's own exit code honestly in both cases.
274:- 27 tests across 6 test classes

$ forbidden stale live-stat checks (no output expected)
```
</details>
<details>
<summary>Evidence: Live coverage regeneration</summary>

<code>coverage: 82.45%&#10;1732 passed, 104 deselected, 2 warnings in 21.69s</code>

```text
tests/test_agent_hooks.py                                 PASS    0.04s
tests/test_apps.py                                        PASS    3.70s
tests/test_apps_characterization.py                       PASS    0.02s
tests/test_auto_inspect.py                                PASS    2.20s
tests/test_axi.py                                         PASS    0.30s
tests/test_axi_apps_checkout.py                           PASS    0.01s
tests/test_axi_apps_list.py                               PASS    0.01s
tests/test_axi_apps_update.py                             PASS    0.03s
tests/test_axi_bench_ops.py                               PASS    0.02s
tests/test_axi_config.py                                  PASS    0.04s
tests/test_axi_init.py                                    PASS    0.25s
tests/test_axi_inspect.py                                 PASS    0.07s
tests/test_axi_label.py                                   PASS    0.10s
tests/test_axi_logs.py                                    PASS    0.01s
tests/test_axi_restart.py                                 PASS    0.04s
tests/test_axi_rm.py                                      PASS    0.01s
tests/test_axi_skill.py                                   PASS    0.01s
tests/test_axi_start_status.py                            PASS    0.11s
tests/test_axi_unlock_stop.py                             PASS    0.09s
tests/test_backup_command_cap.py                          PASS    0.00s
tests/test_bench_label_db_and_command.py                  PASS    0.31s
tests/test_bench_labels.py                                PASS    0.01s
tests/test_bench_selector.py                              PASS    0.01s
tests/test_completion_utils.py                            PASS    2.62s
tests/test_config_characterization.py                     PASS    0.96s
tests/test_config_frontend.py                             PASS    0.95s
tests/test_config_validation.py                           PASS    0.01s
tests/test_core_apps.py                                   PASS    0.02s
tests/test_core_auto_inspect.py                           PASS    0.04s
tests/test_core_backup.py                                 PASS    0.01s
tests/test_core_bench_ops.py                              PASS    0.01s
tests/test_core_config.py                                 PASS    0.02s
tests/test_core_credbridge.py                             PASS    2.37s
tests/test_core_docker.py                                 PASS    0.00s
tests/test_core_envelope.py                               PASS    0.80s
tests/test_core_exec_stream.py                            PASS    0.03s
tests/test_core_init.py                                   PASS    0.06s
tests/test_core_inspect.py                                PASS    0.02s
tests/test_core_label.py                                  PASS    0.46s
tests/test_core_list.py                                   PASS    0.00s
tests/test_core_logs.py                                   PASS    0.01s
tests/test_core_open.py                                   PASS    0.01s
tests/test_core_resolvers.py                              PASS    0.01s
tests/test_core_restart.py                                PASS    0.01s
tests/test_core_restore.py                                PASS    0.02s
tests/test_core_rm.py                                     PASS    0.02s
tests/test_core_run.py                                    PASS    0.11s
tests/test_core_scale.py                                  PASS    0.02s
tests/test_core_start.py                                  PASS    0.01s
tests/test_core_status.py                                 PASS    0.01s
tests/test_core_stop.py                                   PASS    0.01s
tests/test_core_supervision.py                            PASS    0.08s
tests/test_core_unlock.py                                 PASS    0.01s
tests/test_core_update.py                                 PASS    0.07s
tests/test_core_version.py                                PASS    0.03s
tests/test_core_where.py                                  PASS    0.24s
tests/test_cwcli_home.py                                  PASS    0.44s
tests/test_db_security.py                                 PASS    0.09s
tests/test_exec_stream_decode.py                          PASS    0.01s
tests/test_exit_codes.py                                  PASS    0.02s
tests/test_exit_codes_on_failure.py                       PASS    0.02s
tests/test_init_admin_password.py                         PASS    0.11s
tests/test_init_characterization.py                       PASS    0.50s
tests/test_init_frappe_version.py                         PASS    0.18s
tests/test_init_mariadb_flag.py                           PASS    0.00s
tests/test_init_reuse_bench.py                            PASS    0.19s
tests/test_inspect_apps_error.py                          PASS    0.00s
tests/test_inspect_characterization.py                    PASS    0.07s
tests/test_inspect_label_recovery.py                      PASS    0.00s
tests/test_inspect_partial_refresh.py                     PASS    0.01s
tests/test_list.py                                        PASS    0.01s
tests/test_logs.py                                        PASS    0.03s
tests/test_open_characterization.py                       PASS    0.02s
tests/test_open_inspect_fallback.py                       PASS    0.00s
tests/test_restore_characterization.py                    PASS    0.01s
tests/test_restore_inspect_fixes.py                       PASS    0.05s
tests/test_restore_safety.py                              PASS    0.03s
tests/test_rm_characterization.py                         PASS    0.11s
tests/test_rm_safety.py                                   PASS    0.23s
tests/test_rm_stopped.py                                  PASS    0.04s
tests/test_rm_stopped_backup.py                           PASS    0.05s
tests/test_rm_truth.py                                    PASS    0.02s
tests/test_self_update.py                                 PASS    0.02s
tests/test_sendme_utils.py                                PASS    0.04s
tests/test_status_frontend.py                             PASS    0.01s
tests/test_status_watch.py                                PASS    0.01s
tests/test_tips.py                                        PASS    0.46s
tests/test_unlock.py                                      PASS    0.00s
tests/test_unlock_command_cli.py                          PASS    0.00s
tests/test_update_characterization.py                     PASS    0.19s
tests/test_update_notice.py                               PASS    0.00s
tests/test_version_output.py                              PASS    0.02s
tests/test_where.py                                       PASS    0.10s
tests/test_yes_flag.py                                    PASS    0.02s

=============================== warnings summary ===============================
tests/test_core_restore.py::TestCopyOut::test_streams_via_get_archive
  /home/cmckay/.no-mistakes/worktrees/c9173c2bc95d/01KY3XEFQ0QZE9ZB2TGXCP14WG/src/caffeinated_whale_cli/core/restore.py:966: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    tar.extract(member, dest_dir)

tests/test_sendme_utils.py::test_install_success_extracts_and_installs_tar
  /home/cmckay/.no-mistakes/worktrees/c9173c2bc95d/01KY3XEFQ0QZE9ZB2TGXCP14WG/src/caffeinated_whale_cli/utils/sendme_utils.py:231: DeprecationWarning: Python 3.14 will, by default, filter extracted tar archives and reject files or modify their metadata. Use the filter argument to control this behavior.
    tar_ref.extractall(temp_path)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
coverage: 82.45%
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.13.14-final-0 _______________

Name                                                  Stmts   Miss   Cover   Missing
------------------------------------------------------------------------------------
src/caffeinated_whale_cli/commands/apps.py              155      5  96.77%   88, 370-371, 466-467
src/c

... [588 bytes truncated] ...

 267     22  91.76%   123, 154-155, 157, 168, 205-207, 217-223, 226-228, 252, 628-636, 681
src/caffeinated_whale_cli/commands/inspect.py           122     27  77.87%   53-59, 69-78, 127, 145-146, 163-167, 199-204, 215, 226, 263
src/caffeinated_whale_cli/commands/label.py              66      9  86.36%   101-102, 114-117, 131-132, 138-140
src/caffeinated_whale_cli/commands/list.py               66     13  80.30%   27, 39-44, 48, 84, 95-99, 128, 132, 135
src/caffeinated_whale_cli/commands/logs.py               95     17  82.11%   113-123, 125, 139-141, 183, 240-241, 255-262
src/caffeinated_whale_cli/commands/open.py               87     17  80.46%   74, 160, 191-201, 207-214, 224, 230, 239
src/caffeinated_whale_cli/commands/restart.py           151     90  40.40%   37-56, 108, 110-112, 114, 116-118, 120, 127-128, 131-134, 137-138, 159-164, 174-186, 193-219, 224-240, 245-251, 256-260
src/caffeinated_whale_cli/commands/restore.py           453    206  54.53%   66-79, 95, 98-120, 141-143, 145-146, 155-157, 178-183, 194-197, 200, 203, 225-230, 233-237, 240-244, 281, 297-299, 389-390, 421, 424, 432-452, 499-505, 513-514, 562-580, 634-635, 645, 648-659, 666-667, 669, 673-674, 676-678, 717-816, 949-950, 953-957, 966, 979
src/caffeinated_whale_cli/commands/rm.py                254     27  89.37%   56, 135, 140, 368-369, 372-375, 427, 430, 474-477, 495-496, 528-536, 569-573, 576-580
src/caffeinated_whale_cli/commands/run.py                54      2  96.30%   67, 119
src/caffeinated_whale_cli/commands/scale.py              58     45  22.41%   26-51, 91-117, 127-144
src/caffeinated_whale_cli/commands/self_update.py        50      0 100.00%
src/caffeinated_whale_cli/commands/start.py             262    112  57.25%   50-54, 57, 66-68, 71, 81-86, 112-116, 152-158, 163, 171-203, 206-237, 251-262, 270-274, 307, 327-328, 334, 343-351, 415, 417, 419, 421, 423-425, 427, 434-435, 438-441, 463-468, 521-541, 549-551, 559-561
src/caffeinated_whale_cli/commands/status.py            103      7  93.20%   93-98, 136-139, 206
src/caffeinated_whale_cli/commands/stop.py               62     20  67.74%   42, 48-49, 52-55, 69, 84, 90, 112-126
src/caffeinated_whale_cli/commands/unlock.py             64     32  50.00%   64, 73-74, 84-94, 101-102, 108-111, 114-121, 127-128, 133-148
src/caffeinated_whale_cli/commands/update.py            216     28  87.04%   226, 266, 420, 428-429, 468-501
src/caffeinated_whale_cli/commands/utils.py             132     54  59.09%   60, 74, 78, 89, 118-120, 123-124, 192, 205-207, 225, 237-266, 298-300, 325-353
src/caffeinated_whale_cli/commands/where.py              61      0 100.00%
src/caffeinated_whale_cli/core/apps.py                  230      6  97.39%   151, 411, 510-512, 687
src/caffeinated_whale_cli/core/auto_inspect.py          105      0 100.00%
src/caffeinated_whale_cli/core/backup.py                 61      2  96.72%   36, 139
src/caffeinated_whale_cli/core/bench_ops.py             114      2  98.25%   426, 430
src/caffeinated_whale_cli/core/config.py                 80      0 100.00%
src/caffeinated_whale_cli/core/credbridge.py            107      1  99.07%   173
src/caffeinated_whale_cli/core/docker.py                 74     18  75.68%   70-71, 89-99, 112-115, 131-132, 134, 183-184
src/caffeinated_whale_cli/core/envelope.py               27      0 100.00%
src/caffeinated_whale_cli/core/errors.py                 18      0 100.00%
src/caffeinated_whale_cli/core/exec_stream.py            64      2  96.88%   108-109
src/caffeinated_whale_cli/core/init.py                  399     32  91.98%   274, 440, 653-654, 671-672, 677-678, 697-698, 705-706, 714-715, 720-737, 802, 873-879, 939
src/caffeinated_whale_cli/core/inspect.py               258     10  96.12%   237, 292-294, 314-316, 588, 624, 737
src/caffeinated_whale_cli/core/label.py                 129      4  96.90%   195, 203, 302, 378
src/caffeinated_whale_cli/core/list.py                   44      0 100.00%
src/caffeinated_whale_cli/core/logs.py                  153      3  98.04%   416, 432, 445
src/caffeinated_whale_cli/core/open.py                  103      0 100.00%
src/caffeinated_whale_cli/core/resolvers.py              93      2  97.85%   200-201
src/caffeinated_whale_cli/core/restart.py                55      3  94.55%   67, 92-93
src/caffeinated_whale_cli/core/restore.py               456     58  87.28%   146, 168-169, 210, 212, 263, 277, 296-297, 308, 314, 345, 348-349, 375-376, 405, 425-431, 433, 504, 506, 526, 552, 554, 560-567, 637, 641, 643, 649-656, 675-676, 829, 833, 841, 850-858, 898-900, 906, 918-920, 941, 969-972
src/caffeinated_whale_cli/core/rm.py                    415     35  91.57%   157-158, 175, 260, 263, 278, 299-300, 334-336, 374-375, 402-405, 425-427, 443-447, 463-470, 473, 632, 679-680
src/caffeinated_whale_cli/core/run.py                    34      0 100.00%
src/caffeinated_whale_cli/core/scale.py                 231     26  88.74%   158, 228-229, 231, 236-237, 299-309, 333, 357, 367-374, 391, 452, 529, 545-546
src/caffeinated_whale_cli/core/start.py                  72      2  97.22%   125, 145
src/caffeinated_whale_cli/core/status.py                108      7  93.52%   165-166, 174-175, 284, 294-295
src/caffeinated_whale_cli/core/stop.py                   25      0 100.00%
src/caffeinated_whale_cli/core/supervision.py           397     71  82.12%   190, 200, 205, 208, 213-214, 231-232, 238-239, 250, 260, 263, 273, 284, 341, 344, 352, 362, 371, 396, 451, 484-487, 503, 508, 545, 548-549, 761, 786-845
src/caffeinated_whale_cli/core/unlock.py                 57      1  98.25%   48
src/caffeinated_whale_cli/core/update.py                266      7  97.37%   174, 396, 448-449, 834-841
src/caffeinated_whale_cli/core/version.py               187     24  87.17%   158-173, 177-179, 233-251, 296, 299-300, 361-362, 396-397
src/caffeinated_whale_cli/core/where.py                  89      1  98.88%   177
src/caffeinated_whale_cli/main.py                        72      1  98.61%   134
src/caffeinated_whale_cli/update_notice.py               22      0 100.00%
src/caffeinated_whale_cli/utils/agent_hooks.py          125      0 100.00%
src/caffeinated_whale_cli/utils/auto_inspect.py         246    118  52.03%   63-88, 108-142, 152-166, 244-248, 253-268, 280, 288-305, 346-349, 390-440, 461-468, 503, 507-517
src/caffeinated_whale_cli/utils/bench_labels.py          86      5  94.19%   152, 155, 161, 198-199
src/caffeinated_whale_cli/utils/bench_sites.py           36      6  83.33%   49-51, 79-81, 105-106
src/caffeinated_whale_cli/utils/cache.py                  9      1  88.89%   42
src/caffeinated_whale_cli/utils/completion_utils.py      90      7  92.22%   112-114, 136, 184, 198, 211-212
src/caffeinated_whale_cli/utils/config_utils.py          90     24  73.33%   88, 90, 92, 98, 100, 102, 104-105, 126, 131-136, 150-155, 161, 164, 174, 201
src/caffeinated_whale_cli/utils/console.py                3      0 100.00%
src/caffeinated_whale_cli/utils/db_utils.py             282     75  73.40%   29-32, 183, 225-228, 243, 262, 288-289, 334-337, 378-381, 404-406, 417-419, 444, 458, 481, 504-505, 517-518, 543-544, 552-554, 574-604, 618-641, 661-665
src/caffeinated_whale_cli/utils/docker_utils.py          41     14  65.85%   30-32, 38-48, 108-114
src/caffeinated_whale_cli/utils/port_utils.py           163    134  17.79%   37, 45-65, 78-109, 125-168, 218-221, 241-327, 343-356
src/caffeinated_whale_cli/utils/sendme_utils.py         213     24  88.73%   37, 57-59, 242-245, 265-271, 298-321, 354, 362-365
src/caffeinated_whale_cli/utils/startup.py              121     93  23.14%   26-38, 46, 49-52, 57-66, 71-80, 90, 95, 100-138, 143-154, 174-224, 229-250, 260-268, 273-296, 301-309
src/caffeinated_whale_cli/utils/tips.py                  69      6  91.30%   164-172
src/caffeinated_whale_cli/utils/toon.py                 110      5  95.45%   30, 32, 46, 50, 132
src/caffeinated_whale_cli/utils/vscode_utils.py         103     88  14.56%   18-31, 36-49, 56-82, 87, 94, 101, 116-194
------------------------------------------------------------------------------------
TOTAL                                                 10204   1791  82.45%
1732 passed, 104 deselected, 2 warnings in 21.69s
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --check 21e4afba5a11ab7372c962f997006b4378b72073 5af25fd675b0a8edac018c67aaf3f9bc6d28193c`
- <code>Reviewed the complete base-to-target diff and verified only `tests/README.md` changed</code>
- `ls tests/test_*.py | wc -l`
- <code>Searched `tests/README.md` for every required replacement and forbidden stale statistic with `rg`</code>
- <code>Verified the preserved `22 tests ran` and `27 tests across 6 test classes` examples with `rg`</code>
- `uv sync --extra dev`
- <code>`uv run pytest -m unit` with environment retries to diagnose missing test dependencies, foreign `/tmp` ownership, and deep-worktree Unix socket limits</code>
- `Targeted the two socket tests through a short-path compatibility shim; both passed`
- <code>`uv run pytest -m unit --cov=caffeinated_whale_cli --cov-report=term-missing` with the scoped short-path shim; full run passed</code>
- <code>Removed `.venv`, `.pytest-tmp`, `.pytest_cache`, and `.coverage`, then confirmed the worktree matches target commit `5af25fd675b0a8edac018c67aaf3f9bc6d28193c`</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
