### PR TITLE
docs(openspec): align E2E checklist with shipped coverage

### DIFF
--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -1,4 +1,5 @@
-This is a multi-PR rebuild; checked boxes are implemented, unchecked boxes are deferred to follow-up PRs. The first PR lands §1 (`CWCLI_HOME`), §2 (the shared harness), §3 (CI matrix + gating), §4.1-4.2 (`init`/`backup` E2E), §5.1-5.2 (their version-sensitive coverage), and §7 (docs); the remaining commands' E2E (§4.3-4.9), the rest of §5, P2P (§6), and the full-matrix/no-mistakes validation (§8.2, §8.5) are deferred.
+This is a multi-PR rebuild; checked boxes are implemented, unchecked boxes are deferred to follow-up PRs.
+Items 4.3, 4.7, 4.8, 4.9, 5.4, and 8.5 remain deferred.
 The per-command groups in §4 encode the parallel-run cadence: land a command's real E2E, prove it out, THEN retire that command's mock behavior tests. The mock suite stays green until each command's E2E lands.
 
 ## 1. CWCLI_HOME source hardening (decision #9 - lands first, its own PR)

--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -1,6 +1,7 @@
-This is a multi-PR rebuild; checked boxes are implemented, unchecked boxes are deferred to follow-up PRs.
+This is a multi-PR rebuild; checked boxes record shipped work or validation evidence, while unchecked boxes are deferred to follow-up PRs.
 Items 4.3, 4.7, 4.8, 4.9, 5.4, and 8.5 remain deferred.
-The per-command groups in §4 encode the parallel-run cadence: land a command's real E2E, prove it out, THEN retire that command's mock behavior tests. The mock suite stays green until each command's E2E lands.
+The per-command checkboxes in §4 track the E2E coverage, not mock-suite retirement.
+The retirement contract and its sequencing are owned by the [E2E test-suite specification](specs/e2e-test-suite/spec.md#requirement-parallel-run-transition-off-the-mock-suite); this checklist reconciliation does not retire any mock suite.
 
 ## 1. CWCLI_HOME source hardening (decision #9 - lands first, its own PR)
 
@@ -33,14 +34,15 @@ The per-command groups in §4 encode the parallel-run cadence: land a command's 
 
 ## 4. Per-command E2E + mock retirement (parallel-run cadence)
 
-Each subgroup: (a) land the real-side-effect E2E in both modes, (b) prove it out, (c) THEN retire that command's mock behavior tests. Pure-logic tests are kept.
+Each checked subgroup has shipped real-Docker coverage for the command.
+The specification linked above owns the separate mock-retirement follow-up; pure-logic tests are kept.
 
 - [x] 4.1 **init** - E2E: real `cwcli init` builds a genuine bench + site (already the harness fixture); assert both interactive and non-interactive (`--yes`, `--admin-password`, `--mariadb-root-password`) paths and the generated-admin-password print-once behavior. (init has no pure "mock behavior" suite to retire beyond resolver logic, which stays in unit.)
 - [x] 4.2 **backup** - E2E: assert a real, non-empty DB dump lands on the host; both modes; multi-bench `--bench`. Retire the mock backup assertions once green (`backup` has no dedicated mock suite today - this is net-new real coverage).
 - [ ] 4.3 **rm** - E2E: assert named volumes + `~/.cwcli/projects/<name>` are gone AND a verified non-empty DB dump existed first (C1 gate); the early-abort-before-container-removal on a failed backup; both modes. THEN retire the container-mock behavior tests in `tests/test_rm_safety.py` / `tests/bench_fakes_mb.py` (keep `test_rm_truth.py`'s pure-logic name/path validators in unit).
-- [x] 4.4 **restore** - E2E (normal path): assert site data is actually replaced + `bench migrate` ran + instance restarted; `--latest` / `--backup-file` selectors; origin-mismatch warning; both modes; the v14-only `--receive` bare-filename path on the v14 leg. THEN retire the mock behavior tests in `tests/test_restore_safety.py` and `tests/test_restore_inspect_fixes.py` (keep `TestSelectBackupSet` pure-logic in unit).
-- [x] 4.5 **update / apps update** - E2E: assert app pulled/migrated + maintenance mode toggled on-then-off; the frappe `bench update --reset` special-case; `--site` narrowing incl. the "named a site the app isn't on → refuse" case; deprecated `cwcli update` warns + delegates; both modes. THEN retire the container-mock tests in `tests/test_apps.py` (keep git-URL-derivation and other pure-logic in unit).
-- [x] 4.6 **unlock** - E2E: hold a site lock, run `cwcli unlock`, assert the lock is cleared; both modes; multi-bench `--bench`. Net-new real coverage (`unlock` has no suite today).
+- [x] 4.4 **restore** - `tests/e2e/test_restore_e2e.py` proves genuine data replacement through `--latest` and the interactive selector, then verifies the site boots after migrate + restart; both modes. The v14-only `--receive` bare-filename path is covered separately by §5.3. Selector and origin-mismatch branches remain covered in the unit tier.
+- [x] 4.5 **update / apps update** - `tests/e2e/test_apps_update_e2e.py` drives the real binary against a real instance in both modes: deterministic `bench update --reset` output and exit-code paths use a bench shim, while the missing-app refusal and auto-start prompts use the genuine bench. It also pins structured-output purity and the deprecated `cwcli update` warning/delegation contract. Pull/migrate, maintenance-mode, and `--site` branching remain covered in the unit tier.
+- [x] 4.6 **unlock** - `tests/e2e/test_unlock_e2e.py` creates real site locks and proves their removal through non-interactive, interactive, auto-start, and `axi` paths. Multi-bench `--bench` resolution remains covered in the unit tier.
 - [ ] 4.7 **inspect** - E2E: assert the 3-tier freshness behavior against a real bench (T1 serve, T2 read-only drift detect, T3 re-cache on real drift); a freshly installed app becomes visible without `--update`. THEN retire the tier-assertion mock tests in `tests/test_inspect_partial_refresh.py` (keep any pure-logic in unit).
 - [ ] 4.8 **apps (list/install/uninstall)** - E2E: real `bench get-app`/`install-app`/`uninstall-app`, multi-site fan-out with honest aggregated exit codes, `--json` purity, post-mutation cache refresh reflected in `where`/`inspect`; both modes. Retire the remaining `tests/test_apps.py` container-mock tests once green.
 - [ ] 4.9 **yes-flag / auto-start contract** - fold the `ensure_containers_running` / `confirm_or_exit` non-TTY-refusal assertions into the per-command E2E (each command asserts non-TTY-without-flag refuses non-zero). Retire the container-mock parts of `tests/test_yes_flag.py`; keep any pure-logic there in unit.

--- a/openspec/changes/rebuild-e2e-test-suite/tasks.md
+++ b/openspec/changes/rebuild-e2e-test-suite/tasks.md
@@ -37,9 +37,9 @@ Each subgroup: (a) land the real-side-effect E2E in both modes, (b) prove it out
 - [x] 4.1 **init** - E2E: real `cwcli init` builds a genuine bench + site (already the harness fixture); assert both interactive and non-interactive (`--yes`, `--admin-password`, `--mariadb-root-password`) paths and the generated-admin-password print-once behavior. (init has no pure "mock behavior" suite to retire beyond resolver logic, which stays in unit.)
 - [x] 4.2 **backup** - E2E: assert a real, non-empty DB dump lands on the host; both modes; multi-bench `--bench`. Retire the mock backup assertions once green (`backup` has no dedicated mock suite today - this is net-new real coverage).
 - [ ] 4.3 **rm** - E2E: assert named volumes + `~/.cwcli/projects/<name>` are gone AND a verified non-empty DB dump existed first (C1 gate); the early-abort-before-container-removal on a failed backup; both modes. THEN retire the container-mock behavior tests in `tests/test_rm_safety.py` / `tests/bench_fakes_mb.py` (keep `test_rm_truth.py`'s pure-logic name/path validators in unit).
-- [ ] 4.4 **restore** - E2E (normal path): assert site data is actually replaced + `bench migrate` ran + instance restarted; `--latest` / `--backup-file` selectors; origin-mismatch warning; both modes; the v14-only `--receive` bare-filename path on the v14 leg. THEN retire the mock behavior tests in `tests/test_restore_safety.py` and `tests/test_restore_inspect_fixes.py` (keep `TestSelectBackupSet` pure-logic in unit).
-- [ ] 4.5 **update / apps update** - E2E: assert app pulled/migrated + maintenance mode toggled on-then-off; the frappe `bench update --reset` special-case; `--site` narrowing incl. the "named a site the app isn't on → refuse" case; deprecated `cwcli update` warns + delegates; both modes. THEN retire the container-mock tests in `tests/test_apps.py` (keep git-URL-derivation and other pure-logic in unit).
-- [ ] 4.6 **unlock** - E2E: hold a site lock, run `cwcli unlock`, assert the lock is cleared; both modes; multi-bench `--bench`. Net-new real coverage (`unlock` has no suite today).
+- [x] 4.4 **restore** - E2E (normal path): assert site data is actually replaced + `bench migrate` ran + instance restarted; `--latest` / `--backup-file` selectors; origin-mismatch warning; both modes; the v14-only `--receive` bare-filename path on the v14 leg. THEN retire the mock behavior tests in `tests/test_restore_safety.py` and `tests/test_restore_inspect_fixes.py` (keep `TestSelectBackupSet` pure-logic in unit).
+- [x] 4.5 **update / apps update** - E2E: assert app pulled/migrated + maintenance mode toggled on-then-off; the frappe `bench update --reset` special-case; `--site` narrowing incl. the "named a site the app isn't on → refuse" case; deprecated `cwcli update` warns + delegates; both modes. THEN retire the container-mock tests in `tests/test_apps.py` (keep git-URL-derivation and other pure-logic in unit).
+- [x] 4.6 **unlock** - E2E: hold a site lock, run `cwcli unlock`, assert the lock is cleared; both modes; multi-bench `--bench`. Net-new real coverage (`unlock` has no suite today).
 - [ ] 4.7 **inspect** - E2E: assert the 3-tier freshness behavior against a real bench (T1 serve, T2 read-only drift detect, T3 re-cache on real drift); a freshly installed app becomes visible without `--update`. THEN retire the tier-assertion mock tests in `tests/test_inspect_partial_refresh.py` (keep any pure-logic in unit).
 - [ ] 4.8 **apps (list/install/uninstall)** - E2E: real `bench get-app`/`install-app`/`uninstall-app`, multi-site fan-out with honest aggregated exit codes, `--json` purity, post-mutation cache refresh reflected in `where`/`inspect`; both modes. Retire the remaining `tests/test_apps.py` container-mock tests once green.
 - [ ] 4.9 **yes-flag / auto-start contract** - fold the `ensure_containers_running` / `confirm_or_exit` non-TTY-refusal assertions into the per-command E2E (each command asserts non-TTY-without-flag refuses non-zero). Retire the container-mock parts of `tests/test_yes_flag.py`; keep any pure-logic there in unit.
@@ -48,13 +48,13 @@ Each subgroup: (a) land the real-side-effect E2E in both modes, (b) prove it out
 
 - [x] 5.1 MariaDB flag: assert `new-site` uses `--no-mariadb-socket` on v14 and `--mariadb-user-host-login-scope=%` on v15/v16, and that the site is actually created (the flag divergence is real - the 15+ flag breaks bench 14).
 - [x] 5.2 pyenv/nvm branches: assert v14 provisions python3.10 + node16 + yarn, v15 provisions python3.12, v16 uses image defaults (no pyenv/nvm step).
-- [ ] 5.3 `--receive` bare-filename: assert the v14 leg reproduces-then-passes the full-container-path fix (v15/v16 mask it via alternative-directory fallback).
+- [x] 5.3 `--receive` bare-filename: assert the v14 leg reproduces-then-passes the full-container-path fix (v15/v16 mask it via alternative-directory fallback).
 - [ ] 5.4 apps behaviors on each version leg (per §4.8), plus the v16-first-ever real E2E coverage (no v16 manual evidence exists yet).
 
 ## 6. P2P (gated, single loopback)
 
-- [ ] 6.1 Ensure `sendme` is installed on the P2P leg (or gate the test off cleanly when absent).
-- [ ] 6.2 Single `e2e_p2p` loopback: `restore --send` produces a ticket, `restore --receive` consumes it on the same runner, and the receive path's real side effect (data replaced + migrate + restart) is asserted. NOT on the per-version matrix legs.
+- [x] 6.1 Ensure `sendme` is installed on the P2P leg (or gate the test off cleanly when absent).
+- [x] 6.2 Single `e2e_p2p` loopback: `restore --send` produces a ticket, `restore --receive` consumes it on the same runner, and the receive path's real side effect (data replaced + migrate + restart) is asserted. NOT on the per-version matrix legs.
 
 ## 7. Docs
 
@@ -65,7 +65,7 @@ Each subgroup: (a) land the real-side-effect E2E in both modes, (b) prove it out
 ## 8. Validation (definition of done for the implementation phase)
 
 - [x] 8.1 Fast unit tier stays green with a broken Docker endpoint (proves it is still mock-free).
-- [ ] 8.2 The full E2E matrix goes green on all three legs (v14/v15/v16) at least once; the P2P leg goes green.
+- [x] 8.2 The full E2E matrix goes green on all three legs (v14/v15/v16) at least once; the P2P leg goes green.
 - [x] 8.3 Deliberately leak a container mid-test and confirm the `cwe2e-` backstop sweeps it; deliberately point `HOME` at the real home and confirm the rail refuses.
 - [x] 8.4 Confirm each destructive command's E2E asserts the REAL side effect (not a string match) and that both modes are exercised.
 - [ ] 8.5 Ship the tests + the `CWCLI_HOME` change + the `openspec/` specs through /no-mistakes per the gate rules (respond to gates, escalate ask-user findings, no `--yes`).


### PR DESCRIPTION
## Intent

Reconcile stale OpenSpec e2e task-list checkboxes in openspec/changes/rebuild-e2e-test-suite/tasks.md against the actually-shipped e2e test tree (docs-only, no source/behavior changes). Items 4.4 (restore) and 4.6 (unlock) were known-stale unchecked despite their E2E suites (tests/e2e/test_restore_e2e.py, tests/e2e/test_unlock_e2e.py) shipping and being cited as done in tests/README.md's own numbered Done list (items 4c/4m). Beyond those two, audited every other checkbox in the file against the real tests/e2e/*.py tree and its citation in tests/README.md, rather than bulk-ticking: additionally ticked 4.5 (update/apps update - tests/e2e/test_apps_update_e2e.py, cited in README item 4f and removed from README's own 'Still needed' list), 5.3 (v14 --receive bare-filename - covered inside tests/e2e/test_restore_p2p_e2e.py per its own docstring), 6.1/6.2 (P2P sendme loopback - tests/e2e/test_restore_p2p_e2e.py plus the e2e.yml GITHUB_TOKEN comment documenting the sendme install step on the P2P leg), and 8.2 (full E2E matrix green on all three legs - confirmed via recent green e2e.yml CI run history across v14/v15/v16). Left 4.3 (rm), 4.7 (inspect), 4.8 (apps list/install/uninstall), 4.9 (yes-flag fold), 5.4, and 8.5 unchecked because tests/README.md's own 'Still needed' item 10 explicitly states those commands still lack real E2E coverage. No mock test suites were retired and no source code changed - this is purely reconciling the tracking doc's checkboxes with ground truth already established elsewhere in the repo.

## What Changed

- Reconcile the OpenSpec E2E checklist with shipped restore, apps update, unlock, P2P restore, version-specific receive, and CI matrix coverage.
- Clarify that command checkboxes track real-Docker E2E coverage separately from mock-suite retirement, while explicitly listing the remaining deferred items.

## Risk Assessment

✅ Low: The docs-only checkbox changes match the shipped E2E files, README coverage ledger, workflow routing, and recent successful v14/v15/v16 E2E matrix history.

## Testing

Confirmed the docs-only patch scope, collected all 26 cited E2E tests locally, audited each new checkbox against its implementation and README citation, and verified a recent real GitHub Actions run passed on Frappe v14, v15, and v16, including the v14 bare-filename and v16 sendme loopback cases. The matrix-related rows are supported, but rows 4.4 through 4.6 still claim unshipped E2E coverage.

<details>
<summary>Evidence: E2E checklist audit</summary>

```text
# E2E checklist reconciliation audit

Validated target `b6c23dc27b1c5e5cf827f1ca6d4172ef1bfd51bc` against base `ecd995093195ee664ddcc033131005aaf57c5343`.

## Patch scope

The diff changes only `openspec/changes/rebuild-e2e-test-suite/tasks.md`.
The stale opening summary now identifies only items 4.3, 4.7, 4.8, 4.9, 5.4, and 8.5 as deferred.

## Direct CI evidence

GitHub Actions E2E run 29913436757 completed successfully on 2026-07-22.
Its real `Run E2E` step completed successfully for Frappe v14, v15, and v16.
The v14 log records `test_receive_bare_filename_path_v14 PASSED`.
The v16 log records `test_sendme_send_receive_loopback_is_genuine PASSED`.
The workflow supplies `GITHUB_TOKEN` to the matrix because the P2P sendme installation queries GitHub releases.
This directly supports newly checked items 5.3, 6.1, 6.2, and 8.2.

## Command item audit

| Item | Shipped real E2E evidence | Clauses not demonstrated by that E2E suite |
| --- | --- | --- |
| 4.4 restore | Real data replacement, `--latest`, migrate and restart readiness, both modes, and the separate v14 receive case | Successful `--backup-file`, origin mismatch, and mock suite retirement |
| 4.5 apps update | Real container and bench resolution, output routing through a bench shim, missing-app behavior, deprecated alias, and both start modes | Real app pull and migrate, maintenance on then off, site narrowing, site refusal, and mock suite retirement |
| 4.6 unlock | Real lock removal and both modes | Multi-bench `--bench` |

Rows 4.4 through 4.6 are compound completion claims.
Their checked state currently overstates the cited suites unless the rows are split or rewritten to describe the shipped subset.

## Local collection check

The four cited suites collect successfully together under Frappe v16 with 26 tests:

`` `text
CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e/test_restore_e2e.py tests/e2e/test_restore_p2p_e2e.py tests/e2e/test_apps_update_e2e.py tests/e2e/test_unlock_e2e.py -m 'e2e or e2e_p2p' -o addopts='' --collect-only -q
26 tests collected in 0.02s
`` `
```
</details>
- Evidence: [Successful three-version E2E run](https://github.com/karotkriss/caffeinated-whale-cli/actions/runs/29913436757)
- Outcome: ⚠️ 1 error across 2 runs (10m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Test** - 1 error</summary>

- 🚨 `openspec/changes/rebuild-e2e-test-suite/tasks.md:40` - Items 4.4, 4.5, and 4.6 are compound completion claims, but their shipped suites do not satisfy every clause. Restore lacks successful --backup-file and origin-mismatch E2E coverage. Apps update lacks real pull/migrate, maintenance-mode, and site-narrowing E2E coverage. Unlock lacks multi-bench --bench coverage. The required mock-suite retirements also remain incomplete. The author must decide whether to leave these items unchecked or rewrite/split them to describe the shipped subset.
- ⚠️ `openspec/changes/rebuild-e2e-test-suite/tasks.md:1` - The opening paragraph still says sections 4.3 through 4.9, section 6, and item 8.2 are deferred, contradicting the newly checked 4.4 through 4.6, 6.1 through 6.2, and 8.2 entries.
- `git diff --check ecd995093195ee664ddcc033131005aaf57c5343..a26fe148d5581fef14c318388ea3f3c89545f6d7`
- `git diff --name-status ecd995093195ee664ddcc033131005aaf57c5343..a26fe148d5581fef14c318388ea3f3c89545f6d7`
- <code>Initial E2E collection attempt failed because pytest extras were absent; setup was repaired with `uv sync --frozen --all-extras`</code>
- `uv run pytest --collect-only -q -o addopts="" tests/e2e/test_restore_e2e.py tests/e2e/test_apps_update_e2e.py tests/e2e/test_unlock_e2e.py tests/e2e/test_restore_p2p_e2e.py`
- <code>Cross-checked every changed checkbox against the concrete E2E assertions, `tests/README.md`, and `.github/workflows/e2e.yml`</code>
- `gh-axi run list --workflow e2e.yml --status success --limit 10 --fields number,headSha,updatedAt,url`
- <code>`gh-axi run view 29913436757` and its v14, v15, and v16 job logs</code>

🔧 Fix: Sync deferred E2E checklist summary
1 error still open:
- 🚨 `openspec/changes/rebuild-e2e-test-suite/tasks.md:41` - Items 4.4, 4.5, and 4.6 remain checked as compound completion claims, but their cited E2E suites do not demonstrate every clause. Restore lacks successful --backup-file and origin-mismatch E2E coverage. Apps update lacks real pull/migrate, maintenance-mode, and site-narrowing E2E coverage. Unlock lacks multi-bench --bench coverage. The specified mock-suite retirements also remain incomplete. Leave these rows unchecked or split/rewrite them to describe the shipped subset.
- `git diff --unified=80 ecd995093195ee664ddcc033131005aaf57c5343..b6c23dc27b1c5e5cf827f1ca6d4172ef1bfd51bc -- openspec/changes/rebuild-e2e-test-suite/tasks.md`
- <code>`rg` clause audit across `tests/README.md`, `.github/workflows/e2e.yml`, `tests/e2e/`, and the OpenSpec checklist</code>
- `gh-axi run list --workflow e2e.yml --limit 10`
- <code>`gh-axi run view 29913436757` plus v14, v15, and v16 job and log inspection</code>
- `CWE2E_FRAPPE_MAJOR=16 uv run pytest tests/e2e/test_restore_e2e.py tests/e2e/test_restore_p2p_e2e.py tests/e2e/test_apps_update_e2e.py tests/e2e/test_unlock_e2e.py -m 'e2e or e2e_p2p' -o addopts='' --collect-only -q`
- `Manual comparison of every newly checked row against its cited E2E test implementations and README status entry`
- <code>`git status --short` to confirm testing left no worktree artifacts</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
