### PR TITLE
test: use reserved hostname in credential dispatch fixture

### DIFF
--- a/tests/test_core_credbridge.py
+++ b/tests/test_core_credbridge.py
@@ -49,7 +49,7 @@ def _only(paths):
         ("github.com", "gh"),
         ("api.github.com", "gh"),
         ("gitlab.com", "glab"),
-        ("dev.egov.gy", "glab"),
+        ("gitlab.example.com", "glab"),
     ],
 )
 def test_host_credential_dispatches_by_host(monkeypatch, host, expected_tool):


### PR DESCRIPTION
## Intent

Remove a private hostname that had been committed into this repository's tests as a parametrised fixture value, because a public repo's committed tests are outward-facing text and the repo owner has a standing rule that this host must never appear in any public text. The value sat in tests/test_core_credbridge.py at the fourth case of the host-dispatch parametrisation, paired with "glab". It was replaced with the reserved example domain gitlab.example.com.

Deliberate decisions a reviewer reading only the diff would not know:

1. The replacement value was chosen to preserve exactly what the test proves and to match the file's existing convention of bare hostnames (github.com, api.github.com, gitlab.com). The dispatch under test is core/credbridge.py's 'gh if host.endswith("github.com") else glab', so the case still exercises the same else-branch, and it still contributes what gitlab.com alone does not: a self-hosted GitLab host that is neither github.com nor the SaaS GitLab domain. All four parametrised cases pass. The test is not weakened and no assertion changed.

2. The removed value must not be reintroduced anywhere. It is deliberately absent from the commit message, and it must stay out of the PR title and body, the changelog, code comments, test names, and any doc. Commit messages and PR text are permanent and indexed, so a fix that removes it from one file and writes it into a commit message would make the exposure worse. Refer to it only structurally, as 'a private hostname' or 'a self-hosted GitLab host'. Please do not add it to any generated text.

3. No history rewrite was attempted and none should be proposed as a fix here. Exactly one commit introduces the value and it is already published on the default branch, on 46 remote branches, and under tag v1.1.0. filter-repo plus a force push is destructive and irreversible on a public repository and needs the owner's explicit authority. The residue is being reported to the owner for his decision instead of being acted on. It was also confirmed that the sdist includes tests/, so the published v1.1.0 artifact carries the value too; that is likewise reported, not acted on.

4. No lint or test guard against recurrence was built, and this absence is intentional rather than an oversight. Any such guard would have to contain the literal hostname to match on, which republishes the exact string being removed. A design that avoids this - match any FQDN-shaped literal in tests/ and fail unless it is on a small allowlist of known-public and reserved domains - was written up as a proposal for the owner rather than implemented, because it is out of scope for this change.

5. Scope was deliberately limited to the one hostname. The rest of the file and the wider test suite were swept for other real internal hosts, credential fixtures, tenant names, and personal identifiers; the only other hits are public documentation URLs, git@github.com and @example.com fixtures, and the project's own deliberate public identity in packaging metadata. Nothing else needed changing, so nothing else was changed.

6. No CHANGELOG entry: this is a test-fixture-only change with no user-facing behaviour change, and the changelog is also outward-facing text the value must not enter.

## What Changed

- Replaced a private hostname in the credential-bridge dispatch fixture with `gitlab.example.com`, preserving coverage of self-hosted GitLab routing through `glab`.

## Risk Assessment

✅ Low: The single test-fixture substitution removes the private hostname from the target tree and commit metadata while preserving the self-hosted GitLab dispatch coverage and all stated scope constraints.

## Testing

Baseline diff and source inspection confirmed the one-line scope; the initial default-environment test command lacked pytest, the dependency-aware retry passed the complete credential-bridge module including all four visible dispatch cases, privacy scans found no removed-hostname occurrence in the target tree or commit message, the built sdist contained only the reserved replacement in the fixture, and all transient worktree artifacts were cleaned.

<details>
<summary>Evidence: Privacy and scope audit</summary>

<code>changed files: 1&#10;target-tree occurrences of removed private hostname: 0&#10;target commit message omits removed private hostname: yes&#10;current fourth fixture: gitlab.example.com -&gt; glab</code>

```text
changed files: 1
target-tree occurrences of removed private hostname: 0
target commit message omits removed private hostname: yes
current fourth fixture: gitlab.example.com -> glab
```
</details>
<details>
<summary>Evidence: Credential bridge test transcript</summary>

```text
============================= test session starts ==============================
platform linux -- Python 3.13.14, pytest-8.4.2, pluggy-1.6.0 -- /home/cmckay/.no-mistakes/worktrees/c9173c2bc95d/01KY6ESRFVTCTFGMHPZMY3C5QN/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/cmckay/.no-mistakes/worktrees/c9173c2bc95d/01KY6ESRFVTCTFGMHPZMY3C5QN
configfile: pyproject.toml
plugins: cov-7.0.0
collecting ... collected 11 items

tests/test_core_credbridge.py::test_host_credential_dispatches_by_host[github.com-gh] PASSED
tests/test_core_credbridge.py::test_host_credential_dispatches_by_host[api.github.com-gh] PASSED
tests/test_core_credbridge.py::test_host_credential_dispatches_by_host[gitlab.com-glab] PASSED
tests/test_core_credbridge.py::test_host_credential_dispatches_by_host[gitlab.example.com-glab] PASSED
tests/test_core_credbridge.py::test_host_credential_missing_tool_is_empty PASSED
tests/test_core_credbridge.py::test_bridge_stands_up_and_answers_then_tears_down PASSED
tests/test_core_credbridge.py::test_daemon_survives_accept_timeouts PASSED
tests/test_core_credbridge.py::test_bridge_tears_down_on_exception PASSED
tests/test_core_credbridge.py::test_bridge_tears_down_on_setup_failure PASSED
tests/test_core_credbridge.py::test_concurrent_bridges_do_not_clobber_each_other PASSED
tests/test_core_credbridge.py::test_bridge_is_noop_without_bind_mount PASSED

============================== 11 passed in 2.97s ==============================
```
</details>
<details>
<summary>Evidence: Source distribution audit</summary>

<code>sdist contains tests/test_core_credbridge.py: yes&#10;sdist occurrences of removed private hostname in fixture file: 0&#10;sdist occurrences of reserved replacement hostname in fixture file: 1</code>

```text
sdist contains tests/test_core_credbridge.py: yes
sdist occurrences of removed private hostname in fixture file: 0
sdist occurrences of reserved replacement hostname in fixture file: 1
```
</details>
- Evidence: Built source distribution (local file: <code>/tmp/no-mistakes-evidence/01KY6ESRFVTCTFGMHPZMY3C5QN/dist/caffeinated_whale_cli-1.1.0.tar.gz</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>Inspected `tests/test_core_credbridge.py` and `src/caffeinated_whale_cli/core/credbridge.py`</code>
- `git diff --stat 3a8f417e69f78b5f471f64e7ffdc403fd9e8af44..414ed6811b5ab6fe150360adb2f810148b18a21d`
- <code>Dynamic privacy audit of target commit `414ed6811b5ab6fe150360adb2f810148b18a21d` and its commit message</code>
- <code>`uv run pytest -vv tests/test_core_credbridge.py` (initial setup failure because default dependencies omit pytest)</code>
- `uv run --extra dev pytest -vv tests/test_core_credbridge.py`
- `uv build --sdist --out-dir /tmp/no-mistakes-evidence/01KY6ESRFVTCTFGMHPZMY3C5QN/dist`
- `Inspected the built sdist fixture for removed and replacement hostname occurrences`
- <code>Removed test-created `.venv`, `.pytest_cache`, `.coverage`, and Python bytecode caches; confirmed `git status --short` is clean</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
